### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "dependencies": {
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Bumps `package.json` version from 0.1.1 to 0.1.3
- Updates `package-lock.json`

## Test plan
- [ ] Version displays as 0.1.3 in the app footer (edit mode)

https://claude.ai/code/session_012r8f15FVuaL59tnorQwSrW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012r8f15FVuaL59tnorQwSrW)_