### PR TITLE
Fix intent emit and poller failures on mobile/desktop PWAs

### DIFF
--- a/src/hooks/useIntentsPoller.ts
+++ b/src/hooks/useIntentsPoller.ts
@@ -75,6 +75,11 @@ export function useIntentsPoller(onNewCompletion?: () => void): void {
         try {
           rawText = await getFile(config.webdavUrl, config.folderPath, filename, authHeader)
         } catch (err) {
+          const isNetworkError = err instanceof TypeError || (err instanceof DOMException && err.name === 'AbortError')
+          if (isNetworkError) {
+            // Transient failure — leave cursor in place so these files are retried next poll
+            break
+          }
           const message = err instanceof Error ? err.message : String(err)
           addActivityEntry({ type: 'error', message: `Failed to read intent file ${filename}`, detail: message })
           newCursor = parsedFilename!.timestamp

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -104,7 +104,7 @@ export function useNotifications() {
 
     checkAndNotify()
     const interval = setInterval(checkAndNotify, 60 * 60 * 1000)
-    function onVisibilityChange() { checkAndNotify() }
+    function onVisibilityChange() { if (document.visibilityState === 'visible') checkAndNotify() }
     document.addEventListener('visibilitychange', onVisibilityChange)
     return () => {
       clearInterval(interval)

--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -11,7 +11,7 @@ const WEBDAV_TIMEOUT_MS = 15_000
 
 function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), WEBDAV_TIMEOUT_MS)
+  const timer = setTimeout(() => controller.abort(new DOMException('Request timed out', 'AbortError')), WEBDAV_TIMEOUT_MS)
   return fetch(url, { ...init, signal: controller.signal }).finally(() => clearTimeout(timer))
 }
 


### PR DESCRIPTION
## Summary

- **Fix false abort errors on mobile PWA**: `visibilitychange` was triggering `checkAndNotify` on both hide and show transitions. On mobile PWAs, the browser aborts in-flight fetches when the page is hidden — so a WebDAV request kicked off on hide would immediately fail with "signal is aborted without reason" in the activity log. Now only fires on `visible`.
- **Give `AbortController.abort()` an explicit reason**: Timeout-triggered aborts now surface as "Request timed out" instead of the opaque "signal is aborted without reason".
- **Fix transient network errors silently skipping intent files forever**: When `getFile` failed with a network error (`TypeError` / "Failed to fetch"), the poller was advancing the cursor past that file — meaning it was never retried. Now, transient errors break the loop without touching the cursor so the files are picked up on the next poll. Only genuine errors (HTTP failures, corrupt/undecryptable files) log to the activity log and advance the cursor.

## Test plan

- [ ] Create a chore with "Auto-send to dayGLANCE when overdue" enabled, log a completion to make it overdue, then switch apps on mobile — confirm no false "Failed to send" error appears in the activity log
- [ ] Simulate a brief network outage during intent polling — confirm no "Failed to read intent file" appears in the activity log and the file is retried on the next poll
- [ ] Simulate a genuine bad file (corrupt JSON) on the WebDAV server — confirm the error still appears in the activity log and the cursor advances past it

https://claude.ai/code/session_01VHvEG7rybdJiQjR9N7pztU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHvEG7rybdJiQjR9N7pztU)_