### PR TITLE
Fix doubled WebDAV path and MKCOL flood

### DIFF
--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Loader, AlertTriangle, CheckCircle, XCircle } from 'lucide-react'
 import type { SyncEngine } from '@glance-apps/sync'
-import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled } from '@/sync/engine'
+import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled } from '@/sync/engine'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 
 interface Props {
@@ -35,7 +35,10 @@ function splitWebdavUrl(fullUrl: string): { serverUrl: string; folderPath: strin
 function buildWebdavUrl(serverUrl: string, folderPath: string): string {
   const base = serverUrl.replace(/\/+$/, '')
   const folder = folderPath.replace(/^\/+/, '').replace(/\/+$/, '')
-  return folder ? `${base}/${folder}` : base
+  if (!folder) return base
+  // If the user pasted the full path into the server URL field, don't double it
+  if (base.endsWith('/' + folder)) return base
+  return `${base}/${folder}`
 }
 
 export function SyncSettingsModal({ engine, onClose }: Props) {
@@ -69,6 +72,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
     if (!engine) return
     const webdavUrl = buildWebdavUrl(serverUrl, folderPath)
     engine.setConfig(serverUrl.trim() ? { provider: 'webdav', webdavUrl, username, appPassword, enabled: true } : null)
+    resetEnsuredFolder()
   }
 
   function handleClose() {

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -252,6 +252,12 @@ export async function runAutoBackups(engine: SyncEngine): Promise<void> {
   }
 }
 
+let _ensuredForUrl = ''
+
+export function resetEnsuredFolder(): void {
+  _ensuredForUrl = ''
+}
+
 export async function ensureSyncFolder(engine: SyncEngine): Promise<void> {
   const config = engine.getConfig() as Record<string, unknown> | null
   if (!config?.enabled || !config.webdavUrl) return
@@ -259,11 +265,14 @@ export async function ensureSyncFolder(engine: SyncEngine): Promise<void> {
   const username = (config.username as string) ?? ''
   const appPassword = (config.appPassword as string) ?? ''
   if (!webdavUrl || !username) return
+  // Only run MKCOL once per unique folder URL to avoid flooding the server
+  if (_ensuredForUrl === webdavUrl) return
   try {
     const url = new URL(webdavUrl)
     const baseUrl = `${url.protocol}//${url.host}`
     const folderPath = url.pathname.replace(/^\//, '').replace(/\/+$/, '')
     await ensureFolder(baseUrl, folderPath, buildAuthHeader(username, appPassword))
+    _ensuredForUrl = webdavUrl
   } catch {
     // non-fatal — if we can't create the folder the sync will surface its own error
   }


### PR DESCRIPTION
buildWebdavUrl now detects when the server URL already ends with the folder path (user pasted the full URL into the server field) and avoids concatenating it a second time.

ensureSyncFolder now caches the URL it last ran for and skips MKCOL on subsequent syncs, preventing the server from being flooded with repeated requests on every tab-focus sync. resetEnsuredFolder() is called whenever settings are saved so a URL change triggers fresh folder creation.

https://claude.ai/code/session_01ND6izfNJ7LwpPmqV3pgcBd