### PR TITLE
fix: strip weak ETag W/ prefix from If-Match header in WebDAV proxy

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -137,7 +137,10 @@ export default async function handler(req, res) {
       headers['Depth'] = req.headers['depth'];
     }
     if (req.headers['if-match']) {
-      headers['If-Match'] = req.headers['if-match'];
+      headers['If-Match'] = req.headers['if-match']
+        .split(',')
+        .map(e => e.trim().replace(/^W\//, ''))
+        .join(', ');
     }
     if (req.headers['if-none-match']) {
       headers['If-None-Match'] = req.headers['if-none-match'];


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes 412 PRECONDITION_FAILED errors when syncing to self-hosted WebDAV servers (e.g. Apache-based TrueNAS Scale)
- Strips the `W/` weak ETag prefix from each value in the `If-Match` header before forwarding, making the proxy RFC 2616 compliant
- Handles comma-separated multi-ETag values by stripping the prefix from each entry individually

Closes #73

## Test plan

- [ ] Sync to a self-hosted WebDAV server that rejects weak ETags — confirm no more 412 errors
- [ ] Sync to a standard WebDAV server (e.g. Nextcloud) — confirm no regression
- [ ] Verify strong ETags (no `W/` prefix) pass through unchanged
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUzmzPbhaWsTEMnuwzGKyG)_