### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **when did you last...?**
 
-![Version](https://img.shields.io/badge/version-1.0.0-green) ![License](https://img.shields.io/badge/license-MIT-blue)
+![Version](https://img.shields.io/badge/version-1.0.1-green) ![License](https://img.shields.io/badge/license-MIT-blue)
 
 ![lastGLANCE dashboard](public/screenshot.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",
         "@glance-apps/sync": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
$(cat <<'EOF'
Bumps `package.json` and the README badge from 1.0.0 → 1.0.1. Lockfile updated via `npm install`.

Patch release covering the fixes in #60.

https://claude.ai/code/session_016gDjArwHPn3wJyruErf9zG
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016gDjArwHPn3wJyruErf9zG)_