### PR TITLE
fix(sync): cloud sync encryption not applied to uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lastglance",
       "version": "1.5.1",
       "dependencies": {
-        "@glance-apps/intents": "^1.3.2",
+        "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
@@ -2216,9 +2216,9 @@
       }
     },
     "node_modules/@glance-apps/intents": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.3.2.tgz",
-      "integrity": "sha512-wMwfjmKWF9jXsG1sL7GtCHV4xuD6Wi0vzYQqoyVhNcg466ffWhZIlgGopIlYAqVB+ycwNR4Hqq3RTYh0YuBWnQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.3.3.tgz",
+      "integrity": "sha512-WlXjS94OgEYy8qeqGNuEZqLOA9wpCZWa//LGcvduDy3IJ21xIVv6UuIYYUWny2eVrr2hgMeUAtRvjnNbvppWtw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@glance-apps/intents": "^1.3.2",
+    "@glance-apps/intents": "^1.3.3",
     "@glance-apps/sync": "^1.1.2",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -70,7 +70,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
   function saveConfig() {
     if (!engine) return
     const webdavUrl = buildWebdavUrl(serverUrl)
-    engine.setConfig(serverUrl.trim() ? { provider: 'webdav', webdavUrl, username, appPassword, enabled: true } : null)
+    engine.setConfig(serverUrl.trim() ? { provider: 'webdav', webdavUrl, username, appPassword, enabled: true, encryptionEnabled: encEnabled } : null)
     localStorage.setItem(SYNC_FOLDER_KEY, folderPath)
     resetEnsuredFolder()
     // appFolderName is fixed at engine creation — reload so the new folder takes effect
@@ -116,6 +116,8 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
     try {
       await setupEncryptionKey(passphrase.trim(), CRYPTO_CONFIG)
       setEncEnabled(true)
+      const cfg = engine?.getConfig()
+      if (cfg) engine?.setConfig({ ...cfg, encryptionEnabled: true })
       setShowPassphraseInput(false)
       setPassphrase('')
       setConfirmPassphrase('')
@@ -132,6 +134,8 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
     try {
       await clearEncryptionKey(CRYPTO_CONFIG)
       setEncEnabled(false)
+      const cfg = engine?.getConfig()
+      if (cfg) engine?.setConfig({ ...cfg, encryptionEnabled: false })
     } catch (err) {
       setEncError(err instanceof Error ? err.message : 'Failed to clear encryption key')
     } finally {


### PR DESCRIPTION
## Summary

- **Bug fix:** Cloud sync was never encrypting uploaded files even when encryption was enabled and the UI reported it as active. Auto-backups were unaffected.
- **Root cause:** `providers.js` gates upload encryption on `config.encryptionEnabled` (the persisted engine config), but `saveConfig()` never wrote that field. `autoBackup.js` uses `hasEncryptionReady()` (in-memory session key) instead, which is why backups worked correctly.
- **Dependency bump:** `@glance-apps/intents` floor raised from `^1.3.2` to `^1.3.3` to match the current published release.

## Changes

- `SyncSettingsModal.tsx` — `saveConfig()` now includes `encryptionEnabled: encEnabled` in the engine config; `handleEnableEncryption` and `handleDisableEncryption` each update the live engine config immediately so the flag takes effect without requiring the modal to be closed first.
- `package.json` / `package-lock.json` — bumped `@glance-apps/intents` to `^1.3.3` (resolves to `1.3.3`).

## Migration note

Existing users with encryption already configured will need to **open Sync Settings and close it once** after deploying. No passphrase re-entry required — the modal initialises `encEnabled` from `hasEncryptionReady()`, so closing it immediately writes the correct `encryptionEnabled: true` to the config.

## Test plan

- [ ] Enable encryption for the first time — verify the next sync upload is encrypted (file on WebDAV is an `{ v: 1, enc: "AES-GCM-256", data: "..." }` envelope)
- [ ] Disable encryption — verify subsequent uploads are plaintext JSON
- [ ] Re-enable encryption — verify uploads are encrypted again
- [ ] Confirm auto-backups remain encrypted throughout
- [ ] Confirm UI "Encryption is active" / "Data is stored unencrypted" status matches actual upload behaviour

https://claude.ai/code/session_01J9ziPwiitZ7aveuNB1aSfy

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9ziPwiitZ7aveuNB1aSfy)_