### PR TITLE
Fix notifications never firing when app is idle

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -28,7 +28,7 @@ async function checkAndNotify() {
   for (const chore of allChores) {
     if (!chore.notify_when_overdue) continue
     if (!chore.target_cadence_days) continue
-    if (chore.elapsed_days === null || chore.elapsed_days <= chore.target_cadence_days) continue
+    if (chore.elapsed_days === null || chore.elapsed_days < chore.target_cadence_days) continue
     if (localStorage.getItem(STORAGE_KEY(chore.id!)) === today) continue
 
     const overdue = Math.floor(chore.elapsed_days - chore.target_cadence_days)
@@ -51,8 +51,12 @@ export function useNotifications() {
     if (!('Notification' in window)) return
     checkAndNotify()
 
-    function onFocus() { checkAndNotify() }
-    document.addEventListener('visibilitychange', onFocus)
-    return () => document.removeEventListener('visibilitychange', onFocus)
+    const interval = setInterval(checkAndNotify, 60 * 60 * 1000)
+    function onVisibilityChange() { checkAndNotify() }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
   }, [])
 }


### PR DESCRIPTION
## Summary

- **Hourly `setInterval`** — `checkAndNotify()` was only called on mount and on tab visibility change. Added a 60-minute interval so overdue chores are checked while the app is open in the background (the normal state for an installed PWA).
- **Off-by-one fix** — the overdue check used `<=` (strictly greater than cadence), so a chore at exactly its cadence boundary (`elapsed == target`) never triggered. Changed to `<` so it fires at the boundary.

Together these two bugs explain why a 7-day chore with 7.0 days elapsed produced no notification: the comparison rejected it, and even if it hadn't, there was no mechanism to check while the tab was idle.

## Limitations

This fix covers the installed PWA use case (tab open in background). Notifications will not fire if the browser is fully closed — that would require Periodic Background Sync (Chrome Android only) or a push server, neither of which is in scope for v1.

## Test plan

- [ ] Enable `notify_when_overdue` on a chore with a short cadence (e.g. 1 day)
- [ ] Grant notification permission
- [ ] Log a completion so the chore is within cadence
- [ ] Advance time past the cadence boundary (or temporarily lower cadence to force it)
- [ ] Leave the tab open but backgrounded — notification should appear within the hour
- [ ] Confirm the notification does not repeat on the same calendar day (dedup check)
- [ ] Confirm a chore at exactly its cadence boundary (elapsed == target) triggers a notification

https://claude.ai/code/session_01BXFXzzxv2Uh1Hc8thhFY9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXFXzzxv2Uh1Hc8thhFY9y)_