### PR TITLE
v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **when did you last...?**
 
-![Version](https://img.shields.io/badge/version-1.0.1-green) ![License](https://img.shields.io/badge/license-MIT-blue)
+![Version](https://img.shields.io/badge/version-1.1.0-green) ![License](https://img.shields.io/badge/license-MIT-blue)
 
 ![lastGLANCE dashboard](public/screenshot.png)
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Service worker must never be cached so updates reach clients immediately
+    location = /sw.js {
+        expires off;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
     # Immutable assets (hashed filenames from Vite)
     location ~* \.(?:js|css|woff2?|png|jpg|jpeg|gif|svg|ico|webp)$ {
         expires 1y;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",
         "@glance-apps/sync": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { IntegrationSettingsModal } from '@/components/IntegrationSettingsModal/
 import { SyncSettingsModal } from '@/components/SyncSettingsModal/SyncSettingsModal'
 import { PassphraseModal } from '@/components/PassphraseModal/PassphraseModal'
 import { HelpModal } from '@/components/HelpModal/HelpModal'
+import { ShortcutsModal } from '@/components/ShortcutsModal/ShortcutsModal'
 import { ToastProvider } from '@/components/Toast/Toast'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
@@ -112,6 +113,7 @@ function AppInner() {
   const [showSyncSettings, setShowSyncSettings] = useState(false)
   const [showPassphrase, setShowPassphrase] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
+  const [showShortcuts, setShowShortcuts] = useState(false)
   const [ribbonKey, setRibbonKey] = useState(0)
   const [heatmapWeeks, setHeatmapWeeks] = useState<HeatDay[][]>([])
   const [waveKey, setWaveKey] = useState(0)
@@ -330,7 +332,14 @@ function AppInner() {
       )}
 
       {showHelp && (
-        <HelpModal onClose={() => setShowHelp(false)} />
+        <HelpModal
+          onClose={() => setShowHelp(false)}
+          onOpenShortcuts={() => setShowShortcuts(true)}
+        />
+      )}
+
+      {showShortcuts && (
+        <ShortcutsModal onClose={() => setShowShortcuts(false)} />
       )}
 
       {showPassphrase && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Pencil, Check, Sun, Moon, Archive, Plug, Cloud, CloudOff, RefreshCw } from 'lucide-react'
+import { Pencil, Check, Sun, Moon, Archive, Plug, Cloud, CloudOff, RefreshCw, HelpCircle } from 'lucide-react'
 import { Ribbon } from '@/components/Ribbon/Ribbon'
 import { BackupModal } from '@/components/BackupModal/BackupModal'
 import { WelcomeModal } from '@/components/WelcomeModal/WelcomeModal'
@@ -7,6 +7,7 @@ import { clearSeedData } from '@/db/queries'
 import { IntegrationSettingsModal } from '@/components/IntegrationSettingsModal/IntegrationSettingsModal'
 import { SyncSettingsModal } from '@/components/SyncSettingsModal/SyncSettingsModal'
 import { PassphraseModal } from '@/components/PassphraseModal/PassphraseModal'
+import { HelpModal } from '@/components/HelpModal/HelpModal'
 import { ToastProvider } from '@/components/Toast/Toast'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
@@ -110,6 +111,7 @@ function AppInner() {
   const [showIntegration, setShowIntegration] = useState(false)
   const [showSyncSettings, setShowSyncSettings] = useState(false)
   const [showPassphrase, setShowPassphrase] = useState(false)
+  const [showHelp, setShowHelp] = useState(false)
   const [ribbonKey, setRibbonKey] = useState(0)
   const [heatmapWeeks, setHeatmapWeeks] = useState<HeatDay[][]>([])
   const [waveKey, setWaveKey] = useState(0)
@@ -235,7 +237,7 @@ function AppInner() {
               {editMode ? <><Check size={14} /> Done</> : <><Pencil size={14} /> Edit</>}
             </button>
           </div>
-          {/* Row 2: intents, sync, archive */}
+          {/* Row 2: intents, sync, archive, help */}
           <div className="flex items-center gap-2">
             <button
               onClick={() => setShowIntegration(true)}
@@ -266,6 +268,13 @@ function AppInner() {
               aria-label="Backup & Restore"
             >
               <Archive size={15} />
+            </button>
+            <button
+              onClick={() => setShowHelp(true)}
+              className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors"
+              aria-label="Help & Feedback"
+            >
+              <HelpCircle size={15} />
             </button>
           </div>
         </div>
@@ -318,6 +327,10 @@ function AppInner() {
           engine={engineRef.current}
           onClose={() => setShowSyncSettings(false)}
         />
+      )}
+
+      {showHelp && (
+        <HelpModal onClose={() => setShowHelp(false)} />
       )}
 
       {showPassphrase && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { SyncSettingsModal } from '@/components/SyncSettingsModal/SyncSettingsMo
 import { PassphraseModal } from '@/components/PassphraseModal/PassphraseModal'
 import { HelpModal } from '@/components/HelpModal/HelpModal'
 import { ShortcutsModal } from '@/components/ShortcutsModal/ShortcutsModal'
+import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal'
 import { ToastProvider } from '@/components/Toast/Toast'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
@@ -114,6 +115,7 @@ function AppInner() {
   const [showPassphrase, setShowPassphrase] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
   const [showShortcuts, setShowShortcuts] = useState(false)
+  const [showActivityLog, setShowActivityLog] = useState(false)
   const [ribbonKey, setRibbonKey] = useState(0)
   const [heatmapWeeks, setHeatmapWeeks] = useState<HeatDay[][]>([])
   const [waveKey, setWaveKey] = useState(0)
@@ -188,6 +190,33 @@ function AppInner() {
   function toggleTheme() {
     setIsDark(d => !d)
   }
+
+  // Global keyboard shortcuts (D, E, I, S, A, L, ?)
+  // Uses a ref for the "any modal open" guard so the effect never re-registers.
+  const anyModalOpenRef = useRef(false)
+  anyModalOpenRef.current = (
+    showWelcome || showBackup || showIntegration || showSyncSettings ||
+    showPassphrase || showHelp || showShortcuts || showActivityLog
+  )
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (e.target as HTMLElement).isContentEditable) return
+      if (anyModalOpenRef.current || e.metaKey || e.ctrlKey || e.altKey) return
+      switch (e.key) {
+        case 'd': case 'D': setIsDark(d => !d); break
+        case 'e': case 'E': setEditMode(m => !m); break
+        case 'i': case 'I': setShowIntegration(true); break
+        case 's': case 'S': setShowSyncSettings(true); break
+        case 'a': case 'A': setShowBackup(true); break
+        case 'l': case 'L': setShowActivityLog(true); break
+        case '?':           setShowShortcuts(true); break
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col">
@@ -336,6 +365,10 @@ function AppInner() {
           onClose={() => setShowHelp(false)}
           onOpenShortcuts={() => setShowShortcuts(true)}
         />
+      )}
+
+      {showActivityLog && (
+        <ActivityLogModal onClose={() => setShowActivityLog(false)} />
       )}
 
       {showShortcuts && (

--- a/src/components/ActivityLogModal/ActivityLogModal.tsx
+++ b/src/components/ActivityLogModal/ActivityLogModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { createPortal } from 'react-dom'
-import { X, RefreshCw } from 'lucide-react'
+import { X, RefreshCw, ChevronRight, ChevronDown } from 'lucide-react'
 import { type ActivityEntry, getActivityLog, clearActivityLog } from '@/intents/config'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 
@@ -19,11 +19,20 @@ function badgeClass(type: ActivityEntry['type']): string {
 
 export function ActivityLogModal({ onClose }: Props) {
   const [log, setLog] = useState<ActivityEntry[]>(() => getActivityLog())
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
   useEscapeKey(onClose)
 
   function refresh() { setLog(getActivityLog()) }
-  function clear() { clearActivityLog(); setLog([]) }
+  function clear() { clearActivityLog(); setLog([]); setExpandedIds(new Set()) }
+
+  function toggleExpanded(id: string) {
+    setExpandedIds(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
 
   return createPortal(
     <div
@@ -64,30 +73,44 @@ export function ActivityLogModal({ onClose }: Props) {
             <p className="text-xs text-slate-400 dark:text-slate-500 italic">No activity yet.</p>
           ) : (
             <div className="space-y-1">
-              {log.map(entry => (
-                <div
-                  key={entry.id}
-                  className="flex items-start gap-2 text-xs py-2 border-b border-slate-100 dark:border-slate-700/40 last:border-0"
-                >
-                  <span className="text-slate-400 dark:text-slate-500 tabular-nums shrink-0 pt-0.5">
-                    {new Date(entry.timestamp).toLocaleString([], {
-                      month: 'short', day: 'numeric',
-                      hour: '2-digit', minute: '2-digit',
-                    })}
-                  </span>
-                  <span className={`shrink-0 px-1 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide ${badgeClass(entry.type)}`}>
-                    {entry.type}
-                  </span>
-                  <div className="min-w-0 break-words">
-                    <span className="text-slate-600 dark:text-slate-300">{entry.message}</span>
-                    {entry.detail && (
-                      <p className="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-1 leading-relaxed whitespace-pre-wrap break-all">
+              {log.map(entry => {
+                const expanded = expandedIds.has(entry.id)
+                return (
+                  <div
+                    key={entry.id}
+                    className="text-xs py-2 border-b border-slate-100 dark:border-slate-700/40 last:border-0"
+                  >
+                    <div className="flex items-start gap-2">
+                      <span className="text-slate-400 dark:text-slate-500 tabular-nums shrink-0 pt-0.5">
+                        {new Date(entry.timestamp).toLocaleString([], {
+                          month: 'short', day: 'numeric',
+                          hour: '2-digit', minute: '2-digit',
+                        })}
+                      </span>
+                      <span className={`shrink-0 px-1 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide ${badgeClass(entry.type)}`}>
+                        {entry.type}
+                      </span>
+                      <div className="min-w-0 break-words flex-1">
+                        <span className="text-slate-600 dark:text-slate-300">{entry.message}</span>
+                      </div>
+                      {entry.detail && (
+                        <button
+                          onClick={() => toggleExpanded(entry.id)}
+                          className="shrink-0 text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+                          aria-label={expanded ? 'Collapse details' : 'Expand details'}
+                        >
+                          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                        </button>
+                      )}
+                    </div>
+                    {entry.detail && expanded && (
+                      <p className="text-[10px] font-mono text-slate-400 dark:text-slate-500 mt-1 leading-relaxed whitespace-pre-wrap break-all pl-0">
                         {entry.detail}
                       </p>
                     )}
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           )}
         </div>

--- a/src/components/CategorySection/CategorySection.tsx
+++ b/src/components/CategorySection/CategorySection.tsx
@@ -1,13 +1,13 @@
 import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { Pencil, Trash2, Plus, Smile, GripVertical, ChevronDown, ChevronRight, FolderPlus } from 'lucide-react'
+import { Pencil, Trash2, Plus, Smile, GripVertical, ChevronDown, ChevronRight, ChevronUp, FolderPlus } from 'lucide-react'
 import type { CategoryWithChores } from '@/hooks/useChores'
 import type { Category, ChoreWithLastCompletion } from '@/types'
 import { ChoreRow } from '@/components/ChoreRow/ChoreRow'
 import { ChoreFormModal } from '@/components/ChoreFormModal/ChoreFormModal'
 import { CategoryFormModal } from '@/components/CategoryFormModal/CategoryFormModal'
 import { IconPicker } from '@/components/IconPicker/IconPicker'
-import { deleteCategory, deleteChore, updateCategory, updateChore, reorderChores } from '@/db/queries'
+import { deleteCategory, deleteChore, updateCategory, updateChore, reorderChores, reorderCategories } from '@/db/queries'
 import { ICON_REGISTRY } from '@/icons/registry'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 
@@ -265,11 +265,14 @@ interface SubcategorySectionProps {
   onExternalHover: (categoryId: number | null) => void
   onCrossListDrop: (choreId: number, targetCategoryId: number) => void
   compact?: boolean
+  onMoveUp?: () => void
+  onMoveDown?: () => void
 }
 
 function SubcategorySection({
   data, allCategories, rootCategories, editMode, onChoreTab, onRefresh, onLogged,
   wrapChores, collapsed, onToggleCollapse, isDropTarget, onExternalHover, onCrossListDrop, compact,
+  onMoveUp, onMoveDown,
 }: SubcategorySectionProps) {
   const [catForm, setCatForm] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -320,6 +323,24 @@ function SubcategorySection({
 
         {editMode && (
           <div className="flex items-center gap-1 shrink-0">
+            {onMoveUp && (
+              <button
+                onClick={onMoveUp}
+                className="p-1 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                aria-label="Move subcategory up"
+              >
+                <ChevronUp size={12} />
+              </button>
+            )}
+            {onMoveDown && (
+              <button
+                onClick={onMoveDown}
+                className="p-1 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                aria-label="Move subcategory down"
+              >
+                <ChevronDown size={12} />
+              </button>
+            )}
             <button
               onClick={() => setCatForm(true)}
               className="p-1 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
@@ -547,6 +568,18 @@ export function CategorySection({
             isDropTarget={externalHoverTargetId === sub.category.id}
             onExternalHover={setExternalHoverTargetId}
             onCrossListDrop={handleCrossListDrop}
+            onMoveUp={idx > 0 ? async () => {
+              const ids = data.subcategories.map(s => s.category.id)
+              ;[ids[idx - 1], ids[idx]] = [ids[idx], ids[idx - 1]]
+              await reorderCategories(ids)
+              onRefresh()
+            } : undefined}
+            onMoveDown={idx < data.subcategories.length - 1 ? async () => {
+              const ids = data.subcategories.map(s => s.category.id)
+              ;[ids[idx], ids[idx + 1]] = [ids[idx + 1], ids[idx]]
+              await reorderCategories(ids)
+              onRefresh()
+            } : undefined}
           />
         ))}
       </div>

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -13,7 +13,7 @@ function ExternalLinkRow({ href, label }: { href: string; label: string }) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex items-center gap-2 text-sm text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300 transition-colors"
+      className="flex items-center gap-2 text-sm text-green-400 hover:text-green-300 transition-colors"
     >
       <ExternalLink size={14} className="shrink-0" />
       {label}
@@ -52,7 +52,7 @@ export function HelpModal({ onClose }: Props) {
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
         {/* Header */}
         <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-700/40">
-          <HelpCircle size={20} className="text-blue-500 dark:text-blue-400 shrink-0" />
+          <HelpCircle size={20} className="text-slate-400 dark:text-slate-500 shrink-0" />
           <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 flex-1">
             Help &amp; Feedback
           </h2>

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -52,7 +52,7 @@ export function HelpModal({ onClose }: Props) {
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
         {/* Header */}
         <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-700/40">
-          <HelpCircle size={20} className="text-slate-400 dark:text-slate-500 shrink-0" />
+          <HelpCircle size={20} className="text-green-400 shrink-0" />
           <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 flex-1">
             Help &amp; Feedback
           </h2>

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -1,0 +1,95 @@
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { X, HelpCircle, ExternalLink } from 'lucide-react'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
+
+interface Props {
+  onClose: () => void
+}
+
+function ExternalLinkRow({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-2 text-sm text-blue-500 dark:text-blue-400 hover:text-blue-600 dark:hover:text-blue-300 transition-colors"
+    >
+      <ExternalLink size={14} className="shrink-0" />
+      {label}
+    </a>
+  )
+}
+
+export function HelpModal({ onClose }: Props) {
+  const [storage, setStorage] = useState<{ used: number; quota: number } | null>(null)
+
+  useEscapeKey(onClose)
+
+  useEffect(() => {
+    navigator.storage?.estimate().then(est => {
+      if (est.usage != null && est.quota != null) {
+        setStorage({ used: est.usage, quota: est.quota })
+      }
+    }).catch(() => {})
+  }, [])
+
+  function fmtBytes(n: number): string {
+    if (n < 1024) return `${n} B`
+    if (n < 1024 * 1024) return `${Math.round(n / 1024)} KB`
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  const buildDate = new Date(__BUILD_TIME__).toLocaleString(undefined, {
+    dateStyle: 'medium', timeStyle: 'short',
+  })
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-700/40">
+          <HelpCircle size={20} className="text-blue-500 dark:text-blue-400 shrink-0" />
+          <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 flex-1">
+            Help &amp; Feedback
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-5">
+          {/* Contact & Issues */}
+          <div className="space-y-2.5">
+            <p className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider">
+              Contact &amp; Issues
+            </p>
+            <ExternalLinkRow href="mailto:support@glance-apps.com" label="support@glance-apps.com" />
+            <ExternalLinkRow href="https://github.com/krelltunez/lastGLANCE/issues" label="Report an issue on GitHub" />
+          </div>
+
+          <div className="border-t border-slate-100 dark:border-slate-700/40" />
+
+          {/* Build info */}
+          <div className="space-y-1">
+            {storage && (
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                Storage: {fmtBytes(storage.used)} / ~{fmtBytes(storage.quota)}
+              </p>
+            )}
+            <p className="text-xs text-slate-400 dark:text-slate-500">
+              v{__APP_VERSION__} · {buildDate}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -5,6 +5,7 @@ import { useEscapeKey } from '@/hooks/useEscapeKey'
 
 interface Props {
   onClose: () => void
+  onOpenShortcuts: () => void
 }
 
 function ExternalLinkRow({ href, label }: { href: string; label: string }) {
@@ -21,7 +22,7 @@ function ExternalLinkRow({ href, label }: { href: string; label: string }) {
   )
 }
 
-export function HelpModal({ onClose }: Props) {
+export function HelpModal({ onClose, onOpenShortcuts }: Props) {
   const [storage, setStorage] = useState<{ used: number; quota: number } | null>(null)
 
   useEscapeKey(onClose)
@@ -76,16 +77,25 @@ export function HelpModal({ onClose }: Props) {
 
           <div className="border-t border-slate-100 dark:border-slate-700/40" />
 
-          {/* Build info */}
-          <div className="space-y-1">
-            {storage && (
+          {/* Build info + shortcuts button */}
+          <div className="flex items-end justify-between gap-4">
+            <div className="space-y-1">
+              {storage && (
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  Storage: {fmtBytes(storage.used)} / ~{fmtBytes(storage.quota)}
+                </p>
+              )}
               <p className="text-xs text-slate-400 dark:text-slate-500">
-                Storage: {fmtBytes(storage.used)} / ~{fmtBytes(storage.quota)}
+                v{__APP_VERSION__} · {buildDate}
               </p>
-            )}
-            <p className="text-xs text-slate-400 dark:text-slate-500">
-              v{__APP_VERSION__} · {buildDate}
-            </p>
+            </div>
+            <button
+              onClick={() => { onClose(); onOpenShortcuts() }}
+              className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+            >
+              <kbd className="inline-flex items-center justify-center w-4 h-4 rounded bg-slate-300 dark:bg-slate-500 text-[10px] font-mono text-slate-600 dark:text-slate-200 leading-none">?</kbd>
+              <span className="text-xs text-slate-500 dark:text-slate-400">shortcuts</span>
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/LogModal/LogModal.tsx
+++ b/src/components/LogModal/LogModal.tsx
@@ -69,7 +69,7 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
         w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700/50 shadow-2xl
         rounded-t-2xl max-h-[90svh] overflow-hidden flex flex-col
         sm:rounded-2xl sm:max-w-xl
-        lg:max-w-5xl lg:max-h-[85svh] lg:flex-row lg:items-start
+        lg:max-w-5xl lg:max-h-[85svh] lg:flex-row
       ">
 
         {/* ── Left / top: log form ── */}
@@ -133,7 +133,7 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
             <StatCell label="Target" value={chore.target_cadence_days ? `${chore.target_cadence_days}d` : '—'} />
           </div>
 
-          <div className="flex-1 overflow-y-auto">
+          <div className="flex-1 min-h-0 overflow-y-auto">
             <div className="px-5 pt-4 pb-3">
               <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500 mb-3">Past year</p>
               <div ref={heatmapRef} className="overflow-x-auto scrollbar-none">

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -5,8 +5,9 @@ import { reorderCategories } from '@/db/queries'
 import { CategorySection } from '@/components/CategorySection/CategorySection'
 import { LogModal } from '@/components/LogModal/LogModal'
 import { CategoryFormModal } from '@/components/CategoryFormModal/CategoryFormModal'
+import { ChoreFormModal } from '@/components/ChoreFormModal/ChoreFormModal'
 import { SearchModal } from '@/components/SearchModal/SearchModal'
-import type { ChoreWithLastCompletion } from '@/types'
+import type { Category, ChoreWithLastCompletion } from '@/types'
 import type { CategoryWithChores } from '@/hooks/useChores'
 
 interface Props {
@@ -62,6 +63,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const [activeCategoryIndex, setActiveCategoryIndex] = useState(0)
   const [selectedChore, setSelectedChore] = useState<ChoreWithLastCompletion | null>(null)
   const [addingCategory, setAddingCategory] = useState(false)
+  const [newChoreCategory, setNewChoreCategory] = useState<Category | null>(null)
 
   // Category drag
   const [showSearch, setShowSearch] = useState(false)
@@ -116,20 +118,43 @@ export function Ribbon({ editMode, onLogged }: Props) {
     return () => window.removeEventListener('lg:open-chore', handleOpenChore)
   }, [])
 
-  // Keyboard shortcut: Cmd/Ctrl+K or / opens search
+  // Stable refs so shortcut handlers don't need to re-register on state changes
+  const activeCategoryIndexRef = useRef(0)
+  activeCategoryIndexRef.current = activeCategoryIndex
+  const ribbonModalOpenRef = useRef(false)
+  ribbonModalOpenRef.current = showSearch || selectedChore !== null || addingCategory || newChoreCategory !== null
+
+  // Keyboard shortcuts owned by Ribbon: search, category nav, new chore
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (showSearch) return
       const tag = (e.target as HTMLElement).tagName
-      const editable = tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable
-      if ((e.key === 'k' && (e.metaKey || e.ctrlKey)) || (e.key === '/' && !editable)) {
+      const editable = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (e.target as HTMLElement).isContentEditable
+
+      // Search: ⌘K or / (when not in an input)
+      if ((e.key === 'k' && (e.metaKey || e.ctrlKey)) || (e.key === '/' && !editable && !ribbonModalOpenRef.current)) {
         e.preventDefault()
         setShowSearch(true)
+        return
+      }
+
+      if (editable || ribbonModalOpenRef.current || e.metaKey || e.ctrlKey || e.altKey) return
+
+      // Category navigation: mobile layout only
+      if (e.key === 'ArrowLeft' && window.innerWidth < 1060) {
+        e.preventDefault()
+        setActiveCategoryIndex(i => Math.max(0, i - 1))
+      } else if (e.key === 'ArrowRight' && window.innerWidth < 1060) {
+        e.preventDefault()
+        setActiveCategoryIndex(i => Math.min(localDataRef.current.length - 1, i + 1))
+      } else if (e.key === 'n' || e.key === 'N') {
+        const cat = localDataRef.current[activeCategoryIndexRef.current]?.category
+        if (cat) setNewChoreCategory(cat)
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [showSearch])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Sync localData from server when not dragging categories
   useEffect(() => {
@@ -550,6 +575,15 @@ export function Ribbon({ editMode, onLogged }: Props) {
         <CategoryFormModal
           onClose={() => setAddingCategory(false)}
           onSaved={() => { setAddingCategory(false); refresh() }}
+        />
+      )}
+
+      {newChoreCategory && (
+        <ChoreFormModal
+          category={newChoreCategory}
+          allCategories={localData.flatMap(d => [d.category, ...d.subcategories.map(s => s.category)])}
+          onClose={() => setNewChoreCategory(null)}
+          onSaved={() => { setNewChoreCategory(null); refresh() }}
         />
       )}
     </>

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -533,34 +533,32 @@ export function Ribbon({ editMode, onLogged }: Props) {
                   </div>
                 )
               })}
-            </div>
-
-            {editMode && (() => {
-              const pos = positions.get(ADD_CAT_ID)
-              return (
-                <div
-                  data-cat-card-id={ADD_CAT_ID}
-                  className="absolute rounded-2xl border border-dashed border-slate-300 dark:border-slate-700/60"
-                  style={{
-                    top: 0,
-                    left: 0,
-                    width: cardWidth > 0 ? cardWidth : undefined,
-                    transform: pos ? `translate(${pos.x}px,${pos.y}px)` : undefined,
-                    visibility: packPhase >= 1 && pos ? 'visible' : 'hidden',
-                    transition: packPhase >= 2 && draggingCatId === null ? 'transform 300ms ease' : 'none',
-                    willChange: 'transform',
-                  }}
-                >
-                  <button
-                    onClick={() => setAddingCategory(true)}
-                    className="w-full h-full flex items-center justify-center gap-2 p-5 py-8 text-sm text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 rounded-2xl hover:bg-slate-50 dark:hover:bg-slate-800/30 transition-colors"
+              {editMode && (() => {
+                const pos = positions.get(ADD_CAT_ID)
+                return (
+                  <div
+                    data-cat-card-id={ADD_CAT_ID}
+                    className="absolute rounded-2xl border border-dashed border-slate-300 dark:border-slate-700/60"
+                    style={{
+                      top: 0,
+                      left: 0,
+                      width: cardWidth > 0 ? cardWidth : undefined,
+                      transform: pos ? `translate(${pos.x}px,${pos.y}px)` : undefined,
+                      visibility: packPhase >= 1 && pos ? 'visible' : 'hidden',
+                      transition: packPhase >= 2 && draggingCatId === null ? 'transform 300ms ease' : 'none',
+                      willChange: 'transform',
+                    }}
                   >
-                    <Plus size={15} />
-                    Add category
-                  </button>
-                </div>
-              )
-            })()}
+                    <button
+                      onClick={() => setAddingCategory(true)}
+                      className="w-full h-full flex items-center justify-center gap-2 p-5 py-8 text-sm text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 rounded-2xl hover:bg-slate-50 dark:hover:bg-slate-800/30 transition-colors"
+                    >
+                      <Plus size={15} />
+                      Add category
+                    </button>
+                  </div>
+                )
+              })()}
           </div>
         )}
       </div>

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -148,7 +148,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
         setActiveCategoryIndex(i => Math.min(localDataRef.current.length - 1, i + 1))
       } else if (e.key === 'n' || e.key === 'N') {
         const cat = localDataRef.current[activeCategoryIndexRef.current]?.category
-        if (cat) setNewChoreCategory(cat)
+        if (cat) { e.preventDefault(); setNewChoreCategory(cat) }
       }
     }
     window.addEventListener('keydown', onKey)

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -265,7 +265,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
   // ADD_CAT_ID is included when editMode is on so the ghost card is measured.
   const sortedCatIdsKey = [
     ...localData.map(d => d.category.id),
-    ...(editMode && !showEmpty ? [ADD_CAT_ID] : []),
+    ...(editMode && localData.length > 0 ? [ADD_CAT_ID] : []),
   ].sort((a, b) => a - b).join(',')
   useEffect(() => {
     const grid = desktopGridRef.current

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -57,6 +57,8 @@ function packMasonry(
   return { positions, containerHeight: maxH > gap ? maxH - gap : maxH }
 }
 
+const ADD_CAT_ID = -1
+
 export function Ribbon({ editMode, onLogged }: Props) {
   const { data, loading, refresh } = useChores()
   const [localData, setLocalData] = useState<CategoryWithChores[]>([])
@@ -259,8 +261,12 @@ export function Ribbon({ editMode, onLogged }: Props) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [localData.length])
 
-  // Card ResizeObservers — re-created only when the set of category IDs changes (add/remove, not reorder)
-  const sortedCatIdsKey = localData.map(d => d.category.id).sort((a, b) => a - b).join(',')
+  // Card ResizeObservers — re-created only when the set of category IDs changes (add/remove, not reorder).
+  // ADD_CAT_ID is included when editMode is on so the ghost card is measured.
+  const sortedCatIdsKey = [
+    ...localData.map(d => d.category.id),
+    ...(editMode && !showEmpty ? [ADD_CAT_ID] : []),
+  ].sort((a, b) => a - b).join(',')
   useEffect(() => {
     const grid = desktopGridRef.current
     if (!grid) return
@@ -389,8 +395,11 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const cardWidth = colCount > 0 && containerWidth > 0
     ? (containerWidth - MASONRY_GAP * (colCount - 1)) / colCount
     : 0
+  const packIds = editMode && !showEmpty
+    ? [...localData.map(d => d.category.id), ADD_CAT_ID]
+    : localData.map(d => d.category.id)
   const { positions, containerHeight } = packMasonry(
-    localData.map(d => d.category.id),
+    packIds,
     colCount,
     cardHeightsRef.current,
     cardWidth,
@@ -431,6 +440,15 @@ export function Ribbon({ editMode, onLogged }: Props) {
                 {d.category.name}
               </button>
             ))}
+            {editMode && (
+              <button
+                onClick={() => setAddingCategory(true)}
+                className="shrink-0 flex items-center px-3 py-2.5 text-slate-400 dark:text-slate-500 hover:text-green-400 transition-colors border-l border-slate-200 dark:border-slate-700/60"
+                aria-label="Add category"
+              >
+                <Plus size={13} />
+              </button>
+            )}
           </div>
         )}
 
@@ -470,17 +488,6 @@ export function Ribbon({ editMode, onLogged }: Props) {
           </div>
         )}
 
-        {editMode && !showEmpty && (
-          <div className="shrink-0 border-t border-slate-200 dark:border-slate-700/60 p-3">
-            <button
-              onClick={() => setAddingCategory(true)}
-              className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/40 border border-slate-200 dark:border-slate-700/60 transition-colors"
-            >
-              <Plus size={15} />
-              Add category
-            </button>
-          </div>
-        )}
       </div>
 
       {/* ── Desktop: true masonry layout ── */}
@@ -528,17 +535,32 @@ export function Ribbon({ editMode, onLogged }: Props) {
               })}
             </div>
 
-            {editMode && (
-              <div className="mt-5">
-                <button
-                  onClick={() => setAddingCategory(true)}
-                  className="w-full flex items-center justify-center gap-2 py-4 rounded-2xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/30 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors"
+            {editMode && (() => {
+              const pos = positions.get(ADD_CAT_ID)
+              return (
+                <div
+                  data-cat-card-id={ADD_CAT_ID}
+                  className="absolute rounded-2xl border border-dashed border-slate-300 dark:border-slate-700/60"
+                  style={{
+                    top: 0,
+                    left: 0,
+                    width: cardWidth > 0 ? cardWidth : undefined,
+                    transform: pos ? `translate(${pos.x}px,${pos.y}px)` : undefined,
+                    visibility: packPhase >= 1 && pos ? 'visible' : 'hidden',
+                    transition: packPhase >= 2 && draggingCatId === null ? 'transform 300ms ease' : 'none',
+                    willChange: 'transform',
+                  }}
                 >
-                  <Plus size={15} />
-                  Add category
-                </button>
-              </div>
-            )}
+                  <button
+                    onClick={() => setAddingCategory(true)}
+                    className="w-full h-full flex items-center justify-center gap-2 p-5 py-8 text-sm text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 rounded-2xl hover:bg-slate-50 dark:hover:bg-slate-800/30 transition-colors"
+                  >
+                    <Plus size={15} />
+                    Add category
+                  </button>
+                </div>
+              )
+            })()}
           </div>
         )}
       </div>

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -446,7 +446,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
         )}
 
         {editMode && !showEmpty && (
-          <div className="shrink-0 border-t border-slate-200 dark:border-slate-700/60 p-3 flex flex-col gap-2">
+          <div className="shrink-0 border-t border-slate-200 dark:border-slate-700/60 p-3">
             <button
               onClick={() => setAddingCategory(true)}
               className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/40 border border-slate-200 dark:border-slate-700/60 transition-colors"
@@ -454,7 +454,6 @@ export function Ribbon({ editMode, onLogged }: Props) {
               <Plus size={15} />
               Add category
             </button>
-            <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__} · built {new Date(__BUILD_TIME__).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}</p>
           </div>
         )}
       </div>
@@ -505,7 +504,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
             </div>
 
             {editMode && (
-              <div className="mt-5 flex flex-col gap-2">
+              <div className="mt-5">
                 <button
                   onClick={() => setAddingCategory(true)}
                   className="w-full flex items-center justify-center gap-2 py-4 rounded-2xl text-sm text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700/30 border border-dashed border-slate-300 dark:border-slate-700/60 hover:border-slate-400 dark:hover:border-slate-600 transition-colors"
@@ -513,7 +512,6 @@ export function Ribbon({ editMode, onLogged }: Props) {
                   <Plus size={15} />
                   Add category
                 </button>
-                <p className="text-center text-xs text-slate-400 dark:text-slate-600">v{__APP_VERSION__} · built {new Date(__BUILD_TIME__).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}</p>
               </div>
             )}
           </div>

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -537,6 +537,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
                 const pos = positions.get(ADD_CAT_ID)
                 return (
                   <div
+                    key="add-category"
                     data-cat-card-id={ADD_CAT_ID}
                     className="absolute rounded-2xl border border-dashed border-slate-300 dark:border-slate-700/60"
                     style={{
@@ -559,6 +560,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
                   </div>
                 )
               })()}
+            </div>
           </div>
         )}
       </div>

--- a/src/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal/ShortcutsModal.tsx
@@ -66,7 +66,9 @@ export function ShortcutsModal({ onClose }: Props) {
             </p>
             <div className="divide-y divide-slate-100 dark:divide-slate-700/40">
               <ShortcutRow keys={['⌘K', '/']} label="Search" />
-              <ShortcutRow keys={['←', '→']} label="Navigate categories" />
+              <div className="min-[1060px]:hidden">
+                <ShortcutRow keys={['←', '→']} label="Navigate categories" />
+              </div>
             </div>
           </div>
 

--- a/src/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal/ShortcutsModal.tsx
@@ -1,0 +1,113 @@
+import { createPortal } from 'react-dom'
+import { X, Keyboard } from 'lucide-react'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
+
+interface Props {
+  onClose: () => void
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-700 border border-slate-300 dark:border-slate-600 text-[11px] font-mono text-slate-600 dark:text-slate-300 leading-none">
+      {children}
+    </kbd>
+  )
+}
+
+interface ShortcutRowProps {
+  keys: React.ReactNode[]
+  label: string
+}
+
+function ShortcutRow({ keys, label }: ShortcutRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-1.5">
+      <span className="text-sm text-slate-600 dark:text-slate-300">{label}</span>
+      <div className="flex items-center gap-1 shrink-0">
+        {keys.map((k, i) => (
+          <span key={i} className="flex items-center gap-1">
+            {i > 0 && <span className="text-slate-400 dark:text-slate-500 text-xs">or</span>}
+            <Kbd>{k}</Kbd>
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function ShortcutsModal({ onClose }: Props) {
+  useEscapeKey(onClose)
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      onClick={e => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-700/40">
+          <Keyboard size={18} className="text-green-400 shrink-0" />
+          <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 flex-1">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          {/* Navigation */}
+          <div>
+            <p className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">
+              Navigation
+            </p>
+            <div className="divide-y divide-slate-100 dark:divide-slate-700/40">
+              <ShortcutRow keys={['⌘K', '/']} label="Search" />
+              <ShortcutRow keys={['←', '→']} label="Navigate categories" />
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div>
+            <p className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">
+              Actions
+            </p>
+            <div className="divide-y divide-slate-100 dark:divide-slate-700/40">
+              <ShortcutRow keys={['N']} label="New chore" />
+              <ShortcutRow keys={['E']} label="Toggle edit mode" />
+              <ShortcutRow keys={['D']} label="Toggle dark mode" />
+            </div>
+          </div>
+
+          {/* Panels */}
+          <div>
+            <p className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">
+              Panels
+            </p>
+            <div className="divide-y divide-slate-100 dark:divide-slate-700/40">
+              <ShortcutRow keys={['I']} label="Integration settings" />
+              <ShortcutRow keys={['S']} label="Sync settings" />
+              <ShortcutRow keys={['A']} label="Backup &amp; Restore" />
+              <ShortcutRow keys={['L']} label="Activity log" />
+              <ShortcutRow keys={['?']} label="Keyboard shortcuts" />
+            </div>
+          </div>
+
+          {/* General */}
+          <div>
+            <p className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">
+              General
+            </p>
+            <div className="divide-y divide-slate-100 dark:divide-slate-700/40">
+              <ShortcutRow keys={['Esc']} label="Close modal" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,18 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
 
+// crypto.randomUUID() is only available in secure contexts (HTTPS / localhost).
+// This polyfill covers HTTP access over a LAN IP (e.g. self-hosted Docker).
+if (typeof crypto.randomUUID !== 'function') {
+  crypto.randomUUID = () => {
+    const b = crypto.getRandomValues(new Uint8Array(16))
+    b[6] = (b[6] & 0x0f) | 0x40
+    b[8] = (b[8] & 0x3f) | 0x80
+    return [b.slice(0, 4), b.slice(4, 6), b.slice(6, 8), b.slice(8, 10), b.slice(10, 16)]
+      .map(s => Array.from(s).map(x => x.toString(16).padStart(2, '0')).join('')).join('-') as `${string}-${string}-${string}-${string}-${string}`
+  }
+}
+
 // Apply theme before React renders to avoid flash
 const saved = localStorage.getItem('theme')
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches


### PR DESCRIPTION
## Summary

- **Activity log**: entries with details now collapse by default; a chevron toggles the detail block per-entry
- **Subcategory reordering**: up/down caret buttons in Edit mode reorder siblings via `sort_order`
- **Help & Feedback modal**: `?` button in header opens a modal with contact links, storage usage, and build info (replaces the version footer in Edit mode)
- **Shortcuts modal**: full keyboard shortcut reference, accessible via `? shortcuts` in the Help modal; all shortcuts implemented (`D`, `E`, `I`, `S`, `A`, `L`, `?`, `N`, `←/→`)
- **Add category placement**: replaced sticky bottom bar (mobile) and full-width footer button (desktop) — mobile gets a `+` at the end of the tab strip; desktop gets a ghost card that participates in the masonry layout
- **History scrolling fix**: removed `lg:items-start` and added `min-h-0` to the inner scroll div in `LogModal` so the history list actually scrolls on desktop
- **`crypto.randomUUID` polyfill**: fixes silent failures on HTTP LAN access (self-hosted Docker); `getRandomValues`-based fallback added to `main.tsx`
- **nginx `sw.js` caching fix**: dedicated `location = /sw.js` block with `no-cache` headers prevents the 1-year immutable rule from blocking service worker updates

## Test plan

- [ ] Open activity log — entries with details show collapsed; chevron expands/collapses
- [ ] Edit mode — subcategories show ▲/▼ buttons; reordering persists after refresh
- [ ] `?` button opens Help modal with green icon and green links; `? shortcuts` button opens Shortcuts modal
- [ ] All keyboard shortcuts fire correctly; `N` opens chore form without pre-typed letter; `←/→` navigates categories on mobile only
- [ ] Edit mode on desktop — Add category ghost card appears in masonry grid in correct position
- [ ] Edit mode on mobile — `+` tab appears at end of tab strip
- [ ] Chore detail modal — history list scrolls on desktop with many entries
- [ ] Access app over HTTP on LAN IP — creating categories/chores/completions works without errors
- [ ] Docker deployment — service worker updates are picked up after redeploy

https://claude.ai/code/session_01MYEnz4WUmg4P37r4hUr2rH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYEnz4WUmg4P37r4hUr2rH)_