### PR TITLE
v1.1.1 — masonry drag fix, persistent storage prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **when did you last...?**
 
-![Version](https://img.shields.io/badge/version-1.1.0-green) ![License](https://img.shields.io/badge/license-MIT-blue)
+![Version](https://img.shields.io/badge/version-1.1.1-green) ![License](https://img.shields.io/badge/license-MIT-blue)
 
 ![lastGLANCE dashboard](public/screenshot.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",
         "@glance-apps/sync": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Masonry drag fix**: category drag now uses insert (splice) instead of swap, so individual categories can be moved between columns without reshuffling the entire layout
- **Persistent storage**: silent `navigator.storage.persist()` call on app startup; Help modal checks `persisted()` on open and shows an amber notice with an "Allow persistent storage" button if not yet granted — disappears once granted
- **Version bump**: `package.json`, `package-lock.json`, and `README` updated to v1.1.1

## Test plan

- [ ] Desktop masonry: drag a single category to a different column and confirm only that card moves
- [ ] Open Help modal in a browser where storage is not yet persistent — amber notice appears with button
- [ ] Click "Allow persistent storage" — notice disappears and does not reappear on next open
- [ ] Confirm `package.json` version reads `1.1.1`

https://claude.ai/code/session_017QWWH9g3YMc9r49dj1rPQN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017QWWH9g3YMc9r49dj1rPQN)_