### PR TITLE
fix: downgrade MalformedEnvelopeError to warning; move activity log to dedicated modal

### DIFF
--- a/src/components/ActivityLogModal/ActivityLogModal.tsx
+++ b/src/components/ActivityLogModal/ActivityLogModal.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import { X, RefreshCw } from 'lucide-react'
+import { type ActivityEntry, getActivityLog, clearActivityLog } from '@/intents/config'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
+
+interface Props {
+  onClose: () => void
+}
+
+function badgeClass(type: ActivityEntry['type']): string {
+  switch (type) {
+    case 'sent':     return 'bg-blue-100  dark:bg-blue-900/30  text-blue-600  dark:text-blue-400'
+    case 'received': return 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400'
+    case 'warning':  return 'bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400'
+    case 'error':    return 'bg-red-100   dark:bg-red-900/30   text-red-600   dark:text-red-400'
+  }
+}
+
+export function ActivityLogModal({ onClose }: Props) {
+  const [log, setLog] = useState<ActivityEntry[]>(() => getActivityLog())
+
+  useEscapeKey(onClose)
+
+  function refresh() { setLog(getActivityLog()) }
+  function clear() { clearActivityLog(); setLog([]) }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[85vh]">
+        <div className="flex items-center justify-between px-6 pt-5 pb-4 shrink-0 border-b border-slate-100 dark:border-slate-700/40">
+          <h2 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+            Activity Log
+          </h2>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={refresh}
+              className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+            >
+              <RefreshCw size={11} /> Refresh
+            </button>
+            {log.length > 0 && (
+              <button
+                onClick={clear}
+                className="text-xs text-slate-400 dark:text-slate-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+              >
+                Clear
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+            >
+              <X size={18} />
+            </button>
+          </div>
+        </div>
+
+        <div className="overflow-y-auto flex-1 px-6 py-4">
+          {log.length === 0 ? (
+            <p className="text-xs text-slate-400 dark:text-slate-500 italic">No activity yet.</p>
+          ) : (
+            <div className="space-y-1">
+              {log.map(entry => (
+                <div
+                  key={entry.id}
+                  className="flex items-start gap-2 text-xs py-2 border-b border-slate-100 dark:border-slate-700/40 last:border-0"
+                >
+                  <span className="text-slate-400 dark:text-slate-500 tabular-nums shrink-0 pt-0.5">
+                    {new Date(entry.timestamp).toLocaleString([], {
+                      month: 'short', day: 'numeric',
+                      hour: '2-digit', minute: '2-digit',
+                    })}
+                  </span>
+                  <span className={`shrink-0 px-1 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide ${badgeClass(entry.type)}`}>
+                    {entry.type}
+                  </span>
+                  <div className="min-w-0 break-words">
+                    <span className="text-slate-600 dark:text-slate-300">{entry.message}</span>
+                    {entry.detail && (
+                      <p className="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-1 leading-relaxed whitespace-pre-wrap break-all">
+                        {entry.detail}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -6,6 +6,8 @@ import {
   type IntentsConfig,
   DEFAULT_CONFIG,
   saveIntentsConfig,
+  clearActivityLog,
+  getActivityLog,
 } from '@/intents/config'
 import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal'
 import { testConnection } from '@/intents/webdav'
@@ -36,6 +38,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
   const [testStatus, setTestStatus] = useState<TestStatus>('idle')
   const [testError, setTestError] = useState('')
   const [showActivityLog, setShowActivityLog] = useState(false)
+  const [hasActivity, setHasActivity] = useState(() => getActivityLog().length > 0)
   const [rootKeyReady, setRootKeyReady] = useState<boolean | null>(null)
   const [showPassphraseInput, setShowPassphraseInput] = useState(false)
   const [passphraseInput, setPassphraseInput] = useState('')
@@ -319,12 +322,22 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
             <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
               Activity Log
             </h3>
-            <button
-              onClick={() => setShowActivityLog(true)}
-              className="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-            >
-              View log →
-            </button>
+            <div className="flex items-center gap-3">
+              {hasActivity && (
+                <button
+                  onClick={() => { clearActivityLog(); setHasActivity(false) }}
+                  className="text-xs text-slate-400 dark:text-slate-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+                >
+                  Clear
+                </button>
+              )}
+              <button
+                onClick={() => setShowActivityLog(true)}
+                className="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+              >
+                View log →
+              </button>
+            </div>
           </div>
         </div>
 

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -1,15 +1,13 @@
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
-import { X, RefreshCw, Loader } from 'lucide-react'
+import { X, Loader } from 'lucide-react'
 import { hasEncryptionReady, getSyncPassphrase } from '@glance-apps/sync'
 import {
   type IntentsConfig,
-  type ActivityEntry,
   DEFAULT_CONFIG,
   saveIntentsConfig,
-  getActivityLog,
-  clearActivityLog,
 } from '@/intents/config'
+import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal'
 import { testConnection } from '@/intents/webdav'
 import { loadIntentsRootKey, clearIntentsRootKey } from '@/intents/intentsKeyStore'
 import { setupIntentsEncryption } from '@/intents/setupIntentsEncryption'
@@ -37,7 +35,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
 
   const [testStatus, setTestStatus] = useState<TestStatus>('idle')
   const [testError, setTestError] = useState('')
-  const [activityLog, setActivityLog] = useState<ActivityEntry[]>(() => getActivityLog())
+  const [showActivityLog, setShowActivityLog] = useState(false)
   const [rootKeyReady, setRootKeyReady] = useState<boolean | null>(null)
   const [showPassphraseInput, setShowPassphraseInput] = useState(false)
   const [passphraseInput, setPassphraseInput] = useState('')
@@ -50,7 +48,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
     loadIntentsRootKey().then(key => setRootKeyReady(key !== null))
   }, [])
 
-  useEscapeKey(onClose)
+  useEscapeKey(showActivityLog ? () => {} : onClose)
 
   function set<K extends keyof LocalConfig>(key: K, value: LocalConfig[K]) {
     setLocalConfig(prev => ({ ...prev, [key]: value }))
@@ -118,13 +116,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
     }
   }
 
-  function refreshActivity() {
-    setActivityLog(getActivityLog())
-  }
-
-  const recentLog = activityLog.slice(0, 20)
-
-  return createPortal(
+  const modal = createPortal(
     <div
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
@@ -323,63 +315,16 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
           </div>
 
           {/* Activity log */}
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
-                Activity log
-              </h3>
-              <div className="flex items-center gap-3">
-                <button
-                  onClick={refreshActivity}
-                  className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
-                >
-                  <RefreshCw size={11} />
-                  Refresh
-                </button>
-                {activityLog.length > 0 && (
-                  <button
-                    onClick={() => { clearActivityLog(); setActivityLog([]) }}
-                    className="text-xs text-slate-400 dark:text-slate-500 hover:text-red-500 dark:hover:text-red-400 transition-colors"
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-            </div>
-
-            {recentLog.length === 0 ? (
-              <p className="text-xs text-slate-400 dark:text-slate-500 italic">No activity yet.</p>
-            ) : (
-              <div className="space-y-1 max-h-48 overflow-y-auto">
-                {recentLog.map(entry => (
-                  <div key={entry.id} className="flex items-start gap-2 text-xs py-1 border-b border-slate-100 dark:border-slate-700/40 last:border-0">
-                    <span className="text-slate-400 dark:text-slate-500 tabular-nums shrink-0">
-                      {new Date(entry.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                    </span>
-                    <span className={`shrink-0 px-1 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide ${
-                      entry.type === 'sent'
-                        ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'
-                        : entry.type === 'received'
-                          ? 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400'
-                          : 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400'
-                    }`}>
-                      {entry.type}
-                    </span>
-                    <span className="text-slate-600 dark:text-slate-300 break-words min-w-0">
-                      {entry.message}
-                      {entry.detail && (
-                        <span className="text-slate-400 dark:text-slate-500 ml-1">— {entry.detail}</span>
-                      )}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
-            {activityLog.length > recentLog.length && (
-              <p className="text-xs text-slate-400 dark:text-slate-500 italic">
-                Showing {recentLog.length} of {activityLog.length} entries (50 max)
-              </p>
-            )}
+          <div className="flex items-center justify-between py-1">
+            <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+              Activity Log
+            </h3>
+            <button
+              onClick={() => setShowActivityLog(true)}
+              className="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+            >
+              View log →
+            </button>
           </div>
         </div>
 
@@ -404,5 +349,12 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
       </div>
     </div>,
     document.body
+  )
+
+  return (
+    <>
+      {modal}
+      {showActivityLog && <ActivityLogModal onClose={() => setShowActivityLog(false)} />}
+    </>
   )
 }

--- a/src/hooks/useIntentsPoller.ts
+++ b/src/hooks/useIntentsPoller.ts
@@ -96,7 +96,9 @@ export function useIntentsPoller(onNewCompletion?: () => void): void {
             } else if (err instanceof NotEncryptedError) {
               message = 'File is not encrypted as expected'
             } else if (err instanceof MalformedEnvelopeError) {
-              message = 'Malformed encrypted envelope'
+              addActivityEntry({ type: 'warning', message: 'Malformed encrypted envelope', detail: err instanceof Error ? err.message : String(err) })
+              newCursor = parsedFilename!.timestamp
+              continue
             }
             addActivityEntry({ type: 'error', message, detail: err instanceof Error ? err.message : String(err) })
             newCursor = parsedFilename!.timestamp

--- a/src/intents/config.ts
+++ b/src/intents/config.ts
@@ -11,7 +11,7 @@ export interface IntentsConfig {
 export interface ActivityEntry {
   id: string
   timestamp: string
-  type: 'sent' | 'received' | 'error'
+  type: 'sent' | 'received' | 'warning' | 'error'
   message: string
   detail?: string
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **MalformedEnvelopeError demoted to warning**: Encrypted envelopes that decrypt successfully but fail schema validation (e.g. `rescheduled` events from dayGLANCE with timezone-naive `due` fields) now log with an amber `warning` badge instead of red `error`. Genuine failures — wrong key, no key, network errors — stay red. This was the root cause of the alarming-but-harmless errors seen after v1.0.0 shipped with encryption enabled.
- **Activity log extracted to its own modal**: The inline log that was squished at the bottom of the integration settings modal is now a dedicated `ActivityLogModal` (z-60), opened via "View log →". Error details (Zod JSON etc.) render in monospace. The settings modal retains a "Clear" button for quick clearing without opening the log.
- **`warning` added to `ActivityEntry` type** in `config.ts` to support the new badge level.

## Context

After v1.0.0 shipped with intents encryption working, dayGLANCE's `rescheduled` notify events (emitted when a user schedules a task) were producing `MalformedEnvelopeError` due to timezone-naive datetime strings in the `due` field. These errors were visible to users but had no effect — lastGLANCE only acts on `completed` events, and the `completed` notify arrived and logged correctly. A corresponding fix is being made on the dayGLANCE side.

## Test plan

- [ ] Open integration settings — activity log section shows "View log →" and "Clear" (when entries exist)
- [ ] "View log →" opens the activity log modal over the settings modal; Escape closes only the log modal
- [ ] "Clear" in settings row clears the log and hides itself
- [ ] "Clear" in the log modal also works
- [ ] Trigger a `MalformedEnvelopeError` (or manually add a `warning` entry via console) — confirm amber badge, not red
- [ ] Genuine errors (network failure, wrong key) still show red `error` badge

https://claude.ai/code/session_016gDjArwHPn3wJyruErf9zG
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016gDjArwHPn3wJyruErf9zG)_