### PR TITLE
fix: correct WebDAV sync path doubling (v0.1.8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@glance-apps/intents": "^1.1.0",
         "@glance-apps/sync": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -13,7 +13,9 @@ interface Props {
 type TestStatus = 'idle' | 'testing' | 'ok' | 'fail'
 type SyncResult = 'idle' | 'ok' | 'error'
 
-const DEFAULT_FOLDER = 'GLANCE/lastglance'
+const DEFAULT_FOLDER = 'GLANCE'
+// The sync library appends this name as a subfolder to webdavUrl automatically.
+const APP_FOLDER_NAME = 'lastglance'
 
 function splitWebdavUrl(fullUrl: string): { serverUrl: string; folderPath: string } {
   if (!fullUrl) return { serverUrl: '', folderPath: DEFAULT_FOLDER }
@@ -21,10 +23,18 @@ function splitWebdavUrl(fullUrl: string): { serverUrl: string; folderPath: strin
     const url = new URL(fullUrl)
     const pathname = url.pathname.replace(/\/+$/, '')
     if (!pathname) return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
-    const idx = pathname.toUpperCase().indexOf('/GLANCE/')
+    const idx = pathname.toUpperCase().indexOf('/GLANCE')
     if (idx !== -1) {
-      url.pathname = pathname.slice(0, idx) + '/'
-      return { serverUrl: url.toString(), folderPath: pathname.slice(idx + 1) }
+      const afterGlance = pathname[idx + '/GLANCE'.length]
+      if (afterGlance === undefined || afterGlance === '/') {
+        url.pathname = pathname.slice(0, idx) + '/'
+        let folderPath = pathname.slice(idx + 1)
+        // Migrate old configs where webdavUrl included the appFolderName segment
+        if (folderPath.endsWith('/' + APP_FOLDER_NAME)) {
+          folderPath = folderPath.slice(0, -(APP_FOLDER_NAME.length + 1))
+        }
+        return { serverUrl: url.toString(), folderPath }
+      }
     }
     return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
   } catch {


### PR DESCRIPTION
## Summary

- Fixes a breaking change introduced by `@glance-apps/sync` 1.0.3 (released 2026-05-23) that caused sync to hard-stop with a FORBIDDEN error
- `DEFAULT_FOLDER` changed from `'GLANCE/lastglance'` to `'GLANCE'` — the library now appends the `appFolderName` (`lastglance`) to `webdavUrl` automatically, so including it in the folder path caused the sync file to land at `.../GLANCE/lastglance/lastglance/lastglance-sync.json` instead of `.../GLANCE/lastglance/lastglance-sync.json`
- `splitWebdavUrl` updated to match `/GLANCE` at end-of-path (previously required a trailing slash) and auto-migrates existing stored configs by stripping the extra `/lastglance` suffix — no manual user action required beyond opening and saving the sync settings once
- Bumps version to 0.1.8 and updates lockfile

## Test plan

- [ ] Open Cloud Sync settings — Folder field should default to `GLANCE` (not `GLANCE/lastglance`)
- [ ] With an old config stored (webdavUrl ending in `/GLANCE/lastglance`), open and save the dialog — verify the stored URL is auto-corrected to end in `/GLANCE`
- [ ] Click **Clear** on the hard-stop banner, then **Sync now** — verify sync succeeds and file lands at `GLANCE/lastglance/lastglance-sync.json`
- [ ] Test connection button returns success

https://claude.ai/code/session_015WkiumK7paAXRGMNpEFe5D

---
_Generated by [Claude Code](https://claude.ai/code/session_015WkiumK7paAXRGMNpEFe5D)_