### PR TITLE
chore: bump version to v1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.1.2-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.1.3-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",
         "@glance-apps/sync": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps `package.json` version from 1.1.2 → 1.1.3, updates the lockfile, and updates the README version badge to match.

This accompanies the v1.1.3 release, which reverts the broken intents dedup changes from v1.1.2 (PR #69). The subcategory sync fix (PR #68) remains.

https://claude.ai/code/session_01U85HwJpzUSik4CVyxxQUSk

---
_Generated by [Claude Code](https://claude.ai/code/session_01U85HwJpzUSik4CVyxxQUSk)_