### PR TITLE
fix(intents): always route WebDAV through proxy, same as sync package

### DIFF
--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -3,8 +3,8 @@ export function buildAuthHeader(username: string, password: string): string {
 }
 
 function withProxy(url: string): string {
-  const proxy = import.meta.env.VITE_WEBDAV_PROXY_URL
-  return proxy ? `${proxy}/api/webdav-proxy/?url=${encodeURIComponent(url)}` : url
+  const proxy = import.meta.env.VITE_WEBDAV_PROXY_URL ?? ''
+  return `${proxy}/api/webdav-proxy/?url=${encodeURIComponent(url)}`
 }
 
 function buildFolderUrl(baseUrl: string, folderPath: string): string {


### PR DESCRIPTION
VITE_WEBDAV_PROXY_URL is unset in production because the proxy lives on the same origin. Using ?? '' as fallback makes the fetch go to the relative path /api/webdav-proxy/?url=... which resolves correctly, matching the pattern used by @glance-apps/sync's webdavFetch.

https://claude.ai/code/session_01ND6izfNJ7LwpPmqV3pgcBd