### PR TITLE
fix responsive breakpoints: heatmap at 1060px, 4-col at 1260px, chore…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,11 +133,11 @@ export default function App() {
           {heatmapWeeks.length > 0 && (
             <>
               {/* 26 weeks on landscape mobile / small screens */}
-              <div className="hidden md:block lg:hidden pb-0.5 opacity-80">
+              <div className="hidden md:block min-[1060px]:hidden pb-0.5 opacity-80">
                 <HeaderHeatmap key={waveKey} weeks={heatmapWeeks.slice(-26)} />
               </div>
               {/* 52 weeks on large screens */}
-              <div className="hidden lg:block pb-0.5 opacity-80">
+              <div className="hidden min-[1060px]:block pb-0.5 opacity-80">
                 <HeaderHeatmap key={waveKey} weeks={heatmapWeeks} />
               </div>
             </>

--- a/src/components/ChoreRow/ChoreRow.tsx
+++ b/src/components/ChoreRow/ChoreRow.tsx
@@ -113,8 +113,8 @@ export function ChoreRow({ chore, editMode, onTap, onEdit, onDelete, onRefresh, 
         )}
 
         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-slate-800 dark:text-slate-100 group-hover:text-slate-900 dark:group-hover:text-white transition-colors truncate leading-snug flex items-center gap-1.5">
-            {chore.name}
+          <p className="text-sm font-medium text-slate-800 dark:text-slate-100 group-hover:text-slate-900 dark:group-hover:text-white transition-colors leading-snug flex items-center gap-1.5">
+            <span className="truncate min-w-0">{chore.name}</span>
             {chore.notify_when_overdue && <Bell size={10} className="shrink-0 text-slate-400 dark:text-slate-500 opacity-50" />}
           </p>
           <p className="text-xs text-slate-400 dark:text-slate-500 tabular-nums mt-0.5">{elapsedText}</p>

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -40,6 +40,13 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const tabsRef = useRef<HTMLDivElement>(null)
   const desktopGridRef = useRef<HTMLDivElement>(null)
 
+  const [windowWidth, setWindowWidth] = useState(() => window.innerWidth)
+  useEffect(() => {
+    const handler = () => setWindowWidth(window.innerWidth)
+    window.addEventListener('resize', handler)
+    return () => window.removeEventListener('resize', handler)
+  }, [])
+
   // Sync localData from server when not dragging categories
   useEffect(() => {
     if (draggingCatIdRef.current === null) {
@@ -191,12 +198,13 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const prevData = activeCategoryIndex > 0 ? localData[activeCategoryIndex - 1] : null
   const currData = localData[activeCategoryIndex]
   const nextData = activeCategoryIndex < localData.length - 1 ? localData[activeCategoryIndex + 1] : null
-  const cols = Math.min(Math.max(localData.length, 1), 4)
+  const maxCols = windowWidth >= 1260 ? 4 : 3
+  const cols = Math.min(Math.max(localData.length, 1), maxCols)
 
   return (
     <>
       {/* ── Mobile: one category at a time with tab strip ── */}
-      <div className="flex flex-col flex-1 overflow-hidden lg:hidden">
+      <div className="flex flex-col flex-1 overflow-hidden min-[1060px]:hidden">
         {!showEmpty && (
           <div ref={tabsRef} className="flex overflow-x-auto scrollbar-none border-b border-slate-200 dark:border-slate-700/60 bg-slate-100 dark:bg-slate-900 shrink-0">
             {localData.map((d, i) => (
@@ -281,7 +289,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
       </div>
 
       {/* ── Desktop: fluid masonry columns ── */}
-      <div className="hidden lg:block flex-1 overflow-y-auto">
+      <div className="hidden min-[1060px]:block flex-1 overflow-y-auto">
         {showEmpty ? (
           <EmptyState onAdd={() => setAddingCategory(true)} />
         ) : (


### PR DESCRIPTION
… title truncation

- Heatmap: shift from lg (1024px) to min-[1060px] so it no longer overlaps the theme button
- Desktop masonry: move mobile/desktop split from lg to min-[1060px] to match
- Column cap: limit to 3 columns below 1260px (was always up to 4 at 1024px+)
- ChoreRow: fix title ellipsis by wrapping name in <span class="truncate min-w-0"> — truncate on a flex container's text node does not produce ellipsis

https://claude.ai/code/session_01PeEqpFWZjptxki9ZJKbz68