### PR TITLE
Responsive masonry layout + tablet/landscape chore wrapping (v0.1.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/CategorySection/CategorySection.tsx
+++ b/src/components/CategorySection/CategorySection.tsx
@@ -167,8 +167,7 @@ export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogge
         {/* Chore list */}
         <div
           ref={choreListRef}
-          className="flex gap-2"
-          style={wrapChores ? { flexWrap: 'wrap', justifyContent: 'flex-start' } : { flexDirection: 'column' }}
+          className={wrapChores ? 'flex flex-wrap gap-2' : 'flex flex-col gap-2'}
         >
           {localChores.length === 0 && !editMode && (
             <p className="text-sm text-slate-400 dark:text-slate-600 py-3 text-center">
@@ -179,7 +178,8 @@ export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogge
             <div
               key={chore.id}
               data-chore-id={chore.id}
-              style={wrapChores ? { flex: '1 1 320px', maxWidth: 'calc(50% - 4px)', minWidth: 0 } : undefined}
+              className={wrapChores ? 'min-w-0 min-[480px]:max-w-[calc(50%_-_4px)]' : undefined}
+              style={wrapChores ? { flex: '1 1 320px' } : undefined}
             >
               <ChoreRow
                 chore={chore}
@@ -196,8 +196,8 @@ export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogge
           {editMode && (
             <button
               onClick={() => setChoreForm({})}
-              style={wrapChores ? { flex: '1 1 320px', maxWidth: 'calc(50% - 4px)', minWidth: 0 } : undefined}
-              className="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/40 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors"
+              className={`flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/40 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors${wrapChores ? ' min-w-0 min-[480px]:max-w-[calc(50%_-_4px)]' : ''}`}
+              style={wrapChores ? { flex: '1 1 320px' } : undefined}
             >
               <Plus size={14} />
               Add chore

--- a/src/components/CategorySection/CategorySection.tsx
+++ b/src/components/CategorySection/CategorySection.tsx
@@ -18,9 +18,10 @@ interface Props {
   onLogged?: () => void
   onCategoryDragHandlePointerDown?: (e: React.PointerEvent) => void
   isCategoryDragging?: boolean
+  wrapChores?: boolean
 }
 
-export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogged, onCategoryDragHandlePointerDown, isCategoryDragging }: Props) {
+export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogged, onCategoryDragHandlePointerDown, isCategoryDragging, wrapChores }: Props) {
   const [choreForm, setChoreForm] = useState<{ chore?: ChoreWithLastCompletion } | null>(null)
   const [categoryForm, setCategoryForm] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<'category' | number | null>(null)
@@ -164,14 +165,22 @@ export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogge
         </div>
 
         {/* Chore list */}
-        <div ref={choreListRef} className="flex flex-col gap-2">
+        <div
+          ref={choreListRef}
+          className="flex gap-2"
+          style={wrapChores ? { flexWrap: 'wrap', justifyContent: 'flex-start' } : { flexDirection: 'column' }}
+        >
           {localChores.length === 0 && !editMode && (
             <p className="text-sm text-slate-400 dark:text-slate-600 py-3 text-center">
               No chores yet — tap Edit to add one.
             </p>
           )}
           {localChores.map(chore => (
-            <div key={chore.id} data-chore-id={chore.id}>
+            <div
+              key={chore.id}
+              data-chore-id={chore.id}
+              style={wrapChores ? { flex: '1 1 320px', maxWidth: 480, minWidth: 0 } : undefined}
+            >
               <ChoreRow
                 chore={chore}
                 editMode={editMode}
@@ -187,6 +196,7 @@ export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogge
           {editMode && (
             <button
               onClick={() => setChoreForm({})}
+              style={wrapChores ? { flex: '1 1 320px', maxWidth: 480, minWidth: 0 } : undefined}
               className="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/40 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors"
             >
               <Plus size={14} />

--- a/src/components/CategorySection/CategorySection.tsx
+++ b/src/components/CategorySection/CategorySection.tsx
@@ -179,7 +179,7 @@ export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogge
             <div
               key={chore.id}
               data-chore-id={chore.id}
-              style={wrapChores ? { flex: '1 1 320px', maxWidth: 480, minWidth: 0 } : undefined}
+              style={wrapChores ? { flex: '1 1 320px', maxWidth: 'calc(50% - 4px)', minWidth: 0 } : undefined}
             >
               <ChoreRow
                 chore={chore}
@@ -196,7 +196,7 @@ export function CategorySection({ data, editMode, onChoreTab, onRefresh, onLogge
           {editMode && (
             <button
               onClick={() => setChoreForm({})}
-              style={wrapChores ? { flex: '1 1 320px', maxWidth: 480, minWidth: 0 } : undefined}
+              style={wrapChores ? { flex: '1 1 320px', maxWidth: 'calc(50% - 4px)', minWidth: 0 } : undefined}
               className="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/40 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors"
             >
               <Plus size={14} />

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -14,6 +14,46 @@ interface Props {
 }
 
 const SNAP_MS = 280
+const MASONRY_GAP = 20 // px — 1.25rem, matches the former columnGap
+
+function getColCount(containerWidth: number, itemCount: number): number {
+  let cols: number
+  if (containerWidth >= 2400) cols = 6
+  else if (containerWidth >= 1920) cols = 5
+  else if (containerWidth >= 1440) cols = 4
+  else if (containerWidth >= 1200) cols = 3
+  else if (containerWidth >= 800) cols = 2
+  else cols = 1
+  return Math.min(cols, Math.max(itemCount, 1))
+}
+
+interface MasonryPos { x: number; y: number }
+
+// Pure packing function: ordered catIds × column count × measured heights → positions + container height.
+// Shortest-column-next; leftmost column wins on tie (strict <).
+function packMasonry(
+  catIds: number[],
+  cols: number,
+  heights: Map<number, number>,
+  cardWidth: number,
+  gap: number,
+): { positions: Map<number, MasonryPos>; containerHeight: number } {
+  const positions = new Map<number, MasonryPos>()
+  if (catIds.length === 0 || cardWidth <= 0) return { positions, containerHeight: 0 }
+
+  const colHeights = new Array<number>(cols).fill(0)
+  for (const id of catIds) {
+    let shortest = 0
+    for (let c = 1; c < cols; c++) {
+      if (colHeights[c] < colHeights[shortest]) shortest = c
+    }
+    positions.set(id, { x: shortest * (cardWidth + gap), y: colHeights[shortest] })
+    colHeights[shortest] += (heights.get(id) ?? 200) + gap
+  }
+
+  const maxH = Math.max(...colHeights)
+  return { positions, containerHeight: maxH > gap ? maxH - gap : maxH }
+}
 
 export function Ribbon({ editMode, onLogged }: Props) {
   const { data, loading, refresh } = useChores()
@@ -40,12 +80,16 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const tabsRef = useRef<HTMLDivElement>(null)
   const desktopGridRef = useRef<HTMLDivElement>(null)
 
-  const [windowWidth, setWindowWidth] = useState(() => window.innerWidth)
-  useEffect(() => {
-    const handler = () => setWindowWidth(window.innerWidth)
-    window.addEventListener('resize', handler)
-    return () => window.removeEventListener('resize', handler)
-  }, [])
+  // Masonry measurement & layout
+  const [containerWidth, setContainerWidth] = useState(0)
+  const containerWidthRef = useRef(0)
+  const cardHeightsRef = useRef<Map<number, number>>(new Map())
+  const [packVersion, setPackVersion] = useState(0)
+  // packPhase: 0 = hidden, 1 = placed (no transition), 2 = animated
+  const [packPhase, setPackPhase] = useState<0 | 1 | 2>(0)
+  const packPhaseRef = useRef<0 | 1 | 2>(0)
+  const localDataLengthRef = useRef(0)
+  localDataLengthRef.current = localData.length
 
   // Sync localData from server when not dragging categories
   useEffect(() => {
@@ -124,6 +168,67 @@ export function Ribbon({ editMode, onLogged }: Props) {
     setDraggingCatId(catId)
   }
 
+  // Container ResizeObserver — measures width for column count
+  useEffect(() => {
+    const el = desktopGridRef.current
+    if (!el) return
+    const obs = new ResizeObserver(entries => {
+      const w = entries[0].contentRect.width
+      if (w !== containerWidthRef.current) {
+        containerWidthRef.current = w
+        setContainerWidth(w)
+      }
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+
+  // Card ResizeObservers — re-created only when the set of category IDs changes (add/remove, not reorder)
+  const sortedCatIdsKey = localData.map(d => d.category.id).sort((a, b) => a - b).join(',')
+  useEffect(() => {
+    const grid = desktopGridRef.current
+    if (!grid) return
+
+    const obs = new ResizeObserver(entries => {
+      let changed = false
+      for (const entry of entries) {
+        const el = entry.target as HTMLElement
+        const id = parseInt(el.getAttribute('data-cat-card-id') ?? '0')
+        if (!id) continue
+        const h = el.offsetHeight
+        if (cardHeightsRef.current.get(id) !== h) {
+          cardHeightsRef.current.set(id, h)
+          changed = true
+        }
+      }
+      if (!changed) return
+      setPackVersion(v => v + 1)
+      // Transition 0→1: all cards measured and container width known
+      if (
+        packPhaseRef.current === 0 &&
+        cardHeightsRef.current.size >= localDataLengthRef.current &&
+        containerWidthRef.current > 0
+      ) {
+        packPhaseRef.current = 1
+        setPackPhase(1)
+      }
+    })
+
+    grid.querySelectorAll<HTMLElement>('[data-cat-card-id]').forEach(el => obs.observe(el))
+    return () => obs.disconnect()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sortedCatIdsKey])
+
+  // Transition 1→2: enable CSS transitions one frame after cards are placed
+  useEffect(() => {
+    if (packPhase !== 1) return
+    const raf = requestAnimationFrame(() => {
+      packPhaseRef.current = 2
+      setPackPhase(2)
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [packPhase])
+
   // Swipe handlers
   function handleTouchStart(e: React.TouchEvent) {
     if (snapping) return
@@ -198,8 +303,19 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const prevData = activeCategoryIndex > 0 ? localData[activeCategoryIndex - 1] : null
   const currData = localData[activeCategoryIndex]
   const nextData = activeCategoryIndex < localData.length - 1 ? localData[activeCategoryIndex + 1] : null
-  const maxCols = windowWidth >= 1260 ? 4 : 3
-  const cols = Math.min(Math.max(localData.length, 1), maxCols)
+
+  // Masonry layout computation
+  const colCount = getColCount(containerWidth, localData.length)
+  const cardWidth = colCount > 0 && containerWidth > 0
+    ? (containerWidth - MASONRY_GAP * (colCount - 1)) / colCount
+    : 0
+  const { positions, containerHeight } = packMasonry(
+    localData.map(d => d.category.id),
+    colCount,
+    cardHeightsRef.current,
+    cardWidth,
+    MASONRY_GAP,
+  )
 
   return (
     <>
@@ -288,47 +404,61 @@ export function Ribbon({ editMode, onLogged }: Props) {
         )}
       </div>
 
-      {/* ── Desktop: fluid masonry columns ── */}
+      {/* ── Desktop: true masonry layout ── */}
       <div className="hidden min-[1060px]:block flex-1 overflow-y-auto">
         {showEmpty ? (
           <EmptyState onAdd={() => setAddingCategory(true)} />
         ) : (
           <div className="p-6">
+            {/* Masonry container: cards are absolutely positioned within */}
             <div
               ref={desktopGridRef}
-              style={{ columns: cols, columnGap: '1.25rem' }}
+              style={{ position: 'relative', height: containerHeight }}
             >
-              {localData.map(d => (
-                <div
-                  key={d.category.id}
-                  data-cat-card-id={d.category.id}
-                  className="break-inside-avoid mb-5 bg-white dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700/50 rounded-2xl p-5"
-                >
-                  <CategorySection
-                    data={d}
-                    editMode={editMode}
-                    onChoreTab={openChore}
-                    onRefresh={refresh}
-                    onLogged={onLogged}
-                    onCategoryDragHandlePointerDown={editMode
-                      ? e => startCatDrag(e, d.category.id, desktopGridRef.current!, '[data-cat-card-id]')
-                      : undefined}
-                    isCategoryDragging={draggingCatId === d.category.id}
-                  />
-                </div>
-              ))}
-              {editMode && (
+              {localData.map(d => {
+                const pos = positions.get(d.category.id)
+                return (
+                  <div
+                    key={d.category.id}
+                    data-cat-card-id={d.category.id}
+                    className="absolute bg-white dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700/50 rounded-2xl p-5"
+                    style={{
+                      top: 0,
+                      left: 0,
+                      width: cardWidth > 0 ? cardWidth : undefined,
+                      transform: pos ? `translate(${pos.x}px,${pos.y}px)` : undefined,
+                      visibility: packPhase >= 1 ? 'visible' : 'hidden',
+                      transition: packPhase >= 2 ? 'transform 300ms ease' : 'none',
+                      willChange: 'transform',
+                    }}
+                  >
+                    <CategorySection
+                      data={d}
+                      editMode={editMode}
+                      onChoreTab={openChore}
+                      onRefresh={refresh}
+                      onLogged={onLogged}
+                      onCategoryDragHandlePointerDown={editMode
+                        ? e => startCatDrag(e, d.category.id, desktopGridRef.current!, '[data-cat-card-id]')
+                        : undefined}
+                      isCategoryDragging={draggingCatId === d.category.id}
+                    />
+                  </div>
+                )
+              })}
+            </div>
+
+            {editMode && (
+              <div className="mt-5 flex flex-col gap-2">
                 <button
                   onClick={() => setAddingCategory(true)}
-                  className="break-inside-avoid mb-5 w-full flex items-center justify-center gap-2 py-4 rounded-2xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/30 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors"
+                  className="w-full flex items-center justify-center gap-2 py-4 rounded-2xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/30 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors"
                 >
                   <Plus size={15} />
                   Add category
                 </button>
-              )}
-            </div>
-            {editMode && (
-              <p className="mt-2 text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__}</p>
+                <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__}</p>
+              </div>
             )}
           </div>
         )}

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -439,7 +439,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
                       width: cardWidth > 0 ? cardWidth : undefined,
                       transform: pos ? `translate(${pos.x}px,${pos.y}px)` : undefined,
                       visibility: packPhase >= 1 ? 'visible' : 'hidden',
-                      transition: packPhase >= 2 ? 'transform 300ms ease' : 'none',
+                      transition: packPhase >= 2 && draggingCatId === null ? 'transform 300ms ease' : 'none',
                       willChange: 'transform',
                     }}
                   >

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -168,20 +168,31 @@ export function Ribbon({ editMode, onLogged }: Props) {
     setDraggingCatId(catId)
   }
 
-  // Container ResizeObserver — measures width for column count
+  // Container ResizeObserver — measures width for column count.
+  // Deps include localData.length because desktopGridRef.current is null during the loading
+  // spinner render; the effect must re-run once the grid div actually mounts.
   useEffect(() => {
     const el = desktopGridRef.current
     if (!el) return
     const obs = new ResizeObserver(entries => {
       const w = entries[0].contentRect.width
-      if (w !== containerWidthRef.current) {
-        containerWidthRef.current = w
-        setContainerWidth(w)
+      if (w === containerWidthRef.current) return
+      containerWidthRef.current = w
+      setContainerWidth(w)
+      // Phase 0→1 if card heights already arrived before container width did
+      if (
+        packPhaseRef.current === 0 &&
+        cardHeightsRef.current.size >= localDataLengthRef.current &&
+        localDataLengthRef.current > 0
+      ) {
+        packPhaseRef.current = 1
+        setPackPhase(1)
       }
     })
     obs.observe(el)
     return () => obs.disconnect()
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localData.length])
 
   // Card ResizeObservers — re-created only when the set of category IDs changes (add/remove, not reorder)
   const sortedCatIdsKey = localData.map(d => d.category.id).sort((a, b) => a - b).join(',')

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -389,13 +389,13 @@ export function Ribbon({ editMode, onLogged }: Props) {
               }}
             >
               <div className="overflow-y-auto" style={{ width: '33.333%' }}>
-                {prevData && <div className="p-4"><CategorySection key={prevData.category.id} data={prevData} editMode={editMode} onChoreTab={openChore} onRefresh={refresh} onLogged={onLogged} /></div>}
+                {prevData && <div className="p-4"><CategorySection key={prevData.category.id} data={prevData} editMode={editMode} onChoreTab={openChore} onRefresh={refresh} onLogged={onLogged} wrapChores /></div>}
               </div>
               <div className="overflow-y-auto" style={{ width: '33.333%' }}>
-                {currData && <div className="p-4"><CategorySection key={currData.category.id} data={currData} editMode={editMode} onChoreTab={openChore} onRefresh={refresh} onLogged={onLogged} /></div>}
+                {currData && <div className="p-4"><CategorySection key={currData.category.id} data={currData} editMode={editMode} onChoreTab={openChore} onRefresh={refresh} onLogged={onLogged} wrapChores /></div>}
               </div>
               <div className="overflow-y-auto" style={{ width: '33.333%' }}>
-                {nextData && <div className="p-4"><CategorySection key={nextData.category.id} data={nextData} editMode={editMode} onChoreTab={openChore} onRefresh={refresh} onLogged={onLogged} /></div>}
+                {nextData && <div className="p-4"><CategorySection key={nextData.category.id} data={nextData} editMode={editMode} onChoreTab={openChore} onRefresh={refresh} onLogged={onLogged} wrapChores /></div>}
               </div>
             </div>
           </div>

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -84,7 +84,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const [containerWidth, setContainerWidth] = useState(0)
   const containerWidthRef = useRef(0)
   const cardHeightsRef = useRef<Map<number, number>>(new Map())
-  const [packVersion, setPackVersion] = useState(0)
+  const [, setPackVersion] = useState(0)
   // packPhase: 0 = hidden, 1 = placed (no transition), 2 = animated
   const [packPhase, setPackPhase] = useState<0 | 1 | 2>(0)
   const packPhaseRef = useRef<0 | 1 | 2>(0)


### PR DESCRIPTION
## Summary

- **True masonry grid on desktop** — replaces the CSS `columns` layout with a `ResizeObserver`-driven shortest-column-next packing algorithm. Cards are absolutely positioned via `transform: translate(x, y)` so position changes animate. Column count scales from 1 → 6 cols based on container width (breakpoints at 800 / 1200 / 1440 / 1920 / 2400 px). Cards stay `visibility: hidden` until the first measurement+pack cycle completes, preventing flash on load.
- **Drag-and-drop preserved** — existing `getBoundingClientRect()` hit-testing and array-index swap logic work unchanged with absolute positioning. Card transitions are suppressed during drag to prevent the rightward-drag oscillation caused by displaced cards animating back through the pointer's position.
- **Flex-wrap chore rows in mobile carousel** — on tablet/landscape widths, chore rows in the tabbed view wrap into two columns (`flex: 1 1 320px`, `max-w-[calc(50%_-_4px)]` above 480 px). Below 480 px the 320 px flex-basis enforces single column naturally. Desktop masonry cards are unaffected.
- **Version bump to 0.1.2**

## Key implementation details

- `packMasonry()` is a pure function: `catIds[] + colCount + heights Map + cardWidth + gap → positions Map + containerHeight`. Leftmost column wins on tie (strict `<`).
- Per-card `ResizeObserver` re-fires on content or width changes, bumping a version counter to trigger re-pack without manual invalidation.
- Container observer deps set to `[localData.length]` (not `[]`) so it re-runs after the loading spinner gives way to the grid — the initial `[]` dep caused the grid to stay permanently hidden.
- `packPhase` 0 → 1 → 2 gates visibility and transitions: cards appear at correct positions before transitions enable (one `rAF` gap).

## Test plan

- [ ] Desktop: categories display in masonry, column count changes on resize
- [ ] Desktop: drag-to-reorder works in both directions without oscillation
- [ ] Desktop: adding/removing a category re-packs correctly
- [ ] Mobile portrait phone (≤ 430 px): chore rows single column
- [ ] Mobile landscape / tablet (≥ 480 px): chore rows wrap to two columns, odd trailing card capped at 50% width
- [ ] Desktop masonry cards: chore rows remain single column (unaffected by wrapChores)
- [ ] No flash of unstyled content on initial load

https://claude.ai/code/session_01Jgx6qMNqV3bK7676KK2Wze

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jgx6qMNqV3bK7676KK2Wze)_