### PR TITLE
Ensure sync folder exists before upload to work around Apache 403

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { useNotifications } from '@/hooks/useNotifications'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
-import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, CRYPTO_CONFIG } from '@/sync/engine'
+import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG } from '@/sync/engine'
 import type { SyncEngine, SyncStatus } from '@glance-apps/sync'
 import dayjs from 'dayjs'
 
@@ -142,14 +142,15 @@ function AppInner() {
       onPassphraseRequired: () => setShowPassphrase(true),
     })
     engineRef.current = engine
-    engine.sync().catch(() => {/* errors surfaced via onError */})
+    ensureSyncFolder(engine).then(() => engine.sync()).catch(() => {/* errors surfaced via onError */})
   }, [])
 
   // Re-sync on tab focus
   useEffect(() => {
     function handleVisibility() {
-      if (document.visibilityState === 'visible') {
-        engineRef.current?.sync().catch(() => {/* errors surfaced via onError */})
+      if (document.visibilityState === 'visible' && engineRef.current) {
+        const eng = engineRef.current
+        ensureSyncFolder(eng).then(() => eng.sync()).catch(() => {/* errors surfaced via onError */})
       }
     }
     document.addEventListener('visibilitychange', handleVisibility)
@@ -291,7 +292,10 @@ function AppInner() {
           onSubmit={async (passphrase) => {
             await setupEncryptionKey(passphrase, CRYPTO_CONFIG)
             setShowPassphrase(false)
-            engineRef.current?.sync().catch(() => {/* errors surfaced via onError */})
+            if (engineRef.current) {
+              const eng = engineRef.current
+              ensureSyncFolder(eng).then(() => eng.sync()).catch(() => {/* errors surfaced via onError */})
+            }
           }}
           onClose={() => setShowPassphrase(false)}
         />

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Loader, AlertTriangle, CheckCircle, XCircle } from 'lucide-react'
 import type { SyncEngine } from '@glance-apps/sync'
-import { setupEncryptionKey, clearEncryptionKey, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled } from '@/sync/engine'
+import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled } from '@/sync/engine'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 
 interface Props {
@@ -133,6 +133,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
     setSyncResult('idle')
     setSyncResultMsg('')
     try {
+      await ensureSyncFolder(engine)
       await engine.sync()
       const ts = engine.getLastSynced()
       setLastSynced(ts)

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -9,6 +9,7 @@ import {
 } from '@glance-apps/sync'
 import type { SyncEngine, SyncStatus, SyncErrorCode, BackupFrequency } from '@glance-apps/sync'
 import { db } from '@/db/client'
+import { buildAuthHeader, ensureFolder } from '@/intents/webdav'
 import type { SyncPayload } from './types'
 
 export const CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto' }
@@ -248,6 +249,23 @@ export async function runAutoBackups(engine: SyncEngine): Promise<void> {
         // backup failures are non-fatal
       }
     }
+  }
+}
+
+export async function ensureSyncFolder(engine: SyncEngine): Promise<void> {
+  const config = engine.getConfig() as Record<string, unknown> | null
+  if (!config?.enabled || !config.webdavUrl) return
+  const webdavUrl = config.webdavUrl as string
+  const username = (config.username as string) ?? ''
+  const appPassword = (config.appPassword as string) ?? ''
+  if (!webdavUrl || !username) return
+  try {
+    const url = new URL(webdavUrl)
+    const baseUrl = `${url.protocol}//${url.host}`
+    const folderPath = url.pathname.replace(/^\//, '').replace(/\/+$/, '')
+    await ensureFolder(baseUrl, folderPath, buildAuthHeader(username, appPassword))
+  } catch {
+    // non-fatal — if we can't create the folder the sync will surface its own error
   }
 }
 


### PR DESCRIPTION
Apache mod_dav returns 403 (not 404/409) when PUT targets a non-existent parent collection. The @glance-apps/sync webdav provider only retries with MKCOL on 404/409, so the first sync always failed with FORBIDDEN when the GLANCE/lastglance directory hadn't been created yet.

Fix: call ensureSyncFolder() (MKCOL each path segment) before every engine.sync() call, so the directory is guaranteed to exist by the time the engine attempts a PUT.

https://claude.ai/code/session_01ND6izfNJ7LwpPmqV3pgcBd