### PR TITLE
Show app version in edit mode, sourced from package.json

### DIFF
--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -267,7 +267,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
         )}
 
         {editMode && !showEmpty && (
-          <div className="shrink-0 border-t border-slate-200 dark:border-slate-700/60 p-3">
+          <div className="shrink-0 border-t border-slate-200 dark:border-slate-700/60 p-3 flex flex-col gap-2">
             <button
               onClick={() => setAddingCategory(true)}
               className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/40 border border-slate-200 dark:border-slate-700/60 transition-colors"
@@ -275,6 +275,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
               <Plus size={15} />
               Add category
             </button>
+            <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__}</p>
           </div>
         )}
       </div>
@@ -318,6 +319,9 @@ export function Ribbon({ editMode, onLogged }: Props) {
                 </button>
               )}
             </div>
+            {editMode && (
+              <p className="mt-2 text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__}</p>
+            )}
           </div>
         )}
       </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,14 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
+import { readFileSync } from 'fs'
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
Injects __APP_VERSION__ at build time via Vite define so the version never needs to be updated manually. Displayed as a subtle footer label at the bottom of the edit-mode view on both mobile and desktop.

https://claude.ai/code/session_01Bu7DzaPJjq8uGvfCJbNSFs