### PR TITLE
Fix passphrase-in-session gate and encryption toggle alignment

### DIFF
--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -227,7 +227,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
             <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
               Encryption
             </h3>
-            <div className="flex items-center justify-between py-1">
+            <div className="flex items-start justify-between py-1">
               <div>
                 <p className={`text-sm ${encReady ? 'text-slate-700 dark:text-slate-300' : 'text-slate-400 dark:text-slate-500'}`}>
                   Encrypt intent files
@@ -242,7 +242,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
                 type="button"
                 disabled={!encReady}
                 onClick={() => set('encryptionEnabled', !localConfig.encryptionEnabled)}
-                className={`relative w-10 h-6 rounded-full transition-colors disabled:opacity-40 ${localConfig.encryptionEnabled && encReady ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
+                className={`relative w-10 h-6 rounded-full transition-colors disabled:opacity-40 shrink-0 mt-0.5 ${localConfig.encryptionEnabled && encReady ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
                 aria-checked={localConfig.encryptionEnabled && encReady}
                 role="switch"
               >

--- a/src/hooks/useIntentsPoller.ts
+++ b/src/hooks/useIntentsPoller.ts
@@ -11,7 +11,7 @@ import {
   NotEncryptedError,
   MalformedEnvelopeError,
 } from '@glance-apps/intents'
-import { hasEncryptionReady, deriveKeyForSalt } from '@glance-apps/sync'
+import { hasEncryptionReady, deriveKeyForSalt, getSyncPassphrase } from '@glance-apps/sync'
 import { db } from '@/db/client'
 import { logCompletion } from '@/db/queries'
 import {
@@ -78,6 +78,11 @@ export function useIntentsPoller(onNewCompletion?: () => void): void {
         if (isEncrypted) {
           if (!config.encryptionEnabled || !hasEncryptionReady()) {
             addActivityEntry({ type: 'error', message: 'Encrypted intent received but encryption not configured' })
+            newCursor = parsedFilename!.timestamp
+            continue
+          }
+          if (getSyncPassphrase() === null) {
+            addActivityEntry({ type: 'error', message: 'Encrypted intent received — enter your sync passphrase to decrypt' })
             newCursor = parsedFilename!.timestamp
             continue
           }

--- a/src/intents/emitter.ts
+++ b/src/intents/emitter.ts
@@ -1,5 +1,5 @@
 import { ACTIONS, SOURCE_APPS, buildEnvelope, buildEncryptedEnvelope, filenameFor } from '@glance-apps/intents'
-import { hasEncryptionReady, deriveKeyForSalt } from '@glance-apps/sync'
+import { deriveKeyForSalt, getSyncPassphrase } from '@glance-apps/sync'
 import type { ChoreWithLastCompletion } from '@/types'
 import { getIntentsConfig, isIntentsConfigured, addActivityEntry } from './config'
 import { buildAuthHeader, ensureFolder, putFile } from './webdav'
@@ -21,7 +21,7 @@ export async function emitCreateIntent(chore: ChoreWithLastCompletion): Promise<
     }
 
     let envelope: Awaited<ReturnType<typeof buildEncryptedEnvelope>> | ReturnType<typeof buildEnvelope>
-    if (config.encryptionEnabled && hasEncryptionReady()) {
+    if (config.encryptionEnabled && getSyncPassphrase() !== null) {
       envelope = await buildEncryptedEnvelope(
         { action: ACTIONS.CREATE, payload, emittedBy: SOURCE_APPS.LASTGLANCE },
         deriveKeyForSalt


### PR DESCRIPTION
deriveKeyForSalt requires the passphrase to be in session (not just the cached CryptoKey from initSessionKey). hasEncryptionReady() is true after key restore from IndexedDB, but getSyncPassphrase() is null until the user re-enters the passphrase. The sync CHANGELOG documents this: callers should gate on getSyncPassphrase() !== null, not hasEncryptionReady().

Emitter: replace hasEncryptionReady() gate with getSyncPassphrase() !== null so it falls back to plaintext rather than erroring when passphrase not in session. Poller: keep the existing hasEncryptionReady() check for the not-configured case, add a separate getSyncPassphrase() check that surfaces a clear "enter your sync passphrase" message.

Also fix the encryption toggle layout: items-center was vertically centering the toggle against the full label+description block, making it float between lines. Switch to items-start + mt-0.5 so the toggle aligns with the "Encrypt intent files" label.

https://claude.ai/code/session_01YAQKB1cXYWRnzAAZsjUfZP