### PR TITLE
Fix column count by measuring content height for column-fill:auto

### DIFF
--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect } from 'react'
 import { Plus, GripVertical } from 'lucide-react'
 import { useChores } from '@/hooks/useChores'
 import { reorderCategories } from '@/db/queries'
@@ -46,6 +46,22 @@ export function Ribbon({ editMode, onLogged }: Props) {
     window.addEventListener('resize', handler)
     return () => window.removeEventListener('resize', handler)
   }, [])
+
+  // Measure total content height so column-fill:auto distributes correctly.
+  // column-fill:balance ignores column-count when items have break-inside-avoid.
+  const [colHeight, setColHeight] = useState<number | null>(null)
+  useLayoutEffect(() => {
+    const el = desktopGridRef.current
+    if (!el || windowWidth < 1060) { setColHeight(null); return }
+    const savedCC = el.style.columnCount
+    const savedH = el.style.height
+    el.style.columnCount = '1'
+    el.style.height = 'auto'
+    const totalH = el.scrollHeight
+    el.style.columnCount = savedCC
+    el.style.height = savedH
+    setColHeight(Math.ceil(totalH / cols) + 1)
+  }, [cols, localData, windowWidth])
 
   // Sync localData from server when not dragging categories
   useEffect(() => {
@@ -296,7 +312,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
           <div className="p-6">
             <div
               ref={desktopGridRef}
-              style={{ columns: cols, columnGap: '1.25rem' }}
+              style={{ columns: cols, columnGap: '1.25rem', ...(colHeight !== null ? { columnFill: 'auto', height: colHeight } : {}) }}
             >
               {localData.map(d => (
                 <div

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -47,22 +47,6 @@ export function Ribbon({ editMode, onLogged }: Props) {
     return () => window.removeEventListener('resize', handler)
   }, [])
 
-  // Measure total content height so column-fill:auto distributes correctly.
-  // column-fill:balance ignores column-count when items have break-inside-avoid.
-  const [colHeight, setColHeight] = useState<number | null>(null)
-  useLayoutEffect(() => {
-    const el = desktopGridRef.current
-    if (!el || windowWidth < 1060) { setColHeight(null); return }
-    const savedCC = el.style.columnCount
-    const savedH = el.style.height
-    el.style.columnCount = '1'
-    el.style.height = 'auto'
-    const totalH = el.scrollHeight
-    el.style.columnCount = savedCC
-    el.style.height = savedH
-    setColHeight(Math.ceil(totalH / cols) + 1)
-  }, [cols, localData, windowWidth])
-
   // Sync localData from server when not dragging categories
   useEffect(() => {
     if (draggingCatIdRef.current === null) {
@@ -216,6 +200,22 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const nextData = activeCategoryIndex < localData.length - 1 ? localData[activeCategoryIndex + 1] : null
   const maxCols = windowWidth >= 2200 ? 6 : windowWidth >= 1800 ? 5 : windowWidth >= 1400 ? 4 : 3
   const cols = Math.min(Math.max(localData.length, 1), maxCols)
+
+  // Measure total content height so column-fill:auto distributes correctly.
+  // column-fill:balance ignores column-count when items have break-inside-avoid.
+  const [colHeight, setColHeight] = useState<number | null>(null)
+  useLayoutEffect(() => {
+    const el = desktopGridRef.current
+    if (!el || windowWidth < 1060) { setColHeight(null); return }
+    const savedCC = el.style.columnCount
+    const savedH = el.style.height
+    el.style.columnCount = '1'
+    el.style.height = 'auto'
+    const totalH = el.scrollHeight
+    el.style.columnCount = savedCC
+    el.style.height = savedH
+    setColHeight(Math.ceil(totalH / cols) + 1)
+  }, [cols, localData, windowWidth])
 
   return (
     <>


### PR DESCRIPTION
column-fill:balance ignores column-count with break-inside-avoid items, choosing its own column count based on content heights. useLayoutEffect measures total content height (by temporarily collapsing to 1 column) then applies that divided by cols as an explicit height with column-fill:auto, forcing exactly N columns every time.

https://claude.ai/code/session_012r8f15FVuaL59tnorQwSrW