### PR TITLE
fix(sync): filter legacy non-UUID ids from buildPayload output

### DIFF
--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -30,7 +30,9 @@ export const buildPayload = async (): Promise<SyncPayload> => {
   ])
 
   const tombstones: Record<string, string> = {}
-  for (const t of tombstoneRows) tombstones[t.id] = t.deleted_at
+  for (const t of tombstoneRows) {
+    if (uuidRe.test(t.id)) tombstones[t.id] = t.deleted_at
+  }
 
   const choreMap = new Map(chores.map(c => [c.id!, c.sync_id]))
 
@@ -63,14 +65,11 @@ export const buildPayload = async (): Promise<SyncPayload> => {
       createdAt: c.created_at,
       updatedAt: c.updated_at,
     })),
-    completionEvents: completionEvents.map(e => ({
-      id: e.sync_id,
-      choreSyncId: choreMap.get(e.chore_id) ?? '',
-      completedAt: e.completed_at,
-      note: e.note,
-      source: e.source,
-      completedByUserSyncId: e.completed_by_user_sync_id ?? null,
-    })),
+    completionEvents: completionEvents.flatMap(e => {
+      const choreSyncId = choreMap.get(e.chore_id) ?? ''
+      if (!uuidRe.test(e.sync_id) || !uuidRe.test(choreSyncId)) return []
+      return [{ id: e.sync_id, choreSyncId, completedAt: e.completed_at, note: e.note, source: e.source, completedByUserSyncId: e.completed_by_user_sync_id ?? null }]
+    }),
     users: users.map(u => ({
       id: u.sync_id,
       name: u.name,


### PR DESCRIPTION
Bad tombstone and completionEvent ids written by pre-dedup builds were being re-uploaded on every sync cycle, preventing the WebDAV file from ever getting clean. Skip them in buildPayload so the first successful upload permanently removes them from the server.

https://claude.ai/code/session_01Pag3umFkAvSEuvjatJdUvz