### PR TITLE
Multi-device dedup fix, phantom completion fix, cursor skip fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,13 +21,15 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/coverage-v8": "^4.1.7",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.20.0",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "vite": "^6.3.4",
-        "vite-plugin-pwa": "^0.21.1"
+        "vite-plugin-pwa": "^0.21.1",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1617,6 +1619,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -2837,6 +2849,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2894,6 +2913,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2972,6 +3009,180 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -3103,6 +3314,45 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3414,6 +3664,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3861,6 +4121,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4132,6 +4399,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4733,6 +5010,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5251,6 +5535,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -5512,6 +5835,47 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5695,6 +6059,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5836,6 +6211,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6642,6 +7024,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6715,6 +7104,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7022,6 +7425,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7068,6 +7488,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7507,6 +7937,119 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -7629,6 +8172,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.4",
       "dependencies": {
         "@glance-apps/intents": "^1.3.2",
-        "@glance-apps/sync": "^1.1.0",
+        "@glance-apps/sync": "^1.1.1",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "lucide-react": "^1.14.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.0.tgz",
-      "integrity": "sha512-dquq9n2zjPV39P5dnaNvHiZNEiWekEsUOurqnVwx701R64OYe7PAFOTMi1oOWvsHkaQqlfbEFFRlKfwhUIAxnA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.1.tgz",
+      "integrity": "sha512-hc+dkfJTAOOL8BwNoqYR7vi4FDOMKFUtQdnujCsu83bymtioZxERM1VHO28mu0KXTOefH5tUIiGRLFb1oUQBHw==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.2",
-    "@glance-apps/sync": "^1.1.0",
+    "@glance-apps/sync": "^1.1.1",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "lucide-react": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.2",
@@ -29,6 +30,8 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "vite": "^6.3.4",
-    "vite-plugin-pwa": "^0.21.1"
+    "vite-plugin-pwa": "^0.21.1",
+    "vitest": "^4.1.7",
+    "@vitest/coverage-v8": "^4.1.7"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import { getAllCompletionCounts } from '@/db/queries'
 import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
 import type { SyncEngine, SyncStatus } from '@glance-apps/sync'
 import { syncSharedUsers } from '@/multiuser/sharedUsers'
-import { getUsersPath } from '@/multiuser/settings'
+import { getUsersPath, getMultiUserEnabled } from '@/multiuser/settings'
 import dayjs from 'dayjs'
 
 // ── Header heatmap ─────────────────────────────────────────────────────────────
@@ -153,6 +153,7 @@ function AppInner() {
         setSyncStatus(status)
         if (status === 'success' && engineRef.current) {
           runAutoBackups(engineRef.current).catch(() => {/* non-fatal */})
+          runSharedUserSync().catch(() => {/* non-fatal */})
         }
       },
       onError: (msg, _code, isHardStop) => {
@@ -173,6 +174,7 @@ function AppInner() {
   // Shared user roster sync — fire-and-forget, non-fatal
   const sharedUserSyncRunning = useRef(false)
   const runSharedUserSync = useCallback(async () => {
+    if (!getMultiUserEnabled()) return
     if (sharedUserSyncRunning.current) return
     sharedUserSyncRunning.current = true
     try {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -197,7 +197,7 @@ export async function deleteChore(id: number): Promise<void> {
 
 export async function logCompletion(
   choreId: number,
-  opts: { note?: string; completedAt?: string; source?: 'manual' | 'dayglance'; completedByUserSyncId?: string | null } = {}
+  opts: { note?: string; completedAt?: string; source?: 'manual' | 'dayglance'; completedByUserSyncId?: string | null; syncId?: string } = {}
 ): Promise<number> {
   return db.completionEvents.add({
     chore_id: choreId,
@@ -205,7 +205,7 @@ export async function logCompletion(
     note: opts.note ?? null,
     source: opts.source ?? 'manual',
     completed_by_user_sync_id: opts.completedByUserSyncId ?? null,
-    sync_id: crypto.randomUUID(),
+    sync_id: opts.syncId ?? crypto.randomUUID(),
   } as CompletionEvent)
 }
 

--- a/src/hooks/useIntentsPoller.ts
+++ b/src/hooks/useIntentsPoller.ts
@@ -22,6 +22,21 @@ import { buildAuthHeader, listFiles, getFile } from '@/intents/webdav'
 import { loadIntentsRootKey } from '@/intents/intentsKeyStore'
 import { processNotifyEnvelope } from '@/intents/processNotifyEnvelope'
 
+// How far back to look behind the stored cursor when filtering events.
+// Covers the window where a device may upload an event with an earlier
+// timestamp than one already processed (out-of-order WebDAV delivery).
+// isAlreadyLogged guards against re-writing events within the window.
+const CURSOR_LOOKBACK_MS = 60 * 60 * 1000
+
+function cursorLookback(cursor: string, windowMs: number): string {
+  const iso = cursor.replace(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/,
+    '$1-$2-$3T$4:$5:$6Z',
+  )
+  const adjusted = new Date(new Date(iso).getTime() - windowMs)
+  return adjusted.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '')
+}
+
 export function useIntentsPoller(onNewCompletion?: () => void): void {
   const onNewCompletionRef = useRef<(() => void) | undefined>(onNewCompletion)
   useEffect(() => { onNewCompletionRef.current = onNewCompletion }, [onNewCompletion])
@@ -43,10 +58,14 @@ export function useIntentsPoller(onNewCompletion?: () => void): void {
         return
       }
 
-      // Filter by parseFilename and cursor, sort ascending
+      // Filter by parseFilename and cursor (with lookback), sort ascending.
+      // The lookback catches events uploaded with earlier timestamps than the
+      // current cursor (out-of-order delivery). isAlreadyLogged prevents
+      // duplicate writes for events re-examined within the window.
+      const effectiveCursor = cursor ? cursorLookback(cursor, CURSOR_LOOKBACK_MS) : null
       const parsed = filenames
         .map(f => ({ filename: f, parsed: parseFilename(f) }))
-        .filter(({ parsed: p }) => p !== null && (!cursor || p!.timestamp > cursor))
+        .filter(({ parsed: p }) => p !== null && (!effectiveCursor || p!.timestamp > effectiveCursor))
         .sort((a, b) => a.parsed!.timestamp.localeCompare(b.parsed!.timestamp))
 
       let newCursor = cursor
@@ -125,9 +144,10 @@ export function useIntentsPoller(onNewCompletion?: () => void): void {
 
     async function processEnvelope(envelope: Awaited<ReturnType<typeof parseEnvelope>>) {
       await processNotifyEnvelope(envelope, {
-        getChore: (id) => db.chores.get(id),
+        getChore: (syncId) => db.chores.where('sync_id').equals(syncId).first(),
         logCompletion,
         addActivityEntry,
+        isAlreadyLogged: (syncId) => db.completionEvents.where('sync_id').equals(syncId).count().then(n => n > 0),
         dispatchChoreLogged: () => window.dispatchEvent(new CustomEvent('lg:chore-logged')),
         onNewCompletion: () => onNewCompletionRef.current?.(),
       })

--- a/src/hooks/useIntentsPoller.ts
+++ b/src/hooks/useIntentsPoller.ts
@@ -1,8 +1,5 @@
 import { useEffect, useRef } from 'react'
 import {
-  ACTIONS,
-  EVENTS,
-  SOURCE_APPS,
   parseEnvelope,
   parseEncryptedEnvelope,
   parseFilename,
@@ -23,7 +20,7 @@ import {
 } from '@/intents/config'
 import { buildAuthHeader, listFiles, getFile } from '@/intents/webdav'
 import { loadIntentsRootKey } from '@/intents/intentsKeyStore'
-import dayjs from 'dayjs'
+import { processNotifyEnvelope } from '@/intents/processNotifyEnvelope'
 
 export function useIntentsPoller(onNewCompletion?: () => void): void {
   const onNewCompletionRef = useRef<(() => void) | undefined>(onNewCompletion)
@@ -127,27 +124,13 @@ export function useIntentsPoller(onNewCompletion?: () => void): void {
     }
 
     async function processEnvelope(envelope: Awaited<ReturnType<typeof parseEnvelope>>) {
-      if (envelope.action !== ACTIONS.NOTIFY) return
-
-      const payload = envelope.payload
-      if (payload.source_app !== SOURCE_APPS.LASTGLANCE) return
-      if (payload.event !== EVENTS.COMPLETED) return
-
-      const choreId = parseInt(payload.source_entity_id, 10)
-      if (isNaN(choreId)) return
-
-      const chore = await db.chores.get(choreId)
-      if (!chore) return
-
-      await logCompletion(choreId, {
-        completedAt: dayjs(payload.completed_at).isValid() ? payload.completed_at : dayjs().toISOString(),
-        source: 'dayglance',
-        completedByUserSyncId: payload.completed_by_user_id ?? null,
+      await processNotifyEnvelope(envelope, {
+        getChore: (id) => db.chores.get(id),
+        logCompletion,
+        addActivityEntry,
+        dispatchChoreLogged: () => window.dispatchEvent(new CustomEvent('lg:chore-logged')),
+        onNewCompletion: () => onNewCompletionRef.current?.(),
       })
-
-      addActivityEntry({ type: 'received', message: `"${chore.name}" completed in dayGLANCE` })
-      window.dispatchEvent(new CustomEvent('lg:chore-logged'))
-      onNewCompletionRef.current?.()
     }
 
     poll()

--- a/src/intents/emitter.ts
+++ b/src/intents/emitter.ts
@@ -18,7 +18,7 @@ export async function emitCreateIntent(chore: ChoreWithLastCompletion): Promise<
       due: dayjs().format('YYYY-MM-DD'),
       all_day: true,
       source_app: SOURCE_APPS.LASTGLANCE,
-      source_entity_id: String(chore.id),
+      source_entity_id: chore.sync_id,
       ...(assignedUserIds.length > 0 && { assigned_user_ids: assignedUserIds }),
     }
 

--- a/src/intents/processNotifyEnvelope.test.ts
+++ b/src/intents/processNotifyEnvelope.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildEnvelope, ACTIONS, EVENTS, SOURCE_APPS } from '@glance-apps/intents'
+import { processNotifyEnvelope } from './processNotifyEnvelope'
+
+// TEST B — wiring gate
+// Verifies that processNotifyEnvelope passes payload.event_id (the stable
+// transition ID, identical across every device that processes the same notify
+// event) as syncId to logCompletion — NOT envelope.event_id (which is
+// timestamp-plus-random and differs per emission/device).
+describe('processNotifyEnvelope – syncId wiring', () => {
+  it('passes payload.event_id as syncId, not envelope.event_id', async () => {
+    const PAYLOAD_EVENT_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+    const COMPLETED_AT = '2026-05-29T10:00:00.000Z'
+
+    // Build a real notify envelope via the @glance-apps/intents package.
+    // We do NOT set the optional `eventId` arg on buildEnvelope, so
+    // envelope.event_id is a fresh random timestamp-based value — distinct
+    // from PAYLOAD_EVENT_ID. That distinction is what this test protects.
+    const envelope = buildEnvelope({
+      action: ACTIONS.NOTIFY,
+      payload: {
+        event_id: PAYLOAD_EVENT_ID,
+        source_app: SOURCE_APPS.LASTGLANCE,
+        source_entity_id: '42',
+        event: EVENTS.COMPLETED,
+        task_id: 'tsk_abc',
+        title: 'Replace HVAC filter',
+        timestamp: COMPLETED_AT,
+        completed_at: COMPLETED_AT,
+      },
+      emittedBy: SOURCE_APPS.DAYGLANCE,
+    })
+
+    // Confirm the two event_id fields are indeed distinct — the test is only
+    // meaningful if they differ.
+    expect(envelope.event_id).not.toBe(PAYLOAD_EVENT_ID)
+
+    const logCompletion = vi.fn().mockResolvedValue(1)
+    const getChore = vi.fn().mockResolvedValue({ id: 42, name: 'Replace HVAC filter' })
+
+    await processNotifyEnvelope(envelope, {
+      getChore,
+      logCompletion,
+      addActivityEntry: vi.fn(),
+    })
+
+    expect(logCompletion).toHaveBeenCalledOnce()
+
+    const [calledChoreId, calledOpts] = logCompletion.mock.calls[0] as [number, { syncId?: string; completedByUserSyncId?: string | null }]
+    expect(calledChoreId).toBe(42)
+    // Must equal payload.event_id — the stable shared transition ID
+    expect(calledOpts.syncId).toBe(PAYLOAD_EVENT_ID)
+    // Must NOT equal the per-emission envelope.event_id
+    expect(calledOpts.syncId).not.toBe(envelope.event_id)
+    // completed_by_user_id absent in payload → null
+    expect(calledOpts.completedByUserSyncId).toBeNull()
+  })
+
+  it('passes completed_by_user_id when present in payload', async () => {
+    const USER_SYNC_ID = 'uuuuuuuu-uuuu-uuuu-uuuu-uuuuuuuuuuuu'
+    const COMPLETED_AT = '2026-05-29T10:00:00.000Z'
+
+    const envelope = buildEnvelope({
+      action: ACTIONS.NOTIFY,
+      payload: {
+        event_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+        source_app: SOURCE_APPS.LASTGLANCE,
+        source_entity_id: '42',
+        event: EVENTS.COMPLETED,
+        task_id: 'tsk_abc',
+        title: 'Replace HVAC filter',
+        timestamp: COMPLETED_AT,
+        completed_at: COMPLETED_AT,
+        completed_by_user_id: USER_SYNC_ID,
+      },
+      emittedBy: SOURCE_APPS.DAYGLANCE,
+    })
+
+    const logCompletion = vi.fn().mockResolvedValue(1)
+    await processNotifyEnvelope(envelope, {
+      getChore: vi.fn().mockResolvedValue({ id: 42, name: 'Replace HVAC filter' }),
+      logCompletion,
+      addActivityEntry: vi.fn(),
+    })
+
+    const [, calledOpts] = logCompletion.mock.calls[0] as [number, { completedByUserSyncId?: string | null }]
+    expect(calledOpts.completedByUserSyncId).toBe(USER_SYNC_ID)
+  })
+
+  it('does not call logCompletion when chore is not found', async () => {
+    const envelope = buildEnvelope({
+      action: ACTIONS.NOTIFY,
+      payload: {
+        event_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+        source_app: SOURCE_APPS.LASTGLANCE,
+        source_entity_id: '99',
+        event: EVENTS.COMPLETED,
+        task_id: 'tsk_xyz',
+        title: 'Some chore',
+        timestamp: '2026-05-29T10:00:00.000Z',
+      },
+      emittedBy: SOURCE_APPS.DAYGLANCE,
+    })
+
+    const logCompletion = vi.fn()
+    await processNotifyEnvelope(envelope, {
+      getChore: vi.fn().mockResolvedValue(undefined),
+      logCompletion,
+      addActivityEntry: vi.fn(),
+    })
+
+    expect(logCompletion).not.toHaveBeenCalled()
+  })
+})

--- a/src/intents/processNotifyEnvelope.test.ts
+++ b/src/intents/processNotifyEnvelope.test.ts
@@ -2,6 +2,27 @@ import { describe, it, expect, vi } from 'vitest'
 import { buildEnvelope, ACTIONS, EVENTS, SOURCE_APPS } from '@glance-apps/intents'
 import { processNotifyEnvelope } from './processNotifyEnvelope'
 
+const CHORE_SYNC_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+const COMPLETED_AT = '2026-05-29T10:00:00.000Z'
+
+function makeEnvelope(overrides: Record<string, unknown> = {}) {
+  return buildEnvelope({
+    action: ACTIONS.NOTIFY,
+    payload: {
+      event_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      source_app: SOURCE_APPS.LASTGLANCE,
+      source_entity_id: CHORE_SYNC_ID,
+      event: EVENTS.COMPLETED,
+      task_id: 'tsk_abc',
+      title: 'Replace HVAC filter',
+      timestamp: COMPLETED_AT,
+      completed_at: COMPLETED_AT,
+      ...overrides,
+    },
+    emittedBy: SOURCE_APPS.DAYGLANCE,
+  })
+}
+
 // TEST B — wiring gate
 // Verifies that processNotifyEnvelope passes payload.event_id (the stable
 // transition ID, identical across every device that processes the same notify
@@ -10,26 +31,12 @@ import { processNotifyEnvelope } from './processNotifyEnvelope'
 describe('processNotifyEnvelope – syncId wiring', () => {
   it('passes payload.event_id as syncId, not envelope.event_id', async () => {
     const PAYLOAD_EVENT_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
-    const COMPLETED_AT = '2026-05-29T10:00:00.000Z'
 
     // Build a real notify envelope via the @glance-apps/intents package.
     // We do NOT set the optional `eventId` arg on buildEnvelope, so
     // envelope.event_id is a fresh random timestamp-based value — distinct
     // from PAYLOAD_EVENT_ID. That distinction is what this test protects.
-    const envelope = buildEnvelope({
-      action: ACTIONS.NOTIFY,
-      payload: {
-        event_id: PAYLOAD_EVENT_ID,
-        source_app: SOURCE_APPS.LASTGLANCE,
-        source_entity_id: '42',
-        event: EVENTS.COMPLETED,
-        task_id: 'tsk_abc',
-        title: 'Replace HVAC filter',
-        timestamp: COMPLETED_AT,
-        completed_at: COMPLETED_AT,
-      },
-      emittedBy: SOURCE_APPS.DAYGLANCE,
-    })
+    const envelope = makeEnvelope({ event_id: PAYLOAD_EVENT_ID })
 
     // Confirm the two event_id fields are indeed distinct — the test is only
     // meaningful if they differ.
@@ -44,9 +51,14 @@ describe('processNotifyEnvelope – syncId wiring', () => {
       addActivityEntry: vi.fn(),
     })
 
-    expect(logCompletion).toHaveBeenCalledOnce()
+    // getChore must be called with the chore sync_id from source_entity_id,
+    // not a parsed integer
+    expect(getChore).toHaveBeenCalledWith(CHORE_SYNC_ID)
 
+    expect(logCompletion).toHaveBeenCalledOnce()
     const [calledChoreId, calledOpts] = logCompletion.mock.calls[0] as [number, { syncId?: string; completedByUserSyncId?: string | null }]
+    // logCompletion receives the local integer id from the chore object, not
+    // parseInt(source_entity_id)
     expect(calledChoreId).toBe(42)
     // Must equal payload.event_id — the stable shared transition ID
     expect(calledOpts.syncId).toBe(PAYLOAD_EVENT_ID)
@@ -58,23 +70,8 @@ describe('processNotifyEnvelope – syncId wiring', () => {
 
   it('passes completed_by_user_id when present in payload', async () => {
     const USER_SYNC_ID = 'uuuuuuuu-uuuu-uuuu-uuuu-uuuuuuuuuuuu'
-    const COMPLETED_AT = '2026-05-29T10:00:00.000Z'
 
-    const envelope = buildEnvelope({
-      action: ACTIONS.NOTIFY,
-      payload: {
-        event_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
-        source_app: SOURCE_APPS.LASTGLANCE,
-        source_entity_id: '42',
-        event: EVENTS.COMPLETED,
-        task_id: 'tsk_abc',
-        title: 'Replace HVAC filter',
-        timestamp: COMPLETED_AT,
-        completed_at: COMPLETED_AT,
-        completed_by_user_id: USER_SYNC_ID,
-      },
-      emittedBy: SOURCE_APPS.DAYGLANCE,
-    })
+    const envelope = makeEnvelope({ completed_by_user_id: USER_SYNC_ID })
 
     const logCompletion = vi.fn().mockResolvedValue(1)
     await processNotifyEnvelope(envelope, {
@@ -88,25 +85,27 @@ describe('processNotifyEnvelope – syncId wiring', () => {
   })
 
   it('does not call logCompletion when chore is not found', async () => {
-    const envelope = buildEnvelope({
-      action: ACTIONS.NOTIFY,
-      payload: {
-        event_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
-        source_app: SOURCE_APPS.LASTGLANCE,
-        source_entity_id: '99',
-        event: EVENTS.COMPLETED,
-        task_id: 'tsk_xyz',
-        title: 'Some chore',
-        timestamp: '2026-05-29T10:00:00.000Z',
-      },
-      emittedBy: SOURCE_APPS.DAYGLANCE,
-    })
+    const envelope = makeEnvelope()
 
     const logCompletion = vi.fn()
     await processNotifyEnvelope(envelope, {
       getChore: vi.fn().mockResolvedValue(undefined),
       logCompletion,
       addActivityEntry: vi.fn(),
+    })
+
+    expect(logCompletion).not.toHaveBeenCalled()
+  })
+
+  it('does not call logCompletion when isAlreadyLogged returns true', async () => {
+    const envelope = makeEnvelope()
+
+    const logCompletion = vi.fn()
+    await processNotifyEnvelope(envelope, {
+      getChore: vi.fn().mockResolvedValue({ id: 42, name: 'Replace HVAC filter' }),
+      logCompletion,
+      addActivityEntry: vi.fn(),
+      isAlreadyLogged: vi.fn().mockResolvedValue(true),
     })
 
     expect(logCompletion).not.toHaveBeenCalled()

--- a/src/intents/processNotifyEnvelope.ts
+++ b/src/intents/processNotifyEnvelope.ts
@@ -3,12 +3,13 @@ import type { Envelope } from '@glance-apps/intents'
 import dayjs from 'dayjs'
 
 export interface ProcessNotifyDeps {
-  getChore: (id: number) => Promise<{ name: string } | undefined>
+  getChore: (syncId: string) => Promise<{ id: number; name: string } | undefined>
   logCompletion: (
     choreId: number,
     opts: { completedAt?: string; source?: 'manual' | 'dayglance'; completedByUserSyncId?: string | null; syncId?: string }
   ) => Promise<number>
   addActivityEntry: (entry: { type: 'received' | 'error' | 'warning' | 'sent'; message: string }) => void
+  isAlreadyLogged?: (syncId: string) => Promise<boolean>
   onNewCompletion?: () => void
   dispatchChoreLogged?: () => void
 }
@@ -23,13 +24,15 @@ export async function processNotifyEnvelope(
   if (payload.source_app !== SOURCE_APPS.LASTGLANCE) return
   if (payload.event !== EVENTS.COMPLETED) return
 
-  const choreId = parseInt(payload.source_entity_id, 10)
-  if (isNaN(choreId)) return
+  const choreSyncId = payload.source_entity_id
+  if (!choreSyncId) return
 
-  const chore = await deps.getChore(choreId)
+  if (await deps.isAlreadyLogged?.(payload.event_id)) return
+
+  const chore = await deps.getChore(choreSyncId)
   if (!chore) return
 
-  await deps.logCompletion(choreId, {
+  await deps.logCompletion(chore.id, {
     completedAt: dayjs(payload.completed_at).isValid() ? payload.completed_at : undefined,
     source: 'dayglance',
     completedByUserSyncId: payload.completed_by_user_id ?? null,

--- a/src/intents/processNotifyEnvelope.ts
+++ b/src/intents/processNotifyEnvelope.ts
@@ -1,0 +1,42 @@
+import { ACTIONS, EVENTS, SOURCE_APPS } from '@glance-apps/intents'
+import type { Envelope } from '@glance-apps/intents'
+import dayjs from 'dayjs'
+
+export interface ProcessNotifyDeps {
+  getChore: (id: number) => Promise<{ name: string } | undefined>
+  logCompletion: (
+    choreId: number,
+    opts: { completedAt?: string; source?: 'manual' | 'dayglance'; completedByUserSyncId?: string | null; syncId?: string }
+  ) => Promise<number>
+  addActivityEntry: (entry: { type: 'received' | 'error' | 'warning' | 'sent'; message: string }) => void
+  onNewCompletion?: () => void
+  dispatchChoreLogged?: () => void
+}
+
+export async function processNotifyEnvelope(
+  envelope: Envelope,
+  deps: ProcessNotifyDeps,
+): Promise<void> {
+  if (envelope.action !== ACTIONS.NOTIFY) return
+
+  const payload = envelope.payload
+  if (payload.source_app !== SOURCE_APPS.LASTGLANCE) return
+  if (payload.event !== EVENTS.COMPLETED) return
+
+  const choreId = parseInt(payload.source_entity_id, 10)
+  if (isNaN(choreId)) return
+
+  const chore = await deps.getChore(choreId)
+  if (!chore) return
+
+  await deps.logCompletion(choreId, {
+    completedAt: dayjs(payload.completed_at).isValid() ? payload.completed_at : undefined,
+    source: 'dayglance',
+    completedByUserSyncId: payload.completed_by_user_id ?? null,
+    syncId: payload.event_id,
+  })
+
+  deps.addActivityEntry({ type: 'received', message: `"${chore.name}" completed in dayGLANCE` })
+  deps.dispatchChoreLogged?.()
+  deps.onNewCompletion?.()
+}

--- a/src/sync/engine.test.ts
+++ b/src/sync/engine.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { mergePayloads } from './engine'
+import type { SyncPayload } from './types'
+
+// TEST A — merge gate
+// Two devices each process the same notify event and write a CompletionEvent
+// with the same sync_id (the inbound payload.event_id). mergePayloads must
+// collapse them to exactly one record, not union them into two.
+describe('mergePayloads – CompletionEvent dedup on matching sync_id', () => {
+  it('collapses two CompletionEvents with identical id to one record', () => {
+    const TRANSITION_ID = '11111111-1111-1111-1111-111111111111'
+    const CHORE_SYNC_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const COMPLETED_AT = '2026-05-29T10:00:00.000Z'
+
+    const record = {
+      id: TRANSITION_ID,
+      choreSyncId: CHORE_SYNC_ID,
+      completedAt: COMPLETED_AT,
+      note: null,
+      source: 'dayglance' as const,
+      completedByUserSyncId: null,
+    }
+
+    // Device A's local payload after processing the notify event
+    const localPayload: SyncPayload = {
+      categories: [],
+      chores: [],
+      completionEvents: [record],
+      tombstones: {},
+    }
+
+    // Device B's payload — same event processed independently, same stable id
+    const remotePayload: SyncPayload = {
+      categories: [],
+      chores: [],
+      completionEvents: [{ ...record }],
+      tombstones: {},
+    }
+
+    const { data } = mergePayloads(localPayload, remotePayload)
+    const merged = (data as SyncPayload).completionEvents
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].id).toBe(TRANSITION_ID)
+  })
+})

--- a/src/sync/engine.test.ts
+++ b/src/sync/engine.test.ts
@@ -27,6 +27,8 @@ describe('mergePayloads – CompletionEvent dedup on matching sync_id', () => {
       chores: [],
       completionEvents: [record],
       tombstones: {},
+      users: [],
+      settings: { multiUserEnabled: false },
     }
 
     // Device B's payload — same event processed independently, same stable id
@@ -35,6 +37,8 @@ describe('mergePayloads – CompletionEvent dedup on matching sync_id', () => {
       chores: [],
       completionEvents: [{ ...record }],
       tombstones: {},
+      users: [],
+      settings: { multiUserEnabled: false },
     }
 
     const { data } = mergePayloads(localPayload, remotePayload)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

This PR fixes three bugs identified from the multi-device completion dedup incident, plus two shared user roster issues found during investigation.

### 1. Cross-device dedup fix (core)

`logCompletion` now accepts an optional `syncId`. When processing a NOTIFY event, `payload.event_id` (the inner payload field — NOT `envelope.event_id`) is passed as `syncId`. Because `@glance-apps/sync` merges `completionEvents` on `sync_id`, two devices processing the same NOTIFY event will write records with the same `sync_id` and the CRDT collapses them to one.

Requires the companion dayGLANCE fix (stable `transitionId` in `payload.event_id`) to activate. Without it, degrades gracefully to current behaviour — no regression.

### 2. Phantom completions fix (`source_entity_id` ID space mismatch)

The emitter was sending `source_entity_id: String(chore.id)` — the local Dexie auto-increment integer, which is device-local and meaningless on any other device. On a second lastGLANCE instance, `parseInt(source_entity_id)` → DB lookup could find a completely different chore, producing a completion for a task never touched.

- **Emitter:** now sends `chore.sync_id` (the stable cross-device UUID)
- **Consumer:** looks up chore by `sync_id` index instead of integer primary key; `logCompletion` receives `chore.id` from the lookup result

**Migration note:** tasks already sent to dayGLANCE before this fix have integer `source_entity_id` values. NOTIFY events from those tasks will no-op on the consumer (no UUID match) rather than phantom-log. Workaround: re-send affected chores or log completions manually. Expected to affect very few real-world users.

### 3. Cursor skip fix (out-of-order event delivery)

The poll loop cursor filter was strict `timestamp > cursor`, permanently dropping any event uploaded with an earlier timestamp than one already processed (e.g. Android upload delay, WebDAV eventual consistency).

- Cursor filter widened to `cursor minus 1 hour` (`effectiveCursor`) so late-arriving events within the window are re-examined
- `isAlreadyLogged` guard added to `processNotifyEnvelope` — checks `completionEvents.sync_id` before writing, making re-examination idempotent and preventing duplicate local writes

### 4. Shared user roster: guard + post-sync refresh

- `runSharedUserSync` now bails out immediately if `multiUserEnabled` is false — prevents premature or empty roster writes to WebDAV during initial cloud sync setup
- Roster sync now also fires after every successful cloud sync cycle (alongside `runAutoBackups`), so new users propagate automatically at sync cadence rather than waiting for a local trigger

### 5. `processNotifyEnvelope` extraction

All notify-consume logic extracted from `useIntentsPoller` into a standalone testable `processNotifyEnvelope` module. The hook delegates entirely. Preserves `completedByUserSyncId` wiring from PR #74.

### 6. Vitest added; `@glance-apps/sync` bumped to `^1.1.1`

## Tests

- **Test A (merge gate):** two `CompletionEvent` records with identical `sync_id` run through real `mergePayloads` — asserts exactly one survives
- **Test B (wiring gate):** `processNotifyEnvelope` fed a real `buildEnvelope` notify where `payload.event_id` is a known UUID distinct from `envelope.event_id` — asserts `logCompletion` called with `syncId === payload.event_id`, `syncId !== envelope.event_id`, correct `completedByUserSyncId` passthrough
- **Test C (`isAlreadyLogged` gate):** asserts `logCompletion` is not called when `isAlreadyLogged` returns true
- **Test D (chore not found):** asserts `logCompletion` is not called when chore lookup returns undefined

5/5 passing.

## Test plan

- [ ] `npm run dev` — two browser profiles against test WebDAV: complete a chore in dayGLANCE, verify exactly one `completionEvents` row with a plain-UUID `sync_id` on both lastGLANCE instances after sync
- [ ] Verify correct chore resolved (no phantom completion for a different chore)
- [ ] Pre-release builds (Android + Electron + Docker) against test WebDAV — real devices, real encryption round-trip, real network timing
- [ ] Confirm shared user roster only written when multi-user is enabled

https://claude.ai/code/session_01Pag3umFkAvSEuvjatJdUvz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pag3umFkAvSEuvjatJdUvz)_