### PR TITLE
v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.5.3-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.5.4-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.5.4-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.6.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.5.4",
+      "version": "1.6.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.5.4",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -52,6 +52,7 @@
     "clearFailed": "Failed to clear sample data.",
     "remoteListFailed": "Failed to list remote backups.",
     "remoteDownloadFailed": "Failed to download backup.",
+    "restoreFailed": "Restore failed.",
     "unknownDate": "Unknown date"
   },
   "categoryForm": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -52,6 +52,7 @@
     "clearFailed": "Échec de la suppression des données d'exemple.",
     "remoteListFailed": "Impossible de lister les sauvegardes distantes.",
     "remoteDownloadFailed": "Impossible de télécharger la sauvegarde.",
+    "restoreFailed": "Échec de la restauration.",
     "unknownDate": "Date inconnue"
   },
   "categoryForm": {

--- a/src/components/BackupModal/BackupModal.tsx
+++ b/src/components/BackupModal/BackupModal.tsx
@@ -129,7 +129,7 @@ export function BackupModal({ engine, onClose, onImported }: Props) {
       onImported()
       onClose()
     } catch (err) {
-      setErrorMsg(err instanceof Error ? err.message : t('backup.restore'))
+      setErrorMsg(err instanceof Error ? err.message : t('backup.restoreFailed'))
       setState('error')
     }
   }

--- a/src/utils/cadence.ts
+++ b/src/utils/cadence.ts
@@ -48,6 +48,7 @@ export function formatElapsed(elapsedDays: number | null, lastCompletedAt: strin
     const diffHours = Math.floor(diffMinutes / 60)
     return `${diffHours}h ago`
   }
-  if (elapsedDays < 2) return 'yesterday'
-  return `${Math.floor(elapsedDays)}d ago`
+  const calendarDaysAgo = dayjs().startOf('day').diff(dayjs(lastCompletedAt).startOf('day'), 'day')
+  if (calendarDaysAgo === 1) return 'yesterday'
+  return `${calendarDaysAgo}d ago`
 }


### PR DESCRIPTION
## Summary

- **i18n infrastructure + French translation** -- full internationalization via react-i18next with automatic language detection; French translation contributed by @cedriclocqueneux. Fix for incorrect error message key in the remote restore handler included.
- **WebDAV self-hosted fix** -- private/LAN IP addresses are now allowed in the WebDAV proxy when running self-hosted (Docker). The SSRF protection is gated behind the `VERCEL` env var, which Vercel injects automatically, so no configuration needed in either case. Fixes #90
- **Inline note editing on completions** -- a notepad icon appears next to the trash icon on each completion row in the chore detail modal. Clicking it opens an inline text input to add or edit a note, with Save/Cancel and Enter/Escape keyboard support. Icons are always visible on touch devices.
- **"-> send to dayGLANCE" button label** -- expanded from `-> dG` in the chore detail modal for clarity
- **Elapsed time uses calendar days** -- "yesterday" and "Nd ago" now reflect actual calendar days rather than rolling 24/48h windows. A chore done Friday evening correctly shows "3d ago" on Monday.