### PR TITLE
fix(proxy): only set Content-Type when request has a body

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -98,12 +98,6 @@ export default async function handler(req, res) {
   try {
     const headers = {};
 
-    // Only set Content-Type for requests that have a body — sending it on GET/HEAD
-    // causes Apache mod_dav to return 404 (unexpected Content-Type on bodyless request).
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
-      headers['Content-Type'] = req.headers['content-type'] || 'application/octet-stream';
-    }
-
     // Forward X-WebDAV-Auth as Authorization
     if (req.headers['x-webdav-auth']) {
       headers['Authorization'] = req.headers['x-webdav-auth'];
@@ -130,6 +124,9 @@ export default async function handler(req, res) {
       const rawBody = await readRawBody(req);
       if (rawBody) {
         fetchOptions.body = rawBody;
+        // Only set Content-Type when there is an actual body — Apache mod_dav
+        // rejects PROPFIND and MKCOL with Content-Type but no body.
+        headers['Content-Type'] = req.headers['content-type'] || 'application/octet-stream';
       }
     }
 

--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -49,6 +49,8 @@ export async function putFile(baseUrl: string, folderPath: string, filename: str
 
 const HREF_RE = /<[^>]*:href[^>]*>([^<]*)<\/[^>]*:href>/gi
 
+const PROPFIND_BODY = '<?xml version="1.0" encoding="utf-8"?><propfind xmlns="DAV:"><allprop/></propfind>'
+
 export async function listFiles(baseUrl: string, folderPath: string, authHeader: string): Promise<string[]> {
   const folderUrl = buildFolderUrl(baseUrl, folderPath)
   try {
@@ -59,6 +61,7 @@ export async function listFiles(baseUrl: string, folderPath: string, authHeader:
         Depth: '1',
         'Content-Type': 'application/xml',
       },
+      body: PROPFIND_BODY,
     })
     if (res.status === 404) return []
     if (!res.ok) return []
@@ -103,6 +106,7 @@ export async function testConnection(baseUrl: string, folderPath: string, userna
         Depth: '0',
         'Content-Type': 'application/xml',
       },
+      body: PROPFIND_BODY,
     })
     if (res.status === 401) return { success: false, error: 'Authentication failed' }
     if (res.status === 403) return { success: false, error: 'Access denied' }


### PR DESCRIPTION
Apache mod_dav rejects PROPFIND and MKCOL that carry Content-Type but no body. Move Content-Type into the body-present branch. Also send proper allprop XML bodies on intents PROPFIND requests so Content-Type: application/xml is always accurate.

https://claude.ai/code/session_01ND6izfNJ7LwpPmqV3pgcBd