### PR TITLE
fix(sync): v0.1.11 — Docker proxy sidecar, dayGLANCE-aligned folder config, passphrase confirmation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,17 @@ COPY . .
 RUN npm run build
 
 FROM nginx:alpine AS runtime
+# Add Node.js for the WebDAV proxy sidecar
+RUN apk add --no-cache nodejs
+
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Proxy sidecar — only needs package.json (for "type":"module") + the api handler
+WORKDIR /app
+COPY package.json ./
+COPY api/ ./api/
+COPY server.js ./
+
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD sh -c "node /app/server.js & nginx -g 'daemon off;'"

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,6 +10,15 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # WebDAV proxy — forward to the Node.js sidecar
+    location /api/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 30s;
+    }
+
     # SPA fallback — all routes serve index.html
     location / {
         try_files $uri $uri/ /index.html;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@glance-apps/intents": "^1.1.0",
         "@glance-apps/sync": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,25 @@
+import http from 'http'
+import { URL } from 'url'
+import handler from './api/webdav-proxy.js'
+
+const server = http.createServer((req, res) => {
+  const u = new URL(req.url, 'http://localhost')
+  req.query = Object.fromEntries(u.searchParams)
+
+  // Adapt Node.js ServerResponse to the Vercel-style res.status().send() interface
+  res.status = (code) => {
+    res.statusCode = code
+    return {
+      json:  (obj)  => { res.setHeader('Content-Type', 'application/json'); res.end(JSON.stringify(obj)) },
+      send:  (body) => res.end(body),
+      end:   ()     => res.end(),
+    }
+  }
+
+  handler(req, res).catch((err) => {
+    console.error('[proxy] unhandled error:', err)
+    if (!res.headersSent) { res.statusCode = 502; res.end('Bad Gateway') }
+  })
+})
+
+server.listen(3001, '127.0.0.1', () => console.log('[proxy] listening on 127.0.0.1:3001'))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { useNotifications } from '@/hooks/useNotifications'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
-import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG } from '@/sync/engine'
+import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, migrateCloudSyncConfig, CRYPTO_CONFIG } from '@/sync/engine'
 import type { SyncEngine, SyncStatus } from '@glance-apps/sync'
 import dayjs from 'dayjs'
 
@@ -126,6 +126,7 @@ function AppInner() {
 
   // Initialize sync engine on mount
   useEffect(() => {
+    migrateCloudSyncConfig()
     initSessionKey(CRYPTO_CONFIG).catch(() => {/* non-fatal */})
     const engine = createEngine(import.meta.env.VITE_WEBDAV_PROXY_URL, {
       onStatusChange: (status) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { useNotifications } from '@/hooks/useNotifications'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
-import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, migrateCloudSyncConfig, CRYPTO_CONFIG } from '@/sync/engine'
+import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG } from '@/sync/engine'
 import type { SyncEngine, SyncStatus } from '@glance-apps/sync'
 import dayjs from 'dayjs'
 
@@ -126,7 +126,6 @@ function AppInner() {
 
   // Initialize sync engine on mount
   useEffect(() => {
-    migrateCloudSyncConfig()
     initSessionKey(CRYPTO_CONFIG).catch(() => {/* non-fatal */})
     const engine = createEngine(import.meta.env.VITE_WEBDAV_PROXY_URL, {
       onStatusChange: (status) => {

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -47,6 +47,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
 
   const [encEnabled, setEncEnabled] = useState(() => engine?.hasEncryptionReady() ?? false)
   const [passphrase, setPassphrase] = useState('')
+  const [confirmPassphrase, setConfirmPassphrase] = useState('')
   const [showPassphraseInput, setShowPassphraseInput] = useState(false)
   const [encSaving, setEncSaving] = useState(false)
   const [encError, setEncError] = useState('')
@@ -100,6 +101,10 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
 
   async function handleEnableEncryption() {
     if (!passphrase.trim()) return
+    if (passphrase !== confirmPassphrase) {
+      setEncError('Passphrases do not match')
+      return
+    }
     setEncSaving(true)
     setEncError('')
     try {
@@ -107,6 +112,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
       setEncEnabled(true)
       setShowPassphraseInput(false)
       setPassphrase('')
+      setConfirmPassphrase('')
     } catch (err) {
       setEncError(err instanceof Error ? err.message : 'Failed to set passphrase')
     } finally {
@@ -297,6 +303,9 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
                     handleDisableEncryption()
                   } else {
                     setShowPassphraseInput(p => !p)
+                    setPassphrase('')
+                    setConfirmPassphrase('')
+                    setEncError('')
                   }
                 }}
                 disabled={encSaving}
@@ -309,19 +318,41 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
             </div>
 
             {showPassphraseInput && !encEnabled && (
-              <div className="space-y-2">
-                <input
-                  type="password"
-                  value={passphrase}
-                  onChange={e => setPassphrase(e.target.value)}
-                  placeholder="Enter passphrase"
-                  autoComplete="new-password"
-                  onKeyDown={e => { if (e.key === 'Enter') handleEnableEncryption() }}
-                  className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
-                />
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+                    Sync passphrase
+                  </label>
+                  <input
+                    type="password"
+                    value={passphrase}
+                    onChange={e => setPassphrase(e.target.value)}
+                    placeholder="Choose a strong passphrase"
+                    autoComplete="new-password"
+                    className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+                    Confirm passphrase
+                  </label>
+                  <input
+                    type="password"
+                    value={confirmPassphrase}
+                    onChange={e => setConfirmPassphrase(e.target.value)}
+                    placeholder="Re-enter your passphrase"
+                    autoComplete="new-password"
+                    onKeyDown={e => { if (e.key === 'Enter') handleEnableEncryption() }}
+                    className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                  />
+                </div>
+                <div className="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/40 px-4 py-3 space-y-1">
+                  <p className="text-xs font-semibold text-amber-600 dark:text-amber-400">Important — store your passphrase safely</p>
+                  <p className="text-xs text-amber-700 dark:text-amber-300">This passphrase cannot be recovered. You will need it to set up sync on new devices. Store it in a password manager.</p>
+                </div>
                 <button
                   onClick={handleEnableEncryption}
-                  disabled={!passphrase.trim() || encSaving}
+                  disabled={!passphrase.trim() || !confirmPassphrase.trim() || encSaving}
                   className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-green-400 text-white hover:bg-green-300 disabled:opacity-40 transition-colors"
                 >
                   {encSaving && <Loader size={12} className="animate-spin" />}

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Loader, AlertTriangle, CheckCircle, XCircle } from 'lucide-react'
 import type { SyncEngine } from '@glance-apps/sync'
-import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, APP_FOLDER_NAME } from '@/sync/engine'
+import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, DEFAULT_SYNC_FOLDER, SYNC_FOLDER_KEY } from '@/sync/engine'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 
 interface Props {
@@ -13,43 +13,32 @@ interface Props {
 type TestStatus = 'idle' | 'testing' | 'ok' | 'fail'
 type SyncResult = 'idle' | 'ok' | 'error'
 
-const DEFAULT_FOLDER = `GLANCE/${APP_FOLDER_NAME}`
-
-function splitWebdavUrl(fullUrl: string): { serverUrl: string; folderPath: string } {
-  if (!fullUrl) return { serverUrl: '', folderPath: DEFAULT_FOLDER }
+function splitWebdavUrl(fullUrl: string): { serverUrl: string } {
+  if (!fullUrl) return { serverUrl: '' }
   try {
+    // webdavUrl is always the bare server root — strip any leftover path
+    // (handles migration from the old format that baked the folder into the URL)
     const url = new URL(fullUrl)
-    const pathname = url.pathname.replace(/\/+$/, '')
-    if (!pathname || pathname === '/') return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
-    // webdavUrl is stored without APP_FOLDER_NAME (the library appends it).
-    // Add it back for display so the user sees the full path.
-    const suffix = '/' + APP_FOLDER_NAME
-    const folderPath = pathname.endsWith(suffix)
-      ? pathname.slice(1)                        // already has the suffix somehow — show as-is
-      : pathname.slice(1) + suffix               // normal case: add it back
     url.pathname = '/'
-    return { serverUrl: url.toString(), folderPath }
+    return { serverUrl: url.toString() }
   } catch {
-    return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
+    return { serverUrl: fullUrl }
   }
 }
 
-function buildWebdavUrl(serverUrl: string, folderPath: string): string {
-  const base = serverUrl.replace(/\/+$/, '')
-  let folder = folderPath.replace(/^\/+/, '').replace(/\/+$/, '')
-  // Strip APP_FOLDER_NAME from the end — the library appends it automatically.
-  const suffix = '/' + APP_FOLDER_NAME
-  if (folder === APP_FOLDER_NAME) folder = ''
-  else if (folder.endsWith(suffix)) folder = folder.slice(0, -suffix.length)
-  return folder ? `${base}/${folder}` : base
+function buildWebdavUrl(serverUrl: string): string {
+  // The full folder path is stored separately (SYNC_FOLDER_KEY) and passed to
+  // the engine as appFolderName — webdavUrl is the bare server root only.
+  return serverUrl.replace(/\/+$/, '')
 }
 
 export function SyncSettingsModal({ engine, onClose }: Props) {
   const existingConfig = engine?.getConfig() ?? null
-  const { serverUrl: initServer, folderPath: initFolder } = splitWebdavUrl((existingConfig?.webdavUrl as string) ?? '')
+  const { serverUrl: initServer } = splitWebdavUrl((existingConfig?.webdavUrl as string) ?? '')
 
   const [serverUrl, setServerUrl] = useState(() => initServer)
-  const [folderPath, setFolderPath] = useState(() => initFolder)
+  const [folderPath, setFolderPath] = useState(() => localStorage.getItem(SYNC_FOLDER_KEY) ?? DEFAULT_SYNC_FOLDER)
+  const originalFolder = useRef(localStorage.getItem(SYNC_FOLDER_KEY) ?? DEFAULT_SYNC_FOLDER)
   const [username, setUsername] = useState(() => (existingConfig?.username as string) ?? '')
   const [appPassword, setAppPassword] = useState(() => (existingConfig?.appPassword as string) ?? '')
 
@@ -73,9 +62,14 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
 
   function saveConfig() {
     if (!engine) return
-    const webdavUrl = buildWebdavUrl(serverUrl, folderPath)
+    const webdavUrl = buildWebdavUrl(serverUrl)
     engine.setConfig(serverUrl.trim() ? { provider: 'webdav', webdavUrl, username, appPassword, enabled: true } : null)
+    localStorage.setItem(SYNC_FOLDER_KEY, folderPath)
     resetEnsuredFolder()
+    // appFolderName is fixed at engine creation — reload so the new folder takes effect
+    if (folderPath !== originalFolder.current) {
+      window.location.reload()
+    }
   }
 
   function handleClose() {
@@ -90,7 +84,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
     setTestStatus('testing')
     setTestError('')
     try {
-      const webdavUrl = buildWebdavUrl(serverUrl, folderPath)
+      const webdavUrl = buildWebdavUrl(serverUrl)
       const result = await engine.test({ provider: 'webdav', webdavUrl, username, appPassword })
       if (result.success) {
         setTestStatus('ok')
@@ -229,7 +223,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
                 type="text"
                 value={folderPath}
                 onChange={e => setFolderPath(e.target.value)}
-                placeholder={DEFAULT_FOLDER}
+                placeholder={DEFAULT_SYNC_FOLDER}
                 className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
               />
               <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Loader, AlertTriangle, CheckCircle, XCircle } from 'lucide-react'
 import type { SyncEngine } from '@glance-apps/sync'
-import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled } from '@/sync/engine'
+import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, APP_FOLDER_NAME } from '@/sync/engine'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 
 interface Props {
@@ -13,29 +13,22 @@ interface Props {
 type TestStatus = 'idle' | 'testing' | 'ok' | 'fail'
 type SyncResult = 'idle' | 'ok' | 'error'
 
-const DEFAULT_FOLDER = 'GLANCE/lastglance'
-// The sync library appends this as a subfolder to webdavUrl, so it must be
-// stripped from the stored URL and added back for display.
-const APP_FOLDER_NAME = 'lastglance'
+const DEFAULT_FOLDER = APP_FOLDER_NAME
 
 function splitWebdavUrl(fullUrl: string): { serverUrl: string; folderPath: string } {
   if (!fullUrl) return { serverUrl: '', folderPath: DEFAULT_FOLDER }
   try {
     const url = new URL(fullUrl)
+    // Strip any GLANCE or GLANCE/lastglance suffix from the path — webdavUrl is
+    // now stored as the bare server root; APP_FOLDER_NAME is passed to the library directly.
     const pathname = url.pathname.replace(/\/+$/, '')
-    if (!pathname) return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
-    const idx = pathname.toUpperCase().indexOf('/GLANCE')
-    if (idx !== -1) {
-      const afterGlance = pathname[idx + '/GLANCE'.length]
-      if (afterGlance === undefined || afterGlance === '/') {
-        url.pathname = pathname.slice(0, idx) + '/'
-        let folderPath = pathname.slice(idx + 1)
-        // webdavUrl is stored without the appFolderName (the library appends it),
-        // so add it back for display
-        if (!folderPath.endsWith('/' + APP_FOLDER_NAME)) {
-          folderPath = folderPath + '/' + APP_FOLDER_NAME
-        }
-        return { serverUrl: url.toString(), folderPath }
+    const upper = pathname.toUpperCase()
+    const glanceIdx = upper.lastIndexOf('/GLANCE')
+    if (glanceIdx !== -1) {
+      const rest = upper.slice(glanceIdx + '/GLANCE'.length)
+      if (rest === '' || rest.startsWith('/LASTGLANCE')) {
+        url.pathname = pathname.slice(0, glanceIdx) || '/'
+        return { serverUrl: url.toString(), folderPath: DEFAULT_FOLDER }
       }
     }
     return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
@@ -44,15 +37,10 @@ function splitWebdavUrl(fullUrl: string): { serverUrl: string; folderPath: strin
   }
 }
 
-function buildWebdavUrl(serverUrl: string, folderPath: string): string {
-  const base = serverUrl.replace(/\/+$/, '')
-  let folder = folderPath.replace(/^\/+/, '').replace(/\/+$/, '')
-  // Strip appFolderName from the end — the sync library appends it automatically
-  if (folder === APP_FOLDER_NAME) folder = ''
-  else if (folder.endsWith('/' + APP_FOLDER_NAME)) folder = folder.slice(0, -(APP_FOLDER_NAME.length + 1))
-  if (!folder) return base
-  if (base.endsWith('/' + folder)) return base
-  return `${base}/${folder}`
+function buildWebdavUrl(serverUrl: string, _folderPath: string): string {
+  // APP_FOLDER_NAME ('GLANCE/lastglance') is passed to the library via engine config;
+  // webdavUrl must be the bare server root only.
+  return serverUrl.replace(/\/+$/, '')
 }
 
 export function SyncSettingsModal({ engine, onClose }: Props) {
@@ -239,12 +227,11 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
               <input
                 type="text"
                 value={folderPath}
-                onChange={e => setFolderPath(e.target.value)}
-                placeholder={DEFAULT_FOLDER}
-                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                readOnly
+                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 border border-slate-200 dark:border-slate-600 opacity-60 cursor-default"
               />
               <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
-                Path on your WebDAV server where sync files are stored.
+                Fixed path — sync files are always stored here.
               </p>
             </div>
 

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -13,34 +13,35 @@ interface Props {
 type TestStatus = 'idle' | 'testing' | 'ok' | 'fail'
 type SyncResult = 'idle' | 'ok' | 'error'
 
-const DEFAULT_FOLDER = APP_FOLDER_NAME
+const DEFAULT_FOLDER = `GLANCE/${APP_FOLDER_NAME}`
 
 function splitWebdavUrl(fullUrl: string): { serverUrl: string; folderPath: string } {
   if (!fullUrl) return { serverUrl: '', folderPath: DEFAULT_FOLDER }
   try {
     const url = new URL(fullUrl)
-    // Strip any GLANCE or GLANCE/lastglance suffix from the path — webdavUrl is
-    // now stored as the bare server root; APP_FOLDER_NAME is passed to the library directly.
     const pathname = url.pathname.replace(/\/+$/, '')
-    const upper = pathname.toUpperCase()
-    const glanceIdx = upper.lastIndexOf('/GLANCE')
-    if (glanceIdx !== -1) {
-      const rest = upper.slice(glanceIdx + '/GLANCE'.length)
-      if (rest === '' || rest.startsWith('/LASTGLANCE')) {
-        url.pathname = pathname.slice(0, glanceIdx) || '/'
-        return { serverUrl: url.toString(), folderPath: DEFAULT_FOLDER }
-      }
-    }
-    return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
+    if (!pathname || pathname === '/') return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
+    // webdavUrl is stored without APP_FOLDER_NAME (the library appends it).
+    // Add it back for display so the user sees the full path.
+    const suffix = '/' + APP_FOLDER_NAME
+    const folderPath = pathname.endsWith(suffix)
+      ? pathname.slice(1)                        // already has the suffix somehow — show as-is
+      : pathname.slice(1) + suffix               // normal case: add it back
+    url.pathname = '/'
+    return { serverUrl: url.toString(), folderPath }
   } catch {
     return { serverUrl: fullUrl, folderPath: DEFAULT_FOLDER }
   }
 }
 
-function buildWebdavUrl(serverUrl: string, _folderPath: string): string {
-  // APP_FOLDER_NAME ('GLANCE/lastglance') is passed to the library via engine config;
-  // webdavUrl must be the bare server root only.
-  return serverUrl.replace(/\/+$/, '')
+function buildWebdavUrl(serverUrl: string, folderPath: string): string {
+  const base = serverUrl.replace(/\/+$/, '')
+  let folder = folderPath.replace(/^\/+/, '').replace(/\/+$/, '')
+  // Strip APP_FOLDER_NAME from the end — the library appends it automatically.
+  const suffix = '/' + APP_FOLDER_NAME
+  if (folder === APP_FOLDER_NAME) folder = ''
+  else if (folder.endsWith(suffix)) folder = folder.slice(0, -suffix.length)
+  return folder ? `${base}/${folder}` : base
 }
 
 export function SyncSettingsModal({ engine, onClose }: Props) {
@@ -227,11 +228,12 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
               <input
                 type="text"
                 value={folderPath}
-                readOnly
-                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 border border-slate-200 dark:border-slate-600 opacity-60 cursor-default"
+                onChange={e => setFolderPath(e.target.value)}
+                placeholder={DEFAULT_FOLDER}
+                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
               />
               <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
-                Fixed path — sync files are always stored here.
+                Path on your WebDAV server where sync files are stored.
               </p>
             </div>
 

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -13,6 +13,7 @@ import { buildAuthHeader, ensureFolder } from '@/intents/webdav'
 import type { SyncPayload } from './types'
 
 export const CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto' }
+export const APP_FOLDER_NAME = 'GLANCE/lastglance'
 
 export { initSessionKey, setupEncryptionKey, clearEncryptionKey }
 
@@ -269,9 +270,8 @@ export async function ensureSyncFolder(engine: SyncEngine): Promise<void> {
   if (_ensuredForUrl === webdavUrl) return
   try {
     const url = new URL(webdavUrl)
-    const baseUrl = `${url.protocol}//${url.host}`
-    const folderPath = url.pathname.replace(/^\//, '').replace(/\/+$/, '')
-    await ensureFolder(baseUrl, folderPath, buildAuthHeader(username, appPassword))
+    const baseUrl = `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`
+    await ensureFolder(baseUrl, APP_FOLDER_NAME, buildAuthHeader(username, appPassword))
     _ensuredForUrl = webdavUrl
   } catch {
     // non-fatal — if we can't create the folder the sync will surface its own error
@@ -291,7 +291,7 @@ export function createEngine(proxyUrl: string | undefined, callbacks: EngineCall
     cryptoDBName: 'lastglance-crypto',
     autoBackupDBName: 'lastglance-auto-backups',
     syncFilename: 'lastglance-sync.json',
-    appFolderName: 'lastglance',
+    appFolderName: APP_FOLDER_NAME,
     backupFilenamePrefix: 'lastglance-backup-',
     appId: 'lastglance',
     appName: 'lastGLANCE',

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -13,7 +13,7 @@ import { buildAuthHeader, ensureFolder } from '@/intents/webdav'
 import type { SyncPayload } from './types'
 
 export const CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto' }
-export const APP_FOLDER_NAME = 'GLANCE/lastglance'
+export const APP_FOLDER_NAME = 'lastglance'
 
 export { initSessionKey, setupEncryptionKey, clearEncryptionKey }
 
@@ -270,8 +270,10 @@ export async function ensureSyncFolder(engine: SyncEngine): Promise<void> {
   if (_ensuredForUrl === webdavUrl) return
   try {
     const url = new URL(webdavUrl)
-    const baseUrl = `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`
-    await ensureFolder(baseUrl, APP_FOLDER_NAME, buildAuthHeader(username, appPassword))
+    const baseUrl = `${url.protocol}//${url.host}`
+    const parentPath = url.pathname.replace(/^\//, '').replace(/\/+$/, '')
+    const folderPath = parentPath ? `${parentPath}/${APP_FOLDER_NAME}` : APP_FOLDER_NAME
+    await ensureFolder(baseUrl, folderPath, buildAuthHeader(username, appPassword))
     _ensuredForUrl = webdavUrl
   } catch {
     // non-fatal — if we can't create the folder the sync will surface its own error

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -13,7 +13,33 @@ import { buildAuthHeader, ensureFolder } from '@/intents/webdav'
 import type { SyncPayload } from './types'
 
 export const CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto' }
-export const APP_FOLDER_NAME = 'lastglance'
+export const DEFAULT_SYNC_FOLDER = 'GLANCE/lastglance'
+export const SYNC_FOLDER_KEY = 'lastglance-cloud-sync-folder'
+
+// One-time migration: old format stored the parent path inside webdavUrl
+// (e.g. "https://server/GLANCE"). New format stores bare server root and
+// keeps the full folder path in SYNC_FOLDER_KEY.
+export function migrateCloudSyncConfig(): void {
+  const configKey = 'lastglance-cloud-sync-config'
+  const raw = localStorage.getItem(configKey)
+  if (!raw) return
+  try {
+    const cfg = JSON.parse(raw)
+    if (!cfg?.webdavUrl) return
+    const url = new URL(cfg.webdavUrl)
+    const pathname = url.pathname.replace(/\/+$/, '')
+    if (!pathname || pathname === '/') return  // already bare — nothing to do
+    // Save the reconstructed full folder path if not already stored
+    if (!localStorage.getItem(SYNC_FOLDER_KEY)) {
+      const parent = pathname.replace(/^\//, '')
+      localStorage.setItem(SYNC_FOLDER_KEY, `${parent}/lastglance`)
+    }
+    // Strip path from stored webdavUrl
+    url.pathname = '/'
+    cfg.webdavUrl = url.toString().replace(/\/$/, '')
+    localStorage.setItem(configKey, JSON.stringify(cfg))
+  } catch { /* non-fatal */ }
+}
 
 export { initSessionKey, setupEncryptionKey, clearEncryptionKey }
 
@@ -270,10 +296,9 @@ export async function ensureSyncFolder(engine: SyncEngine): Promise<void> {
   if (_ensuredForUrl === webdavUrl) return
   try {
     const url = new URL(webdavUrl)
-    const baseUrl = `${url.protocol}//${url.host}`
-    const parentPath = url.pathname.replace(/^\//, '').replace(/\/+$/, '')
-    const folderPath = parentPath ? `${parentPath}/${APP_FOLDER_NAME}` : APP_FOLDER_NAME
-    await ensureFolder(baseUrl, folderPath, buildAuthHeader(username, appPassword))
+    const baseUrl = `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`
+    const folder = localStorage.getItem(SYNC_FOLDER_KEY) || DEFAULT_SYNC_FOLDER
+    await ensureFolder(baseUrl, folder, buildAuthHeader(username, appPassword))
     _ensuredForUrl = webdavUrl
   } catch {
     // non-fatal — if we can't create the folder the sync will surface its own error
@@ -288,12 +313,13 @@ interface EngineCallbacks {
 }
 
 export function createEngine(proxyUrl: string | undefined, callbacks: EngineCallbacks): SyncEngine {
+  const appFolderName = localStorage.getItem(SYNC_FOLDER_KEY) || DEFAULT_SYNC_FOLDER
   return createSyncEngine({
     storageKeyPrefix: 'lastglance',
     cryptoDBName: 'lastglance-crypto',
     autoBackupDBName: 'lastglance-auto-backups',
     syncFilename: 'lastglance-sync.json',
-    appFolderName: APP_FOLDER_NAME,
+    appFolderName,
     backupFilenamePrefix: 'lastglance-backup-',
     appId: 'lastglance',
     appName: 'lastGLANCE',

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -16,31 +16,6 @@ export const CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto' }
 export const DEFAULT_SYNC_FOLDER = 'GLANCE/lastglance'
 export const SYNC_FOLDER_KEY = 'lastglance-cloud-sync-folder'
 
-// One-time migration: old format stored the parent path inside webdavUrl
-// (e.g. "https://server/GLANCE"). New format stores bare server root and
-// keeps the full folder path in SYNC_FOLDER_KEY.
-export function migrateCloudSyncConfig(): void {
-  const configKey = 'lastglance-cloud-sync-config'
-  const raw = localStorage.getItem(configKey)
-  if (!raw) return
-  try {
-    const cfg = JSON.parse(raw)
-    if (!cfg?.webdavUrl) return
-    const url = new URL(cfg.webdavUrl)
-    const pathname = url.pathname.replace(/\/+$/, '')
-    if (!pathname || pathname === '/') return  // already bare — nothing to do
-    // Save the reconstructed full folder path if not already stored
-    if (!localStorage.getItem(SYNC_FOLDER_KEY)) {
-      const parent = pathname.replace(/^\//, '')
-      localStorage.setItem(SYNC_FOLDER_KEY, `${parent}/lastglance`)
-    }
-    // Strip path from stored webdavUrl
-    url.pathname = '/'
-    cfg.webdavUrl = url.toString().replace(/\/$/, '')
-    localStorage.setItem(configKey, JSON.stringify(cfg))
-  } catch { /* non-fatal */ }
-}
-
 export { initSessionKey, setupEncryptionKey, clearEncryptionKey }
 
 // buildPayload: read all Dexie tables, map to sync shapes


### PR DESCRIPTION
## Summary

- **Docker proxy sidecar**: `api/webdav-proxy.js` is a Vercel serverless function and never ran in Docker. Added `server.js` (thin Node HTTP adapter) + updated `nginx.conf` to route `/api/` to it, and updated `Dockerfile` to install Node.js and start both processes.
- **Aligned `appFolderName` with dayGLANCE**: User-entered folder path is now passed directly to the library as `appFolderName`; `webdavUrl` stores only the bare server root. Folder is persisted in its own `localStorage` key (`lastglance-cloud-sync-folder`). Engine is re-created on folder change via page reload.
- **Fixed `ensureSyncFolder`**: Was only MKCOLing the parent folder (`GLANCE`), not the full sync path (`GLANCE/lastglance`).
- **Passphrase confirmation field**: Encryption setup now requires entering the passphrase twice, with a mismatch error and an amber warning box ("store your passphrase safely"), matching dayGLANCE UX.
- **Proxy HTML-body detection**: WebDAV servers that return `200 OK` with an HTML error page are now normalised to `404` so the sync library treats them as "file not found".
- **`workflow_dispatch`** added to `publish-ghcr.yml` for manual Docker builds.
- Version bumped to **0.1.11** (lockfile updated).

## Test plan

- [ ] Fresh Docker build via `publish-ghcr` workflow dispatch
- [ ] Open Cloud Sync settings — Server URL field shows bare server, Folder defaults to `GLANCE/lastglance`
- [ ] Change folder, save — page reloads, new folder is used on next sync
- [ ] Enable encryption — confirm field required, mismatch shows error, warning box visible
- [ ] Sync completes without HTML-body or 405 errors in console

---
_Generated by [Claude Code](https://claude.ai/code/session_015WkiumK7paAXRGMNpEFe5D)_