### PR TITLE
Fix missing translation key for add-subcategory button

### DIFF
--- a/src/components/CategorySection/CategorySection.tsx
+++ b/src/components/CategorySection/CategorySection.tsx
@@ -515,8 +515,8 @@ export function CategorySection({
               <button
                 onClick={() => setAddingSubcategory(true)}
                 className="p-1.5 rounded-lg text-slate-400 dark:text-slate-500 hover:text-green-400 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
-                aria-label={t('categorySection.addSubcategory')}
-                title={t('categorySection.addSubcategory')}
+                aria-label={t('categoryForm.addSubcategory')}
+                title={t('categoryForm.addSubcategory')}
               >
                 <FolderPlus size={13} />
               </button>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `categorySection.addSubcategory` was referenced in `CategorySection.tsx` (lines 518–519) but did not exist in `translation.json`
- Pointed both `aria-label` and `title` to the correct existing key `categoryForm.addSubcategory`, which already has translations in both EN and FR
- No new translation keys needed; no string duplication

## Test plan

- [ ] In edit mode, hover the "add subcategory" button — tooltip should read "Add subcategory" (not the raw key string)
- [ ] Switch locale to French — tooltip should read "Ajouter une sous-catégorie"
- [ ] Screen reader announces the button label correctly
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017gkpEkhrAjjAAioAXDb6U4)_