### PR TITLE
fix(proxy): treat HTML GET responses as 404

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -133,7 +133,15 @@ export default async function handler(req, res) {
     const response = await fetch(url, fetchOptions);
     const body = await response.text();
 
-    res.setHeader('Content-Type', response.headers.get('content-type') || 'text/plain');
+    // Some WebDAV servers return 200 HTML (error page) for missing resources
+    // instead of a proper 404. Normalise these so the sync library can treat
+    // them as "file not found" rather than crashing on JSON.parse('<').
+    const contentType = response.headers.get('content-type') || '';
+    if (req.method === 'GET' && response.ok && contentType.includes('text/html')) {
+      return res.status(404).end();
+    }
+
+    res.setHeader('Content-Type', contentType || 'text/plain');
     res.setHeader('Cache-Control', 'no-store');
     const etag = response.headers.get('etag');
     if (etag) res.setHeader('ETag', etag);


### PR DESCRIPTION
Some WebDAV servers return 200 OK with an HTML error page for missing resources instead of a proper 404. The sync library calls JSON.parse on the response body and blows up with SyntaxError on the doctype. Map these to 404 so the library treats them as "file not found" and proceeds to the first upload.

https://claude.ai/code/session_015WkiumK7paAXRGMNpEFe5D