### PR TITLE
Add build timestamp to version footer in Edit screen

### DIFF
--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -454,7 +454,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
               <Plus size={15} />
               Add category
             </button>
-            <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__}</p>
+            <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__} · {__BUILD_TIME__}</p>
           </div>
         )}
       </div>
@@ -513,7 +513,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
                   <Plus size={15} />
                   Add category
                 </button>
-                <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__}</p>
+                <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__} · {__BUILD_TIME__}</p>
               </div>
             )}
           </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -9,3 +9,4 @@ interface ImportMeta {
 }
 
 declare const __APP_VERSION__: string
+declare const __BUILD_TIME__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,10 +5,12 @@ import path from 'path'
 import { readFileSync } from 'fs'
 
 const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
+const buildTime = new Date().toISOString()
 
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(version),
+    __BUILD_TIME__: JSON.stringify(buildTime),
   },
   plugins: [
     react(),


### PR DESCRIPTION
Helps identify the deployed build at a glance without checking the network tab.

https://claude.ai/code/session_01ND6izfNJ7LwpPmqV3pgcBd