### PR TITLE
fix(proxy): detect HTML body directly, not just via Content-Type

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -136,8 +136,11 @@ export default async function handler(req, res) {
     // Some WebDAV servers return 200 HTML (error page) for missing resources
     // instead of a proper 404. Normalise these so the sync library can treat
     // them as "file not found" rather than crashing on JSON.parse('<').
+    // Check both the Content-Type header and the body itself since some servers
+    // omit the header or use a non-standard value.
     const contentType = response.headers.get('content-type') || '';
-    if (req.method === 'GET' && response.ok && contentType.includes('text/html')) {
+    if (req.method === 'GET' && response.ok &&
+        (contentType.includes('text/html') || body.trimStart().startsWith('<'))) {
       return res.status(404).end();
     }
 


### PR DESCRIPTION
The previous check relied on the server sending text/html as the Content-Type, which isn't guaranteed. Also inspect the response body — if a GET response is 200 OK and the body starts with '<', it's an HTML error page and should be returned as 404.

https://claude.ai/code/session_015WkiumK7paAXRGMNpEFe5D