### PR TITLE
v1.7.0 — multi-language support, Koofr/Nextcloud sync providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.6.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.7.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -295,7 +295,8 @@
     "syncFailed": "Sync fehlgeschlagen",
     "lastSynced": "Zuletzt synchronisiert: {{date}}",
     "neverSynced": "Nie",
-    "saveClose": "Speichern & Schließen"
+    "saveClose": "Speichern & Schließen",
+    "provider": "Anbieter"
   },
   "users": {
     "title": "Benutzer",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -295,7 +295,8 @@
     "syncFailed": "Sync failed",
     "lastSynced": "Last synced: {{date}}",
     "neverSynced": "Never",
-    "saveClose": "Save & Close"
+    "saveClose": "Save & Close",
+    "provider": "Provider"
   },
   "users": {
     "title": "Users",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -295,7 +295,8 @@
     "syncFailed": "Error en la sincronización",
     "lastSynced": "Última sincronización: {{date}}",
     "neverSynced": "Nunca",
-    "saveClose": "Guardar y cerrar"
+    "saveClose": "Guardar y cerrar",
+    "provider": "Proveedor"
   },
   "users": {
     "title": "Usuarios",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -295,7 +295,8 @@
     "syncFailed": "Échec de la sync",
     "lastSynced": "Dernière sync : {{date}}",
     "neverSynced": "Jamais",
-    "saveClose": "Enregistrer & Fermer"
+    "saveClose": "Enregistrer & Fermer",
+    "provider": "Fournisseur"
   },
   "users": {
     "title": "Utilisateurs",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -295,7 +295,8 @@
     "syncFailed": "Sincronizzazione fallita",
     "lastSynced": "Ultima sincronizzazione: {{date}}",
     "neverSynced": "Mai",
-    "saveClose": "Salva e chiudi"
+    "saveClose": "Salva e chiudi",
+    "provider": "Provider"
   },
   "users": {
     "title": "Utenti",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -295,7 +295,8 @@
     "syncFailed": "Sincronização falhada",
     "lastSynced": "Última sincronização: {{date}}",
     "neverSynced": "Nunca",
-    "saveClose": "Guardar e fechar"
+    "saveClose": "Guardar e fechar",
+    "provider": "Fornecedor"
   },
   "users": {
     "title": "Utilizadores",

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { X, Loader, AlertTriangle, CheckCircle, XCircle } from 'lucide-react'
 import type { SyncEngine } from '@glance-apps/sync'
 import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, DEFAULT_SYNC_FOLDER, SYNC_FOLDER_KEY } from '@/sync/engine'
+import { cloudSyncProviders } from '@/utils/cloudSyncProviders'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from 'react-i18next'
 
@@ -14,36 +15,22 @@ interface Props {
 type TestStatus = 'idle' | 'testing' | 'ok' | 'fail'
 type SyncResult = 'idle' | 'ok' | 'error'
 
-function splitWebdavUrl(fullUrl: string, folderPath: string): { serverUrl: string } {
-  if (!fullUrl) return { serverUrl: '' }
-  try {
-    const url = new URL(fullUrl)
-    const folder = folderPath.replace(/^\//, '').replace(/\/+$/, '')
-    const cleanPath = url.pathname.replace(/\/+$/, '')
-    if (folder && cleanPath.endsWith('/' + folder)) {
-      url.pathname = cleanPath.slice(0, -(folder.length + 1)) + '/'
-    }
-    return { serverUrl: url.toString() }
-  } catch {
-    return { serverUrl: fullUrl }
-  }
-}
-
-function buildWebdavUrl(serverUrl: string): string {
-  return serverUrl.replace(/\/+$/, '')
-}
-
 export function SyncSettingsModal({ engine, onClose }: Props) {
   const { t } = useTranslation()
   const existingConfig = engine?.getConfig() ?? null
   const initFolder = localStorage.getItem(SYNC_FOLDER_KEY) ?? DEFAULT_SYNC_FOLDER
-  const { serverUrl: initServer } = splitWebdavUrl((existingConfig?.webdavUrl as string) ?? '', initFolder)
 
-  const [serverUrl, setServerUrl] = useState(() => initServer)
+  const [provider, setProvider] = useState<string>(() => (existingConfig?.provider as string) ?? 'nextcloud')
+  const [formData, setFormData] = useState<Record<string, string>>(() => {
+    const initial: Record<string, string> = {}
+    Object.values(cloudSyncProviders).forEach(p => {
+      p.configFields.forEach(f => { initial[f.key] = (existingConfig?.[f.key] as string) ?? '' })
+    })
+    return initial
+  })
+
   const [folderPath, setFolderPath] = useState(() => initFolder)
   const originalFolder = useRef(initFolder)
-  const [username, setUsername] = useState(() => (existingConfig?.username as string) ?? '')
-  const [appPassword, setAppPassword] = useState(() => (existingConfig?.appPassword as string) ?? '')
 
   const [testStatus, setTestStatus] = useState<TestStatus>('idle')
   const [testError, setTestError] = useState('')
@@ -64,10 +51,12 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
 
   const halted = engine?.isHardStopped() ?? false
 
+  const activeProvider = cloudSyncProviders[provider]
+  const requiredFieldsFilled = activeProvider?.configFields.every(f => formData[f.key]) ?? false
+
   function saveConfig() {
     if (!engine) return
-    const webdavUrl = buildWebdavUrl(serverUrl)
-    engine.setConfig(serverUrl.trim() ? { provider: 'webdav', webdavUrl, username, appPassword, enabled: true, encryptionEnabled: encEnabled } : null)
+    engine.setConfig(requiredFieldsFilled ? { provider, ...formData, syncFolder: folderPath, enabled: true, encryptionEnabled: encEnabled } : null)
     localStorage.setItem(SYNC_FOLDER_KEY, folderPath)
     resetEnsuredFolder()
     if (folderPath !== originalFolder.current) {
@@ -83,12 +72,11 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
   useEscapeKey(handleClose)
 
   async function handleTest() {
-    if (!engine || !serverUrl) return
+    if (!engine || !requiredFieldsFilled) return
     setTestStatus('testing')
     setTestError('')
     try {
-      const webdavUrl = buildWebdavUrl(serverUrl)
-      const result = await engine.test({ provider: 'webdav', webdavUrl, username, appPassword })
+      const result = await engine.test({ provider, ...formData })
       if (result.success) {
         setTestStatus('ok')
       } else {
@@ -219,19 +207,37 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
 
             <div>
               <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
-                {t('sync.serverUrlLabel')}
+                {t('sync.provider')}
               </label>
-              <input
-                type="url"
-                value={serverUrl}
-                onChange={e => setServerUrl(e.target.value)}
-                placeholder="https://your-server.com/"
-                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
-              />
-              <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
-                {t('sync.nextcloudHint')}
-              </p>
+              <select
+                value={provider}
+                onChange={e => { setProvider(e.target.value); setTestStatus('idle'); setTestError('') }}
+                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+              >
+                {Object.entries(cloudSyncProviders).map(([key, p]) => (
+                  <option key={key} value={key}>{p.name}</option>
+                ))}
+              </select>
             </div>
+
+            {activeProvider?.configFields.map(field => (
+              <div key={field.key}>
+                <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+                  {field.label}
+                </label>
+                <input
+                  type={field.type}
+                  value={formData[field.key] ?? ''}
+                  onChange={e => setFormData(prev => ({ ...prev, [field.key]: e.target.value }))}
+                  placeholder={field.placeholder}
+                  autoComplete={field.type === 'password' ? 'current-password' : field.key === 'username' ? 'username' : 'off'}
+                  className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                />
+                {field.type === 'password' && (
+                  <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">{t('sync.passwordHint')}</p>
+                )}
+              </div>
+            ))}
 
             <div>
               <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
@@ -249,39 +255,14 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
               </p>
             </div>
 
-            <div>
-              <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
-                {t('sync.username')}
-              </label>
-              <input
-                type="text"
-                value={username}
-                onChange={e => setUsername(e.target.value)}
-                placeholder={t('sync.usernamePlaceholder')}
-                autoComplete="username"
-                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
-              />
-            </div>
-
-            <div>
-              <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
-                {t('sync.password')}
-              </label>
-              <input
-                type="password"
-                value={appPassword}
-                onChange={e => setAppPassword(e.target.value)}
-                placeholder={t('sync.passwordPlaceholder')}
-                autoComplete="current-password"
-                className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
-              />
-              <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">{t('sync.passwordHint')}</p>
-            </div>
+            {activeProvider?.helpText && (
+              <p className="text-xs text-slate-400 dark:text-slate-500">{activeProvider.helpText}</p>
+            )}
 
             <div className="flex items-center gap-3 pt-1">
               <button
                 onClick={handleTest}
-                disabled={testStatus === 'testing' || !serverUrl}
+                disabled={testStatus === 'testing' || !requiredFieldsFilled}
                 className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-40 transition-colors"
               >
                 {testStatus === 'testing' && <Loader size={12} className="animate-spin" />}

--- a/src/utils/cloudSyncProviders.ts
+++ b/src/utils/cloudSyncProviders.ts
@@ -1,0 +1,17 @@
+import { createProviders } from '@glance-apps/sync'
+import type { SyncEngineConfig } from '@glance-apps/sync'
+
+// createProviders only uses the transport/crypto subset of SyncEngineConfig;
+// the data lifecycle callbacks are engine-only concerns.
+const lastGlanceEngineConfig = {
+  appFolderName: 'GLANCE/lastglance',
+  syncFilename: 'lastglance-sync.json',
+  cryptoDBName: 'lastglance-crypto',
+  nativeHttpRequest: null,
+  electronProxyFetch: null,
+  proxyUrl: import.meta.env.VITE_WEBDAV_PROXY_URL ?? '',
+  nativeGetSyncKey: null,
+  nativeStoreSyncKey: null,
+} as unknown as SyncEngineConfig
+
+export const cloudSyncProviders = createProviders(lastGlanceEngineConfig)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **4 new UI languages** (DE, ES, IT, PT) — 352 keys each, registered in `i18n.ts`; language detection order updated to honour `localStorage` so manual selection persists (merged from #99)
- **Fix missing translation key** for add-subcategory button tooltip — was referencing `categorySection.addSubcategory` (nonexistent); corrected to `categoryForm.addSubcategory` (merged from #98)
- **Koofr and Nextcloud sync providers** — replaces the single hardcoded WebDAV form with a provider picker driven by `createProviders` from `@glance-apps/sync`, matching the pattern used in dayGLANCE and lifeGLANCE. Koofr now shows email + app password only (URL hardcoded in package) and surfaces a clear error when blocked rather than failing silently. Fixes #100.
- **Version bump** to 1.7.0 in `package.json`, `package-lock.json`, and README badge

## Test plan

- [ ] Open sync settings on a fresh install — provider picker shows Nextcloud/WebDAV, Koofr, Generic WebDAV
- [ ] Existing WebDAV config loads correctly with Generic WebDAV pre-selected and credentials pre-filled
- [ ] Koofr: enter email + app password, hit Test — should succeed or return a meaningful error (no silent failure)
- [ ] Nextcloud: enter server URL + credentials, hit Test — connects successfully
- [ ] Switch UI language to DE/ES/IT/PT — all strings translate; switching back to EN/FR still works
- [ ] Add-subcategory button tooltip renders correctly in all languages (not the raw key string)
- [ ] Sync Now works end-to-end for each provider

https://claude.ai/code/session_01MpdzGhKKX2woaebivp5qvz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpdzGhKKX2woaebivp5qvz)_