### PR TITLE
Fix subcategory changes not syncing across instances

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -99,6 +99,25 @@ class LastGlanceDB extends Dexie {
         })
       )
 
+    // Re-derives category_sync_id from category_id for all chores, fixing cases
+    // where updateChore was called with a new category_id but category_sync_id
+    // was not updated alongside it.
+    this.version(7)
+      .stores({})
+      .upgrade(async tx => {
+        const categories = await tx.table('categories').toArray()
+        const catSyncIdMap = new Map<number, string>(
+          categories.map((c: Category) => [c.id as number, c.sync_id as string])
+        )
+        const chores = await tx.table('chores').toArray()
+        for (const chore of chores) {
+          const category_sync_id = chore.category_id != null
+            ? (catSyncIdMap.get(chore.category_id as number) ?? null)
+            : null
+          await tx.table('chores').update(chore.id as number, { category_sync_id })
+        }
+      })
+
     this.on('populate', async () => {
       const catIds = (await this.categories.bulkAdd(
         SEED_CATEGORIES.map((cat) => ({

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -165,7 +165,12 @@ export async function updateChore(
   id: number,
   data: Partial<Omit<Chore, 'id' | 'created_at' | 'updated_at'>> & { icon?: string }
 ): Promise<void> {
-  await db.chores.update(id, { ...data, updated_at: dayjs().toISOString() })
+  let extra: { category_sync_id?: string | null } = {}
+  if (data.category_id != null) {
+    const cat = await db.categories.get(data.category_id)
+    extra = { category_sync_id: cat?.sync_id ?? null }
+  }
+  await db.chores.update(id, { ...data, ...extra, updated_at: dayjs().toISOString() })
 }
 
 export async function deleteChore(id: number): Promise<void> {


### PR DESCRIPTION
## Summary

- `updateChore` was saving the new `category_id` but never updating `category_sync_id`, so subcategory changes were invisible to the sync payload
- Added a DB v7 migration to backfill `category_sync_id` from `category_id` for all existing chores, repairing any that were already affected

## Test plan

- [ ] Change a chore's subcategory, trigger a sync, and confirm the change appears on a second instance
- [ ] Verify the v7 migration runs cleanly on an existing DB (check DevTools → IndexedDB that `category_sync_id` matches the chore's current category)
- [ ] Confirm chores created fresh after this change still sync subcategory correctly

https://claude.ai/code/session_01TxGqiKuABStXeVC17FZXBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxGqiKuABStXeVC17FZXBD)_