### PR TITLE
chore: bump version to v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.1.4-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.5.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lastglance",
-  "version": "1.1.4",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.1.4",
+      "version": "1.5.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.2",
-        "@glance-apps/sync": "^1.1.1",
+        "@glance-apps/sync": "^1.1.2",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "lucide-react": "^1.14.0",
@@ -2228,9 +2228,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.1.tgz",
-      "integrity": "sha512-hc+dkfJTAOOL8BwNoqYR7vi4FDOMKFUtQdnujCsu83bymtioZxERM1VHO28mu0KXTOefH5tUIiGRLFb1oUQBHw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.2.tgz",
+      "integrity": "sha512-BlfzcgyVLz+3xdWWa1f+oin0p3fJTmCuCprurRX+CaOpr366eCrTKa4DR0Z3EaoHmXS/qck/WM0qYz0EbjPzCg==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bumps `package.json` version from `1.1.4` to `1.5.0`
- Updates version badge in `README.md` to match
- Runs `npm install` to sync `package-lock.json`

This release reflects the significant work since v1.1.4: multi-user support, intents enhancements, Mine/All filter, WebDAV proxy overhaul, sync performance improvements, and mobile UI restructuring.

https://claude.ai/code/session_01UdbaRrkDgy71uRoZLBaNLh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdbaRrkDgy71uRoZLBaNLh)_