### PR TITLE
v1.1.4 — Security patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.1.3-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.1.4-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "dependencies": {
         "@glance-apps/intents": "^1.3.0",
         "@glance-apps/sync": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,7 +156,7 @@ function AppInner() {
     ensureSyncFolder(engine).then(() => engine.sync()).catch(() => {/* errors surfaced via onError */})
   }, [])
 
-  // Re-sync on tab focus
+  // Re-sync on tab focus and on a recurring interval
   useEffect(() => {
     function handleVisibility() {
       if (document.visibilityState === 'visible' && engineRef.current) {
@@ -165,7 +165,18 @@ function AppInner() {
       }
     }
     document.addEventListener('visibilitychange', handleVisibility)
-    return () => document.removeEventListener('visibilitychange', handleVisibility)
+
+    const interval = setInterval(() => {
+      if (engineRef.current) {
+        const eng = engineRef.current
+        ensureSyncFolder(eng).then(() => eng.sync()).catch(() => {/* errors surfaced via onError */})
+      }
+    }, 5 * 60 * 1000)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility)
+      clearInterval(interval)
+    }
   }, [])
 
   const loadHeatmap = useCallback(async () => {

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -205,6 +205,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
                 autoComplete="current-password"
                 className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
               />
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">Stored in browser localStorage — keep your device secure.</p>
             </div>
 
             {/* Folder path */}

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -269,6 +269,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
                 autoComplete="current-password"
                 className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
               />
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">Stored in browser localStorage — keep your device secure.</p>
             </div>
 
             <div className="flex items-center gap-3 pt-1">

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -246,7 +246,34 @@ export async function exportBackup(): Promise<BackupPayload> {
   return { version: 1, exportedAt: new Date().toISOString(), categories, chores, completionEvents }
 }
 
+function validateBackupPayload(payload: BackupPayload): void {
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  const isoRe = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+  const mmddRe = /^\d{2}-\d{2}$/
+  for (const c of payload.categories) {
+    if (typeof c.name !== 'string' || c.name.length === 0 || c.name.length > 500) throw new Error('invalid category name')
+    if (typeof c.sort_order !== 'number') throw new Error('invalid category sort_order')
+    if (c.sync_id !== undefined && !uuidRe.test(c.sync_id)) throw new Error('invalid category sync_id')
+    if (c.updated_at !== undefined && !isoRe.test(c.updated_at)) throw new Error('invalid category updated_at')
+  }
+  for (const c of payload.chores) {
+    if (typeof c.name !== 'string' || c.name.length === 0 || c.name.length > 500) throw new Error('invalid chore name')
+    if (typeof c.sort_order !== 'number') throw new Error('invalid chore sort_order')
+    if (c.sync_id !== undefined && !uuidRe.test(c.sync_id)) throw new Error('invalid chore sync_id')
+    if (!isoRe.test(c.created_at)) throw new Error('invalid chore created_at')
+    if (!isoRe.test(c.updated_at)) throw new Error('invalid chore updated_at')
+    if (c.seasonal_start !== null && c.seasonal_start !== undefined && !mmddRe.test(c.seasonal_start)) throw new Error('invalid chore seasonal_start')
+    if (c.seasonal_end !== null && c.seasonal_end !== undefined && !mmddRe.test(c.seasonal_end)) throw new Error('invalid chore seasonal_end')
+  }
+  for (const e of payload.completionEvents) {
+    if (e.sync_id !== undefined && !uuidRe.test(e.sync_id)) throw new Error('invalid completionEvent sync_id')
+    if (!isoRe.test(e.completed_at)) throw new Error('invalid completionEvent completed_at')
+    if (e.source !== 'manual' && e.source !== 'dayglance') throw new Error('invalid completionEvent source')
+  }
+}
+
 export async function importBackup(payload: BackupPayload): Promise<void> {
+  validateBackupPayload(payload)
   await db.transaction('rw', db.categories, db.chores, db.completionEvents, db.tombstones, async () => {
     await db.completionEvents.clear()
     await db.chores.clear()

--- a/src/hooks/useIntentsPoller.ts
+++ b/src/hooks/useIntentsPoller.ts
@@ -140,7 +140,7 @@ export function useIntentsPoller(onNewCompletion?: () => void): void {
       if (!chore) return
 
       await logCompletion(choreId, {
-        completedAt: payload.completed_at ?? dayjs().toISOString(),
+        completedAt: dayjs(payload.completed_at).isValid() ? payload.completed_at : dayjs().toISOString(),
         source: 'dayglance',
       })
 

--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -65,11 +65,10 @@ export async function listFiles(baseUrl: string, folderPath: string, authHeader:
     if (res.status === 404) return []
     if (!res.ok) return []
     const text = await res.text()
+    const doc = new DOMParser().parseFromString(text, 'application/xml')
     const filenames: string[] = []
-    const hrefRe = /<[^>]*:href[^>]*>([^<]*)<\/[^>]*:href>/gi
-    let match: RegExpExecArray | null
-    while ((match = hrefRe.exec(text)) !== null) {
-      const href = decodeURIComponent(match[1].trim())
+    for (const el of Array.from(doc.getElementsByTagNameNS('DAV:', 'href'))) {
+      const href = decodeURIComponent((el.textContent ?? '').trim())
       const filename = href.split('/').pop() ?? ''
       if (filename.endsWith('.json')) {
         filenames.push(filename)

--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -47,7 +47,6 @@ export async function putFile(baseUrl: string, folderPath: string, filename: str
   }
 }
 
-const HREF_RE = /<[^>]*:href[^>]*>([^<]*)<\/[^>]*:href>/gi
 
 const PROPFIND_BODY = '<?xml version="1.0" encoding="utf-8"?><propfind xmlns="DAV:"><allprop/></propfind>'
 
@@ -67,9 +66,9 @@ export async function listFiles(baseUrl: string, folderPath: string, authHeader:
     if (!res.ok) return []
     const text = await res.text()
     const filenames: string[] = []
+    const hrefRe = /<[^>]*:href[^>]*>([^<]*)<\/[^>]*:href>/gi
     let match: RegExpExecArray | null
-    HREF_RE.lastIndex = 0
-    while ((match = HREF_RE.exec(text)) !== null) {
+    while ((match = hrefRe.exec(text)) !== null) {
       const href = decodeURIComponent(match[1].trim())
       const filename = href.split('/').pop() ?? ''
       if (filename.endsWith('.json')) {

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -245,12 +245,12 @@ export function setRemoteBackupsEnabled(enabled: boolean): void {
   localStorage.setItem(REMOTE_BACKUPS_ENABLED_KEY, String(enabled))
 }
 
-let _backupInProgress = false
+const _backupInProgress = new WeakSet<SyncEngine>()
 
 export async function runAutoBackups(engine: SyncEngine): Promise<void> {
   if (!getRemoteBackupsEnabled()) return
-  if (_backupInProgress) return
-  _backupInProgress = true
+  if (_backupInProgress.has(engine)) return
+  _backupInProgress.add(engine)
   try {
     const now = Date.now()
     for (const freq of ['hourly', 'daily', 'weekly'] as BackupFrequency[]) {
@@ -265,7 +265,7 @@ export async function runAutoBackups(engine: SyncEngine): Promise<void> {
       }
     }
   } finally {
-    _backupInProgress = false
+    _backupInProgress.delete(engine)
   }
 }
 

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -96,10 +96,42 @@ export const mergePayloads = (
   }
 }
 
+function validateSyncPayload(data: SyncPayload): void {
+  const uuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  const isoRe = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+  const mmddRe = /^\d{2}-\d{2}$/
+  for (const c of (data.categories ?? [])) {
+    if (!uuidRe.test(c.id)) throw new Error('invalid category id')
+    if (typeof c.name !== 'string' || c.name.length === 0 || c.name.length > 500) throw new Error('invalid category name')
+    if (typeof c.sortOrder !== 'number') throw new Error('invalid category sortOrder')
+    if (!isoRe.test(c.updatedAt)) throw new Error('invalid category updatedAt')
+  }
+  for (const c of (data.chores ?? [])) {
+    if (!uuidRe.test(c.id)) throw new Error('invalid chore id')
+    if (typeof c.name !== 'string' || c.name.length === 0 || c.name.length > 500) throw new Error('invalid chore name')
+    if (typeof c.sortOrder !== 'number') throw new Error('invalid chore sortOrder')
+    if (!isoRe.test(c.createdAt)) throw new Error('invalid chore createdAt')
+    if (!isoRe.test(c.updatedAt)) throw new Error('invalid chore updatedAt')
+    if (c.seasonalStart != null && !mmddRe.test(c.seasonalStart)) throw new Error('invalid chore seasonalStart')
+    if (c.seasonalEnd != null && !mmddRe.test(c.seasonalEnd)) throw new Error('invalid chore seasonalEnd')
+  }
+  for (const e of (data.completionEvents ?? [])) {
+    if (!uuidRe.test(e.id)) throw new Error('invalid completionEvent id')
+    if (!uuidRe.test(e.choreSyncId)) throw new Error('invalid completionEvent choreSyncId')
+    if (!isoRe.test(e.completedAt)) throw new Error('invalid completionEvent completedAt')
+    if (e.source !== 'manual' && e.source !== 'dayglance') throw new Error('invalid completionEvent source')
+  }
+  for (const [syncId, deletedAt] of Object.entries(data.tombstones ?? {})) {
+    if (!uuidRe.test(syncId)) throw new Error('invalid tombstone id')
+    if (!isoRe.test(deletedAt)) throw new Error('invalid tombstone deletedAt')
+  }
+}
+
 // applyPayload: write merged data back to Dexie (two-pass for categories)
 export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpty: boolean }): Promise<void> => {
   const data = rawData as SyncPayload
   if (!allowEmpty && !data?.chores?.length && !data?.categories?.length && !data?.completionEvents?.length) return
+  validateSyncPayload(data)
 
   await db.transaction('rw', db.categories, db.chores, db.completionEvents, db.tombstones, async () => {
     // ── CATEGORIES pass 1: upsert by sync_id ──


### PR DESCRIPTION
## Summary

Security audit findings addressed in this patch release.

- **Backup import validation** — field-level checks (name length, UUID format, ISO dates, enum values) on all three tables before any DB writes; malformed backup files now surface an error instead of silently importing corrupt data
- **Remote sync payload validation** — same field-level checks applied to payloads coming back from WebDAV before they are written to IndexedDB
- **DOMParser for PROPFIND** — replaces the regex-based `<href>` extractor with `getElementsByTagNameNS('DAV:', 'href')`; immune to hrefs appearing in XML comments, CDATA, or attributes
- **Per-engine backup lock** — `_backupInProgress` changed from a module-level boolean to a `WeakSet<SyncEngine>` so the lock is scoped to the engine instance
- **Stateful regex eliminated** — `hrefRe` is now constructed inside `listFiles` on each call, removing the shared `lastIndex` that could corrupt concurrent calls
- **`completed_at` validation** — remote intent `completed_at` is validated with `dayjs().isValid()` before writing to DB; falls back to `now` if malformed
- **localStorage disclosure** — added "Stored in browser localStorage — keep your device secure." under the password fields in both SyncSettingsModal and IntegrationSettingsModal, mirroring the dayGLANCE pattern
- **Auto-sync interval** — `setInterval` added to call `eng.sync()` every 5 minutes alongside the existing visibility-change sync

## Test plan

- [ ] Import a valid lastGLANCE backup — should succeed as before
- [ ] Import a hand-edited backup with a malformed `completed_at` — should show "Import failed" error
- [ ] Configure WebDAV sync and confirm sync works normally
- [ ] Confirm password fields in both settings modals show the localStorage warning
- [ ] Leave the app open for 5+ minutes and confirm sync fires automatically (check network tab)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtD5GkfgFBxFWxJ2jyowk9)_