### PR TITLE
fix: add trailing slash to testConnection URL to avoid 301 redirect

### DIFF
--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -118,7 +118,7 @@ export async function getFileOrNull(baseUrl: string, folderPath: string, filenam
 
 export async function testConnection(baseUrl: string, folderPath: string, username: string, password: string): Promise<{ success: boolean; error?: string }> {
   const authHeader = buildAuthHeader(username, password)
-  const folderUrl = buildFolderUrl(baseUrl, folderPath)
+  const folderUrl = buildFolderUrl(baseUrl, folderPath) + '/'
   try {
     const res = await fetchWithTimeout(withProxy(folderUrl), {
       method: 'PROPFIND',


### PR DESCRIPTION
WebDAV servers commonly redirect directory URLs without a trailing slash to the same URL with one. The proxy passes 301 through as-is rather than following redirects, so the client was surfacing "Server returned 301 Moved Permanently". listFiles already appended '/' after buildFolderUrl; testConnection now does the same.

https://claude.ai/code/session_01T5nb2U83WmYPUxtGL7CZo2