### PR TITLE
Phase 4: cut over sync to GLANCEvault DB transport (additive, behind toggle)

### DIFF
--- a/PHASE4_TESTING.md
+++ b/PHASE4_TESTING.md
@@ -1,0 +1,111 @@
+# Phase 4 Testing: GLANCEvault database transport
+
+This document covers manual verification of the GLANCEvault (DB) sync transport
+that was wired into lastGLANCE in Phase 4. The transport is additive and
+reversible: it runs alongside the existing file tier (WebDAV) engine and is
+gated entirely by the vault config. With the vault disabled, the app behaves
+exactly as before.
+
+## What is automated
+
+The unit tests (run with `npm test`) cover the parts that do not need a live
+vault:
+
+1. `getDeviceId` returns a stable UUID across calls and generates a fresh one
+   when none is stored (`src/sync/deviceId.test.ts`).
+2. `getLocalEntity` looks up entities across all four Dexie tables
+   (categories, chores, completionEvents, users) by `sync_id` and returns the
+   camelCase sync shape, including resolving a completion event's `choreSyncId`
+   (`src/sync/dbEngine.test.ts`).
+3. `isInsertOnly` returns true only for completion events
+   (`src/sync/dbEngine.test.ts`).
+4. `getEntityLastModified` returns `updatedAt` for categories, chores, and
+   users, and `completedAt` for completion events (`src/sync/dbEngine.test.ts`).
+5. The vault config is saved to and loaded from localStorage, treats
+   disabled/incomplete configs as not enabled, and tolerates malformed JSON
+   (`src/sync/vaultConfig.test.ts`).
+
+## What needs a running GLANCEvault
+
+Entity push, pull, per entity encryption, salt registration, and the device
+cursor cannot be exercised without a live vault. Use the steps below against a
+running GLANCEvault instance.
+
+### Prerequisites
+
+- A running GLANCEvault instance reachable from the browser (its URL).
+- A device bearer token and a household account id provisioned in the vault.
+- Two browsers or profiles (call them Device A and Device B) so you can observe
+  cross device sync.
+
+### 1. Enable the vault on Device A
+
+1. Open lastGLANCE, open the Cloud Sync settings (the cloud icon, or press `s`).
+2. Scroll to the "GLANCEvault (beta)" section and turn the toggle on.
+3. Fill in:
+   - Vault URL, for example `https://vault.glance-apps.com`
+   - Device token (the bearer token)
+   - Account ID (the household account id)
+4. Make sure encryption is enabled and that you have set your sync passphrase
+   (the DB transport derives its root key from the same passphrase as the file
+   tier). If you have not set a passphrase yet, enable encryption in the
+   Encryption section and choose one.
+5. Close the settings modal. The app reloads to construct the DB engine.
+
+### 2. Make a change and confirm it reaches the vault
+
+1. After the reload, create or complete a chore (any local write: add a
+   category, add a chore, log a completion, rename a user).
+2. The change is marked dirty and pushed on the next DB sync cycle (which fires
+   on load, on tab focus, and every 5 minutes). To force it immediately, switch
+   to another tab and back, or wait for the interval.
+3. Verify the row landed in the vault:
+
+   ```
+   curl -s \
+     -H "Authorization: Bearer $VAULT_TOKEN" \
+     "$VAULT_URL/sync/lastglance/list?accountId=$ACCOUNT_ID&since=0"
+   ```
+
+   You should see one row per changed entity, each with an `entityId` matching
+   the entity's `sync_id`, a `seq`, and an opaque `ciphertext` (the data is
+   encrypted per entity, so the body is not human readable). Deletions appear as
+   rows with `deleted: true`.
+
+### 3. Sync back to a second device
+
+1. On Device B, enable the vault with the SAME Vault URL, account id, and a
+   device token for that device, and enter the SAME sync passphrase.
+2. Close settings (the app reloads). On the next DB sync cycle Device B pulls
+   from `since = 0` and applies the remote rows.
+3. Confirm the entity you created on Device A now appears on Device B.
+4. Make a change on Device B (for example rename the chore), let it push, then
+   switch back to Device A and confirm the change syncs in. This exercises the
+   entity grain last writer wins path (`updatedAt` / `completedAt` decides the
+   winner).
+
+### 4. Verify deletions propagate
+
+1. Delete a chore on Device A. This writes a local tombstone and marks the
+   entity dirty; because the row no longer exists locally, the push sends a soft
+   delete to the vault.
+2. Confirm with the `list` curl above that the entity now shows `deleted: true`.
+3. On Device B, after the next cycle, confirm the chore is gone.
+
+### 5. Confirm the file tier is unaffected
+
+1. Keep WebDAV sync configured as well. Make a change and confirm it still syncs
+   over WebDAV exactly as before (check the sync folder file timestamp).
+2. Turn the GLANCEvault toggle off and close settings (the app reloads). Confirm
+   the app reverts to file only sync with no errors. Re-enabling restores DB
+   sync.
+
+## Notes and limitations
+
+- Completion events are insert only in both transports: an edited note does not
+  overwrite an event that already exists on another device. This matches the
+  file tier behavior.
+- The DB engine never reads or writes the WebDAV sync file; the two transports
+  share only the local Dexie data and the sync passphrase.
+- The `meUserSyncId` device identity is never synced by either transport; it is
+  not part of any entity's sync shape.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "^1.1.3",
+        "@glance-apps/sync": "1.2.0",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -28,6 +28,7 @@
         "@vitest/coverage-v8": "^4.1.7",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.20.0",
+        "fake-indexeddb": "^6.2.5",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
@@ -2231,9 +2232,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.1.3.tgz",
-      "integrity": "sha512-tvtaGlRFILVwX+6LG29omq2e1SCuegLQsfo3kpZwCSgwivE7TNZLE6Hnh88CZdcnUerdKHFQn0LsWbz/8uqoJA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.2.0.tgz",
+      "integrity": "sha512-Iq370ZJ/b6d+es8hhEouxPPsuAydryhDQMSCSwl0WYCTRPkYCiL091o4mjAuQP9p0GAuua0VOnN3RLfC6FDTsw==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {
@@ -4457,6 +4458,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "^1.1.3",
+    "@glance-apps/sync": "1.2.0",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",
@@ -31,6 +31,7 @@
     "@vitest/coverage-v8": "^4.1.7",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.20.0",
+    "fake-indexeddb": "^6.2.5",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,9 @@ import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
 import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
-import type { SyncEngine, SyncStatus } from '@glance-apps/sync'
+import { createDbEngine } from '@/sync/dbEngine'
+import { registerDbEngine } from '@/sync/dirtyTracker'
+import type { SyncEngine, SyncStatus, DbSyncEngine } from '@glance-apps/sync'
 import { syncSharedUsers } from '@/multiuser/sharedUsers'
 import { getUsersPath, getMultiUserEnabled } from '@/multiuser/settings'
 import dayjs from 'dayjs'
@@ -137,9 +139,20 @@ function AppInner() {
 
   // Sync engine
   const engineRef = useRef<SyncEngine | null>(null)
+  // GLANCEvault DB transport engine, null unless the vault config is enabled.
+  // Runs alongside the file engine; does not affect the file sync path.
+  const dbEngineRef = useRef<DbSyncEngine | null>(null)
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
   const [syncError, setSyncError] = useState<string | null>(null)
   const [syncHalted, setSyncHalted] = useState(false)
+
+  // Runs one DB sync cycle when the vault transport is enabled. No-op otherwise.
+  // Fired on the same triggers as the file engine; errors are surfaced through
+  // the engine's onError callback (logged, non-fatal to the file tier).
+  const runDbSync = useCallback(() => {
+    const eng = dbEngineRef.current
+    if (eng) eng.dbSyncCycle().catch(() => {/* surfaced via onError */})
+  }, [])
 
   useEffect(() => {
     document.documentElement.classList.toggle('dark', isDark)
@@ -166,12 +179,24 @@ function AppInner() {
       onPassphraseRequired: () => setShowPassphrase(true),
     })
     engineRef.current = engine
+
+    // Construct the DB transport engine alongside the file engine when the vault
+    // is enabled. It shares the local data but uses an entirely separate cycle.
+    const dbEngine = createDbEngine({
+      onError: (msg) => { if (msg) console.warn('[lastglance] vault sync error:', msg) },
+    })
+    dbEngineRef.current = dbEngine
+    registerDbEngine(dbEngine)
+
     deduplicateUsers()
       .catch(() => {})
       .then(() => ensureSyncFolder(engine))
       .then(() => engine.sync())
       .catch(() => {/* errors surfaced via onError */})
-  }, [])
+    runDbSync()
+
+    return () => { registerDbEngine(null) }
+  }, [runDbSync])
 
   // Shared user roster sync — fire-and-forget, non-fatal
   const sharedUserSyncRunning = useRef(false)
@@ -213,6 +238,7 @@ function AppInner() {
       if (document.visibilityState === 'visible' && engineRef.current) {
         const eng = engineRef.current
         ensureSyncFolder(eng).then(() => eng.sync()).catch(() => {/* errors surfaced via onError */})
+        runDbSync()
       }
     }
     document.addEventListener('visibilitychange', handleVisibility)
@@ -222,13 +248,14 @@ function AppInner() {
         const eng = engineRef.current
         ensureSyncFolder(eng).then(() => eng.sync()).catch(() => {/* errors surfaced via onError */})
       }
+      runDbSync()
     }, 5 * 60 * 1000)
 
     return () => {
       document.removeEventListener('visibilitychange', handleVisibility)
       clearInterval(interval)
     }
-  }, [])
+  }, [runDbSync])
 
   const loadHeatmap = useCallback(async () => {
     const counts = await getAllCompletionCounts()
@@ -503,6 +530,15 @@ function AppInner() {
             if (engineRef.current) {
               const eng = engineRef.current
               ensureSyncFolder(eng).then(() => eng.sync()).catch(() => {/* errors surfaced via onError */})
+            }
+            // The DB engine derives its root key from the same passphrase (now
+            // cached in the sync session). ensureRootKey fetches or registers the
+            // per-account salt with the vault automatically on first use.
+            const dbEng = dbEngineRef.current
+            if (dbEng) {
+              dbEng.ensureRootKey()
+                .then(() => dbEng.dbSyncCycle())
+                .catch((err) => console.warn('[lastglance] vault root key setup failed:', err))
             }
           }}
           onClose={() => setShowPassphrase(false)}

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -418,11 +418,14 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
             <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
               GLANCEvault (beta)
             </h3>
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              ⚠️ Experimental. Requires a self-hosted GLANCEvault server. Not recommended for most users.
+            </p>
             <div className="flex items-center justify-between py-1">
               <div>
                 <p className="text-sm text-slate-700 dark:text-slate-300">Sync via GLANCEvault</p>
                 <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
-                  Row-grained database sync. Runs alongside WebDAV sync.
+                  Row-grained database sync. Runs alongside your existing WebDAV sync. Your WebDAV data is never modified.
                 </p>
               </div>
               <button

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { X, Loader, AlertTriangle, CheckCircle, XCircle } from 'lucide-react'
 import type { SyncEngine } from '@glance-apps/sync'
 import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, DEFAULT_SYNC_FOLDER, SYNC_FOLDER_KEY } from '@/sync/engine'
+import { getVaultConfig, setVaultConfig } from '@/sync/vaultConfig'
 import { cloudSyncProviders } from '@/utils/cloudSyncProviders'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from 'react-i18next'
@@ -44,6 +45,14 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
 
   const [remoteBackupsEnabled, setRemoteBackupsEnabledState] = useState(() => getRemoteBackupsEnabled())
 
+  // GLANCEvault (beta) DB transport config. Stored separately from the WebDAV
+  // config; enabling it makes the app build a DB engine alongside the file one.
+  const initVault = useRef(getVaultConfig())
+  const [vaultEnabled, setVaultEnabled] = useState(() => initVault.current?.enabled ?? false)
+  const [vaultUrl, setVaultUrl] = useState(() => initVault.current?.vaultUrl ?? '')
+  const [vaultToken, setVaultToken] = useState(() => initVault.current?.vaultToken ?? '')
+  const [vaultAccountId, setVaultAccountId] = useState(() => initVault.current?.accountId ?? '')
+
   const [syncing, setSyncing] = useState(false)
   const [syncResult, setSyncResult] = useState<SyncResult>('idle')
   const [syncResultMsg, setSyncResultMsg] = useState('')
@@ -55,11 +64,27 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
   const requiredFieldsFilled = activeProvider?.configFields.every(f => formData[f.key]) ?? false
 
   function saveConfig() {
-    if (!engine) return
-    engine.setConfig(requiredFieldsFilled ? { provider, ...formData, syncFolder: folderPath, enabled: true, encryptionEnabled: encEnabled } : null)
-    localStorage.setItem(SYNC_FOLDER_KEY, folderPath)
-    resetEnsuredFolder()
-    if (folderPath !== originalFolder.current) {
+    // GLANCEvault config is independent of the file engine: only saved when the
+    // toggle is on, cleared (reverting to file tier) when off.
+    const prevVault = initVault.current
+    const nextVault = vaultEnabled
+      ? { enabled: true, vaultUrl: vaultUrl.trim(), vaultToken: vaultToken.trim(), accountId: vaultAccountId.trim() }
+      : null
+    setVaultConfig(nextVault)
+    const vaultChanged =
+      (prevVault?.enabled ?? false) !== (nextVault?.enabled ?? false) ||
+      (prevVault?.vaultUrl ?? '') !== (nextVault?.vaultUrl ?? '') ||
+      (prevVault?.vaultToken ?? '') !== (nextVault?.vaultToken ?? '') ||
+      (prevVault?.accountId ?? '') !== (nextVault?.accountId ?? '')
+
+    if (engine) {
+      engine.setConfig(requiredFieldsFilled ? { provider, ...formData, syncFolder: folderPath, enabled: true, encryptionEnabled: encEnabled } : null)
+      localStorage.setItem(SYNC_FOLDER_KEY, folderPath)
+      resetEnsuredFolder()
+    }
+    // A folder change or any vault change requires a reload so the engines are
+    // reconstructed with the new transport config on next mount.
+    if (folderPath !== originalFolder.current || vaultChanged) {
       window.location.reload()
     }
   }
@@ -386,6 +411,77 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
                 <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${remoteBackupsEnabled ? 'translate-x-4' : ''}`} />
               </button>
             </div>
+          </div>
+
+          {/* GLANCEvault (beta) section */}
+          <div className="space-y-3">
+            <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+              GLANCEvault (beta)
+            </h3>
+            <div className="flex items-center justify-between py-1">
+              <div>
+                <p className="text-sm text-slate-700 dark:text-slate-300">Sync via GLANCEvault</p>
+                <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+                  Row-grained database sync. Runs alongside WebDAV sync.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setVaultEnabled(v => !v)}
+                className={`relative w-10 h-6 rounded-full transition-colors ${vaultEnabled ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
+                aria-checked={vaultEnabled}
+                role="switch"
+              >
+                <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${vaultEnabled ? 'translate-x-4' : ''}`} />
+              </button>
+            </div>
+
+            {vaultEnabled && (
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+                    Vault URL
+                  </label>
+                  <input
+                    type="text"
+                    value={vaultUrl}
+                    onChange={e => setVaultUrl(e.target.value)}
+                    placeholder="https://vault.glance-apps.com"
+                    autoComplete="off"
+                    className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+                    Device token
+                  </label>
+                  <input
+                    type="password"
+                    value={vaultToken}
+                    onChange={e => setVaultToken(e.target.value)}
+                    placeholder="Bearer token"
+                    autoComplete="off"
+                    className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
+                    Account ID
+                  </label>
+                  <input
+                    type="text"
+                    value={vaultAccountId}
+                    onChange={e => setVaultAccountId(e.target.value)}
+                    placeholder="Household account id"
+                    autoComplete="off"
+                    className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                  />
+                </div>
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  Saved on close. The app reloads to apply vault changes. Uses your sync passphrase for encryption.
+                </p>
+              </div>
+            )}
           </div>
 
           {/* Manual sync section */}

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,5 +1,6 @@
 import { db, SEED_CAT_SYNC_IDS, SEED_CHORE_SYNC_IDS } from './client'
 import type { Category, Chore, ChoreWithLastCompletion, CompletionEvent, User } from '@/types'
+import { markDirty, markDeleted } from '@/sync/dirtyTracker'
 import dayjs from 'dayjs'
 
 // Tombstone helpers
@@ -27,16 +28,19 @@ export async function createCategory(
     const parent = await db.categories.get(parent_category_id)
     parent_sync_id = parent?.sync_id ?? null
   }
-  return db.categories.add({
+  const sync_id = crypto.randomUUID()
+  const id = await db.categories.add({
     name,
     sort_order: order,
     icon,
     parent_category_id,
-    sync_id: crypto.randomUUID(),
+    sync_id,
     parent_sync_id,
     assigned_user_sync_ids,
     updated_at: new Date().toISOString(),
   } as Category)
+  markDirty(sync_id)
+  return id
 }
 
 export async function updateCategory(id: number, fields: { name?: string; icon?: string; parent_category_id?: number | null; assigned_user_sync_ids?: string[] }): Promise<void> {
@@ -67,6 +71,8 @@ export async function updateCategory(id: number, fields: { name?: string; icon?:
     // Nothing to update but stamp the timestamp anyway
     await db.categories.update(id, { updated_at })
   }
+  const cat = await db.categories.get(id)
+  markDirty(cat?.sync_id)
 }
 
 export async function getAllCompletionCounts(): Promise<Map<string, number>> {
@@ -80,6 +86,7 @@ export async function getAllCompletionCounts(): Promise<Map<string, number>> {
 }
 
 export async function deleteCategory(id: number): Promise<void> {
+  let deletedSyncIds: string[] = []
   await db.transaction('rw', db.categories, db.chores, db.completionEvents, db.tombstones, async () => {
     const subcats = await db.categories.where('parent_category_id').equals(id).toArray()
     const catIds = [id, ...subcats.map(c => c.id!)]
@@ -110,7 +117,9 @@ export async function deleteCategory(id: number): Promise<void> {
     if (allSyncIds.length > 0) {
       await db.tombstones.bulkPut(allSyncIds.map(sid => ({ id: sid, deleted_at: now })))
     }
+    deletedSyncIds = allSyncIds
   })
+  for (const sid of deletedSyncIds) markDeleted(sid)
 }
 
 // Chores
@@ -146,26 +155,33 @@ export async function createChore(
   const count = await db.chores.where('category_id').equals(data.category_id).count()
   const cat = await db.categories.get(data.category_id)
   const category_sync_id = cat?.sync_id ?? null
-  return db.chores.add({
+  const sync_id = crypto.randomUUID()
+  const id = await db.chores.add({
     ...data,
     sort_order: count,
     created_at: now,
     updated_at: now,
-    sync_id: crypto.randomUUID(),
+    sync_id,
     category_sync_id,
   } as Chore)
+  markDirty(sync_id)
+  return id
 }
 
 export async function reorderChores(orderedIds: number[]): Promise<void> {
   await db.transaction('rw', db.chores, () =>
     Promise.all(orderedIds.map((id, idx) => db.chores.update(id, { sort_order: idx, updated_at: dayjs().toISOString() })))
   )
+  const chores = await db.chores.bulkGet(orderedIds)
+  for (const c of chores) markDirty(c?.sync_id)
 }
 
 export async function reorderCategories(orderedIds: number[]): Promise<void> {
   await db.transaction('rw', db.categories, () =>
     Promise.all(orderedIds.map((id, idx) => db.categories.update(id, { sort_order: idx, updated_at: dayjs().toISOString() })))
   )
+  const categories = await db.categories.bulkGet(orderedIds)
+  for (const c of categories) markDirty(c?.sync_id)
 }
 
 export async function updateChore(
@@ -178,9 +194,12 @@ export async function updateChore(
     extra = { category_sync_id: cat?.sync_id ?? null }
   }
   await db.chores.update(id, { ...data, ...extra, updated_at: dayjs().toISOString() })
+  const chore = await db.chores.get(id)
+  markDirty(chore?.sync_id)
 }
 
 export async function deleteChore(id: number): Promise<void> {
+  let deletedSyncIds: string[] = []
   await db.transaction('rw', db.chores, db.completionEvents, db.tombstones, async () => {
     const chore = await db.chores.get(id)
     const evts = await db.completionEvents.where('chore_id').equals(id).toArray()
@@ -197,7 +216,9 @@ export async function deleteChore(id: number): Promise<void> {
     if (syncIds.length > 0) {
       await db.tombstones.bulkPut(syncIds.map(sid => ({ id: sid, deleted_at: now })))
     }
+    deletedSyncIds = syncIds
   })
+  for (const sid of deletedSyncIds) markDeleted(sid)
 }
 
 // Completion events
@@ -206,14 +227,18 @@ export async function logCompletion(
   choreId: number,
   opts: { note?: string; completedAt?: string; source?: 'manual' | 'dayglance'; completedByUserSyncId?: string | null; syncId?: string } = {}
 ): Promise<number> {
-  return db.completionEvents.add({
+  const sync_id = opts.syncId ?? crypto.randomUUID()
+  const id = await db.completionEvents.add({
     chore_id: choreId,
     completed_at: opts.completedAt ?? dayjs().toISOString(),
     note: opts.note ?? null,
     source: opts.source ?? 'manual',
     completed_by_user_sync_id: opts.completedByUserSyncId ?? null,
-    sync_id: opts.syncId ?? crypto.randomUUID(),
+    sync_id,
   } as CompletionEvent)
+  // Completion events are insert-only: mark dirty at creation time.
+  markDirty(sync_id)
+  return id
 }
 
 export async function getCompletionHistory(
@@ -229,6 +254,8 @@ export async function getCompletionHistory(
 
 export async function updateCompletionNote(id: number, note: string | null): Promise<void> {
   await db.completionEvents.update(id, { note: note || null })
+  const evt = await db.completionEvents.get(id)
+  markDirty(evt?.sync_id)
 }
 
 export async function deleteCompletion(id: number): Promise<void> {
@@ -236,6 +263,7 @@ export async function deleteCompletion(id: number): Promise<void> {
   await db.completionEvents.delete(id)
   if (evt?.sync_id) {
     await writeTombstone(evt.sync_id)
+    markDeleted(evt.sync_id)
   }
 }
 
@@ -248,25 +276,33 @@ export async function getUsers(): Promise<User[]> {
 
 export async function createUser(name: string, syncId?: string): Promise<number> {
   const now = new Date().toISOString()
-  return db.users.add({
+  const sync_id = syncId ?? crypto.randomUUID()
+  const id = await db.users.add({
     name,
-    sync_id: syncId ?? crypto.randomUUID(),
+    sync_id,
     updated_at: now,
   } as User)
+  markDirty(sync_id)
+  return id
 }
 
 export async function updateUser(id: number, fields: { name: string }): Promise<void> {
   await db.users.update(id, { ...fields, updated_at: new Date().toISOString() })
+  const user = await db.users.get(id)
+  markDirty(user?.sync_id)
 }
 
 export async function deleteUser(id: number): Promise<void> {
+  let deletedSyncId: string | undefined
   await db.transaction('rw', db.users, db.tombstones, async () => {
     const user = await db.users.get(id)
     await db.users.delete(id)
     if (user?.sync_id) {
       await writeTombstone(user.sync_id)
+      deletedSyncId = user.sync_id
     }
   })
+  markDeleted(deletedSyncId)
 }
 
 // Removes duplicate user rows that share the same sync_id, keeping the one
@@ -341,6 +377,7 @@ function validateBackupPayload(payload: BackupPayload): void {
 
 export async function importBackup(payload: BackupPayload): Promise<void> {
   validateBackupPayload(payload)
+  let restoredSyncIds: string[] = []
   await db.transaction('rw', db.categories, db.chores, db.completionEvents, db.tombstones, async () => {
     await db.completionEvents.clear()
     await db.chores.clear()
@@ -367,7 +404,15 @@ export async function importBackup(payload: BackupPayload): Promise<void> {
     await db.categories.bulkAdd(categories)
     await db.chores.bulkAdd(chores)
     await db.completionEvents.bulkAdd(completionEvents)
+    restoredSyncIds = [
+      ...categories.map(c => c.sync_id),
+      ...chores.map(c => c.sync_id),
+      ...completionEvents.map(e => e.sync_id),
+    ]
   })
+  // A restore replaces local data wholesale; push every restored entity so the
+  // vault reflects it on the next cycle.
+  for (const sid of restoredSyncIds) markDirty(sid)
 }
 
 // ── Seed data helpers ─────────────────────────────────────────────────────────

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -255,6 +255,10 @@ export async function getCompletionHistory(
 export async function updateCompletionNote(id: number, note: string | null): Promise<void> {
   await db.completionEvents.update(id, { note: note || null })
   const evt = await db.completionEvents.get(id)
+  // Pushes the updated ciphertext for this event to the vault, so a fresh device
+  // that has never seen the event receives the latest note on its first pull.
+  // Devices that already hold the event keep their own copy: completion events
+  // are insert-only, and applyRemoteEntity skips events already present locally.
   markDirty(evt?.sync_id)
 }
 

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -1,0 +1,112 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { db } from '@/db/client'
+import {
+  getLocalEntity,
+  isInsertOnly,
+  getEntityLastModified,
+} from './dbEngine'
+import type { Category, Chore, CompletionEvent, User } from '@/types'
+
+// Stable ids for the records we seed and look up.
+const USER_ID = '11111111-1111-1111-1111-111111111111'
+const CAT_ID = '22222222-2222-2222-2222-222222222222'
+const CHORE_ID = '33333333-3333-3333-3333-333333333333'
+const EVENT_ID = '44444444-4444-4444-4444-444444444444'
+
+let choreSyncIdForEvent = ''
+
+beforeAll(async () => {
+  const userKey = await db.users.add({
+    name: 'Alice', sync_id: USER_ID, updated_at: '2026-01-01T00:00:00.000Z',
+  } as unknown as User)
+  expect(userKey).toBeTypeOf('number')
+
+  const catKey = await db.categories.add({
+    name: 'Garage', sort_order: 99, icon: 'Car', sync_id: CAT_ID,
+    parent_sync_id: null, assigned_user_sync_ids: [], updated_at: '2026-02-02T00:00:00.000Z',
+  } as unknown as Category)
+
+  const choreKey = await db.chores.add({
+    name: 'Sweep', category_id: catKey as number, category_sync_id: CAT_ID,
+    sort_order: 0, target_cadence_days: 7, notify_when_overdue: false,
+    auto_schedule_to_dayglance: false, preferred_schedule_behavior: null,
+    seasonal_start: null, seasonal_end: null, icon: 'Broom', assigned_user_sync_ids: [],
+    created_at: '2026-03-03T00:00:00.000Z', updated_at: '2026-03-04T00:00:00.000Z',
+    sync_id: CHORE_ID,
+  } as unknown as Chore)
+  const chore = await db.chores.get(choreKey as number)
+  choreSyncIdForEvent = chore!.sync_id
+
+  await db.completionEvents.add({
+    chore_id: choreKey as number, completed_at: '2026-04-04T00:00:00.000Z',
+    note: 'done', source: 'manual', completed_by_user_sync_id: null, sync_id: EVENT_ID,
+  } as unknown as CompletionEvent)
+})
+
+describe('getLocalEntity', () => {
+  it('looks up a user by sync_id', async () => {
+    const e = await getLocalEntity(USER_ID) as Record<string, unknown>
+    expect(e).not.toBeNull()
+    expect(e.id).toBe(USER_ID)
+    expect(e.name).toBe('Alice')
+    expect(e.updatedAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('looks up a category by sync_id', async () => {
+    const e = await getLocalEntity(CAT_ID) as Record<string, unknown>
+    expect(e.id).toBe(CAT_ID)
+    expect(e.name).toBe('Garage')
+    expect(e.sortOrder).toBe(99)
+    expect(e.parentId).toBeNull()
+  })
+
+  it('looks up a chore by sync_id', async () => {
+    const e = await getLocalEntity(CHORE_ID) as Record<string, unknown>
+    expect(e.id).toBe(CHORE_ID)
+    expect(e.name).toBe('Sweep')
+    expect(e.categorySyncId).toBe(CAT_ID)
+    expect(e.createdAt).toBe('2026-03-03T00:00:00.000Z')
+  })
+
+  it('looks up a completion event and resolves its choreSyncId', async () => {
+    const e = await getLocalEntity(EVENT_ID) as Record<string, unknown>
+    expect(e.id).toBe(EVENT_ID)
+    expect(e.choreSyncId).toBe(choreSyncIdForEvent)
+    expect(e.completedAt).toBe('2026-04-04T00:00:00.000Z')
+  })
+
+  it('returns null for an unknown sync_id', async () => {
+    expect(await getLocalEntity('99999999-9999-9999-9999-999999999999')).toBeNull()
+  })
+})
+
+describe('isInsertOnly', () => {
+  it('is true only for completion events', () => {
+    const evt = { id: EVENT_ID, choreSyncId: CHORE_ID, completedAt: '2026-04-04T00:00:00.000Z', note: null, source: 'manual', completedByUserSyncId: null }
+    const cat = { id: CAT_ID, name: 'Garage', sortOrder: 1, icon: undefined, parentId: null, assignedUserSyncIds: [], updatedAt: '2026-02-02T00:00:00.000Z' }
+    const chore = { id: CHORE_ID, name: 'Sweep', categorySyncId: CAT_ID, sortOrder: 0, updatedAt: '2026-03-04T00:00:00.000Z', createdAt: '2026-03-03T00:00:00.000Z' }
+    const user = { id: USER_ID, name: 'Alice', updatedAt: '2026-01-01T00:00:00.000Z' }
+
+    expect(isInsertOnly(evt)).toBe(true)
+    expect(isInsertOnly(cat)).toBe(false)
+    expect(isInsertOnly(chore)).toBe(false)
+    expect(isInsertOnly(user)).toBe(false)
+  })
+})
+
+describe('getEntityLastModified', () => {
+  it('returns completedAt for completion events', () => {
+    const evt = { id: EVENT_ID, choreSyncId: CHORE_ID, completedAt: '2026-04-04T00:00:00.000Z', note: null, source: 'manual', completedByUserSyncId: null }
+    expect(getEntityLastModified(evt)).toBe('2026-04-04T00:00:00.000Z')
+  })
+
+  it('returns updatedAt for categories, chores, and users', () => {
+    const cat = { id: CAT_ID, name: 'Garage', sortOrder: 1, parentId: null, assignedUserSyncIds: [], updatedAt: '2026-02-02T00:00:00.000Z' }
+    const chore = { id: CHORE_ID, name: 'Sweep', categorySyncId: CAT_ID, sortOrder: 0, updatedAt: '2026-03-04T00:00:00.000Z', createdAt: '2026-03-03T00:00:00.000Z' }
+    const user = { id: USER_ID, name: 'Alice', updatedAt: '2026-01-01T00:00:00.000Z' }
+    expect(getEntityLastModified(cat)).toBe('2026-02-02T00:00:00.000Z')
+    expect(getEntityLastModified(chore)).toBe('2026-03-04T00:00:00.000Z')
+    expect(getEntityLastModified(user)).toBe('2026-01-01T00:00:00.000Z')
+  })
+})

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -1,0 +1,321 @@
+// GLANCEvault database transport wiring for lastGLANCE (Phase 4 cutover).
+//
+// This constructs the row-grained DB engine from @glance-apps/sync v1.2.0 and
+// supplies the data callbacks that bridge it to the Dexie tables. It runs only
+// when the vault config is enabled, and runs ALONGSIDE the file-tier engine,
+// never replacing it. The file engine, its WebDAV payload, and its sync cycle
+// are completely untouched by this module.
+//
+// The callbacks here read and write the same camelCase sync shapes that the
+// file tier's buildPayload / applyPayload use, so a household can run either
+// transport against the same local data. Crucially, applyRemoteEntity and
+// applyRemoteDelete write to Dexie DIRECTLY (not through src/db/queries.ts), so
+// remote applies never call markDirty and cannot loop back into a push.
+
+import { createDbSyncEngine } from '@glance-apps/sync'
+import type { DbSyncEngine, SyncStatus, SyncErrorCode } from '@glance-apps/sync'
+import { db } from '@/db/client'
+import type { Category, Chore, CompletionEvent, User } from '@/types'
+import type { SyncCategory, SyncChore, SyncCompletionEvent, SyncUser } from './types'
+import { getVaultConfig, isVaultEnabled } from './vaultConfig'
+import { getDeviceId } from './deviceId'
+
+const APP_ID = 'lastglance'
+const CRYPTO_DB_NAME = 'lastglance-crypto'
+
+// ── Entity-shape helpers (pure; safe to unit test without a DB) ──────────────
+
+type EntityKind = 'category' | 'chore' | 'completionEvent' | 'user'
+
+// Determine which entity a decrypted sync shape represents. Order matters:
+// completion events and chores carry fields that uniquely identify them before
+// the broader category / user checks.
+function entityKind(entity: unknown): EntityKind | null {
+  if (!entity || typeof entity !== 'object') return null
+  const e = entity as Record<string, unknown>
+  if ('completedAt' in e || 'choreSyncId' in e) return 'completionEvent'
+  if ('categorySyncId' in e) return 'chore'
+  if ('parentId' in e || 'sortOrder' in e) return 'category'
+  if ('name' in e) return 'user'
+  return null
+}
+
+// Insert-only types never conflict on merge: completion events are immutable.
+export function isInsertOnly(entity: unknown): boolean {
+  return entityKind(entity) === 'completionEvent'
+}
+
+// Timestamp the engine compares for entity-grain last-writer-wins: updatedAt
+// for categories, chores, and users; completedAt for completion events.
+export function getEntityLastModified(entity: unknown): string | number | undefined {
+  if (!entity || typeof entity !== 'object') return undefined
+  const e = entity as Record<string, unknown>
+  if (entityKind(e) === 'completionEvent') return e.completedAt as string | undefined
+  return e.updatedAt as string | undefined
+}
+
+// ── Row -> sync shape mappings (mirror the file tier's buildPayload) ─────────
+
+function toSyncCategory(c: Category): SyncCategory {
+  return {
+    id: c.sync_id,
+    name: c.name,
+    sortOrder: c.sort_order,
+    icon: c.icon,
+    parentId: c.parent_sync_id,
+    assignedUserSyncIds: c.assigned_user_sync_ids ?? [],
+    updatedAt: c.updated_at,
+  }
+}
+
+function toSyncChore(c: Chore): SyncChore {
+  return {
+    id: c.sync_id,
+    name: c.name,
+    categorySyncId: c.category_sync_id,
+    sortOrder: c.sort_order,
+    targetCadenceDays: c.target_cadence_days,
+    notifyWhenOverdue: c.notify_when_overdue,
+    autoScheduleToDayglance: c.auto_schedule_to_dayglance,
+    preferredScheduleBehavior: c.preferred_schedule_behavior,
+    seasonalStart: c.seasonal_start ?? null,
+    seasonalEnd: c.seasonal_end ?? null,
+    icon: c.icon,
+    assignedUserSyncIds: c.assigned_user_sync_ids ?? [],
+    createdAt: c.created_at,
+    updatedAt: c.updated_at,
+  }
+}
+
+function toSyncCompletionEvent(e: CompletionEvent, choreSyncId: string): SyncCompletionEvent {
+  return {
+    id: e.sync_id,
+    choreSyncId,
+    completedAt: e.completed_at,
+    note: e.note,
+    source: e.source,
+    completedByUserSyncId: e.completed_by_user_sync_id ?? null,
+  }
+}
+
+function toSyncUser(u: User): SyncUser {
+  return { id: u.sync_id, name: u.name, updatedAt: u.updated_at }
+}
+
+// ── getLocalEntity: look up by sync_id across all four tables ─────────────────
+
+export async function getLocalEntity(entityId: string): Promise<unknown | null> {
+  const cat = await db.categories.where('sync_id').equals(entityId).first()
+  if (cat) return toSyncCategory(cat)
+
+  const chore = await db.chores.where('sync_id').equals(entityId).first()
+  if (chore) return toSyncChore(chore)
+
+  const evt = await db.completionEvents.where('sync_id').equals(entityId).first()
+  if (evt) {
+    const parent = await db.chores.get(evt.chore_id)
+    return toSyncCompletionEvent(evt, parent?.sync_id ?? '')
+  }
+
+  const user = await db.users.where('sync_id').equals(entityId).first()
+  if (user) return toSyncUser(user)
+
+  return null
+}
+
+// ── applyRemoteEntity: upsert a decrypted entity into the right table ────────
+
+async function applyCategory(cat: SyncCategory): Promise<void> {
+  await db.transaction('rw', db.categories, async () => {
+    let parent_category_id: number | undefined
+    if (cat.parentId) {
+      const parent = await db.categories.where('sync_id').equals(cat.parentId).first()
+      parent_category_id = parent?.id
+    }
+    const existing = await db.categories.where('sync_id').equals(cat.id).first()
+    if (existing) {
+      await db.categories.update(existing.id, {
+        name: cat.name,
+        sort_order: cat.sortOrder,
+        icon: cat.icon,
+        parent_sync_id: cat.parentId,
+        parent_category_id,
+        assigned_user_sync_ids: cat.assignedUserSyncIds ?? [],
+        updated_at: cat.updatedAt,
+      })
+    } else {
+      await db.categories.add({
+        sync_id: cat.id,
+        name: cat.name,
+        sort_order: cat.sortOrder,
+        icon: cat.icon,
+        parent_sync_id: cat.parentId,
+        parent_category_id,
+        assigned_user_sync_ids: cat.assignedUserSyncIds ?? [],
+        updated_at: cat.updatedAt,
+      } as Category)
+    }
+  })
+}
+
+async function applyChore(chore: SyncChore): Promise<void> {
+  await db.transaction('rw', db.chores, db.categories, async () => {
+    const cat = chore.categorySyncId
+      ? await db.categories.where('sync_id').equals(chore.categorySyncId).first()
+      : undefined
+    const category_id = cat?.id
+    const existing = await db.chores.where('sync_id').equals(chore.id).first()
+    if (existing) {
+      await db.chores.update(existing.id, {
+        name: chore.name,
+        category_id: category_id ?? existing.category_id,
+        category_sync_id: chore.categorySyncId,
+        sort_order: chore.sortOrder,
+        target_cadence_days: chore.targetCadenceDays,
+        notify_when_overdue: chore.notifyWhenOverdue,
+        auto_schedule_to_dayglance: chore.autoScheduleToDayglance,
+        preferred_schedule_behavior: chore.preferredScheduleBehavior,
+        seasonal_start: chore.seasonalStart ?? null,
+        seasonal_end: chore.seasonalEnd ?? null,
+        icon: chore.icon,
+        assigned_user_sync_ids: chore.assignedUserSyncIds ?? [],
+        updated_at: chore.updatedAt,
+      })
+    } else {
+      // Category was deleted locally; skip rather than store a dangling id.
+      if (category_id == null) return
+      await db.chores.add({
+        sync_id: chore.id,
+        name: chore.name,
+        category_id,
+        category_sync_id: chore.categorySyncId,
+        sort_order: chore.sortOrder,
+        target_cadence_days: chore.targetCadenceDays,
+        notify_when_overdue: chore.notifyWhenOverdue,
+        auto_schedule_to_dayglance: chore.autoScheduleToDayglance,
+        preferred_schedule_behavior: chore.preferredScheduleBehavior,
+        seasonal_start: chore.seasonalStart ?? null,
+        seasonal_end: chore.seasonalEnd ?? null,
+        icon: chore.icon,
+        assigned_user_sync_ids: chore.assignedUserSyncIds ?? [],
+        created_at: chore.createdAt,
+        updated_at: chore.updatedAt,
+      } as Chore)
+    }
+  })
+}
+
+async function applyCompletionEvent(evt: SyncCompletionEvent): Promise<void> {
+  await db.transaction('rw', db.completionEvents, db.chores, async () => {
+    // Insert-only: if it is already present, leave it untouched.
+    const existing = await db.completionEvents.where('sync_id').equals(evt.id).first()
+    if (existing) return
+    const chore = await db.chores.where('sync_id').equals(evt.choreSyncId).first()
+    if (!chore) return // chore was deleted; skip orphaned event
+    await db.completionEvents.add({
+      sync_id: evt.id,
+      chore_id: chore.id,
+      completed_at: evt.completedAt,
+      note: evt.note,
+      source: evt.source,
+      completed_by_user_sync_id: evt.completedByUserSyncId ?? null,
+    } as CompletionEvent)
+  })
+}
+
+async function applyUser(user: SyncUser): Promise<void> {
+  await db.transaction('rw', db.users, async () => {
+    const existing = await db.users.where('sync_id').equals(user.id).first()
+    if (existing) {
+      await db.users.update(existing.id, { name: user.name, updated_at: user.updatedAt })
+    } else {
+      await db.users.add({ sync_id: user.id, name: user.name, updated_at: user.updatedAt } as User)
+    }
+  })
+}
+
+export async function applyRemoteEntity(_entityId: string, entity: unknown): Promise<void> {
+  switch (entityKind(entity)) {
+    case 'category':
+      await applyCategory(entity as SyncCategory)
+      break
+    case 'chore':
+      await applyChore(entity as SyncChore)
+      break
+    case 'completionEvent':
+      await applyCompletionEvent(entity as SyncCompletionEvent)
+      break
+    case 'user':
+      await applyUser(entity as SyncUser)
+      break
+    default:
+      return
+  }
+  notifyApplied()
+}
+
+// ── applyRemoteDelete: tombstone the id and remove it from its table ─────────
+
+export async function applyRemoteDelete(entityId: string): Promise<void> {
+  await db.transaction(
+    'rw',
+    [db.categories, db.chores, db.completionEvents, db.users, db.tombstones],
+    async () => {
+      await db.tombstones.put({ id: entityId, deleted_at: new Date().toISOString() })
+
+      const cat = await db.categories.where('sync_id').equals(entityId).first()
+      if (cat) { await db.categories.delete(cat.id); return }
+
+      const chore = await db.chores.where('sync_id').equals(entityId).first()
+      if (chore) { await db.chores.delete(chore.id); return }
+
+      const evt = await db.completionEvents.where('sync_id').equals(entityId).first()
+      if (evt) { await db.completionEvents.delete(evt.id); return }
+
+      const user = await db.users.where('sync_id').equals(entityId).first()
+      if (user) { await db.users.delete(user.id); return }
+    },
+  )
+  notifyApplied()
+}
+
+// Mirror applyPayload's UI refresh signal so views update after a remote apply.
+function notifyApplied(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('lg:sync-applied'))
+  window.dispatchEvent(new CustomEvent('lg:chore-logged'))
+}
+
+// ── Engine construction ──────────────────────────────────────────────────────
+
+export interface DbEngineCallbacks {
+  onStatusChange?: (status: SyncStatus) => void
+  onError?: (message: string | null, code: SyncErrorCode | null) => void
+}
+
+// Builds the DB engine when the vault is enabled and fully configured, else
+// returns null (file tier only). The root key is derived from the same sync
+// passphrase the file engine holds; the engine fetches or registers the salt
+// with the vault automatically on first use (see ensureRootKey).
+export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine | null {
+  if (!isVaultEnabled()) return null
+  const cfg = getVaultConfig()!
+
+  return createDbSyncEngine({
+    storageKeyPrefix: APP_ID,
+    appId: APP_ID,
+    vaultApp: APP_ID,
+    cryptoDBName: CRYPTO_DB_NAME,
+    vaultUrl: cfg.vaultUrl,
+    vaultToken: cfg.vaultToken,
+    accountId: cfg.accountId,
+    deviceId: getDeviceId(),
+    getLocalEntity,
+    applyRemoteEntity,
+    applyRemoteDelete,
+    isInsertOnly,
+    getEntityLastModified,
+    onStatusChange: callbacks.onStatusChange,
+    onError: callbacks.onError,
+  })
+}

--- a/src/sync/deviceId.test.ts
+++ b/src/sync/deviceId.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getDeviceId } from './deviceId'
+
+// Minimal in-memory localStorage for the node test environment.
+function installLocalStorage(): void {
+  const store = new Map<string, string>()
+  ;(globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size },
+  } as Storage
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe('getDeviceId', () => {
+  beforeEach(() => { installLocalStorage() })
+
+  it('generates a UUID when none is stored', () => {
+    expect(localStorage.getItem('lastglance-device-id')).toBeNull()
+    const id = getDeviceId()
+    expect(id).toMatch(UUID_RE)
+    expect(localStorage.getItem('lastglance-device-id')).toBe(id)
+  })
+
+  it('returns the same id across multiple calls (stable)', () => {
+    const a = getDeviceId()
+    const b = getDeviceId()
+    const c = getDeviceId()
+    expect(b).toBe(a)
+    expect(c).toBe(a)
+  })
+
+  it('reuses an existing persisted id rather than regenerating', () => {
+    const existing = '00000000-1111-2222-3333-444444444444'
+    localStorage.setItem('lastglance-device-id', existing)
+    expect(getDeviceId()).toBe(existing)
+  })
+})

--- a/src/sync/deviceId.ts
+++ b/src/sync/deviceId.ts
@@ -1,0 +1,18 @@
+// Stable per-device identifier for the GLANCEvault DB sync transport.
+//
+// The DB engine uses this to maintain its device cursor on the vault (so the
+// server can track which seq each device has seen for tombstone GC). It is
+// generated once on first use and then persisted for the lifetime of the
+// installation. It is never synced and never changes.
+
+const DEVICE_ID_KEY = 'lastglance-device-id'
+
+// Returns the stable device id, generating and persisting one on first call.
+export function getDeviceId(): string {
+  let id = localStorage.getItem(DEVICE_ID_KEY)
+  if (!id) {
+    id = crypto.randomUUID()
+    localStorage.setItem(DEVICE_ID_KEY, id)
+  }
+  return id
+}

--- a/src/sync/dirtyTracker.ts
+++ b/src/sync/dirtyTracker.ts
@@ -1,0 +1,35 @@
+// Bridge between the data layer (src/db/queries.ts) and the DB sync engine.
+//
+// The file-tier engine diffs whole entity arrays, so it needs no per-write
+// signal. The DB engine, by contrast, only exchanges rows that changed: its
+// sole input is markDirty(entityId). This module lets the data layer signal
+// dirtiness without importing the engine or React, and is a no-op whenever the
+// vault transport is disabled (no engine registered).
+
+import type { DbSyncEngine } from '@glance-apps/sync'
+
+let dbEngine: DbSyncEngine | null = null
+
+// Called by App on startup (and on config changes) to wire the active DB engine,
+// or null to detach it (vault disabled).
+export function registerDbEngine(engine: DbSyncEngine | null): void {
+  dbEngine = engine
+}
+
+// Mark an entity changed so the DB transport pushes it on the next cycle.
+// Safe to call from inside the app's own write path: it is synchronous and
+// idempotent, and does nothing when the vault transport is off.
+export function markDirty(syncId: string | null | undefined): void {
+  if (!syncId || !dbEngine) return
+  dbEngine.markDirty(syncId)
+}
+
+// Mark an entity deleted. The DB engine resolves deletions by absence: a dirty
+// entity whose getLocalEntity returns null is pushed to the vault as a
+// soft-delete. v1.2.0 exposes no dedicated delete call, so this reuses
+// markDirty; keeping it as a named helper documents intent at delete sites and
+// gives us one place to switch if the engine later gains a delete API.
+export function markDeleted(syncId: string | null | undefined): void {
+  if (!syncId || !dbEngine) return
+  dbEngine.markDirty(syncId)
+}

--- a/src/sync/vaultConfig.test.ts
+++ b/src/sync/vaultConfig.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getVaultConfig, setVaultConfig, isVaultEnabled } from './vaultConfig'
+
+function installLocalStorage(): void {
+  const store = new Map<string, string>()
+  ;(globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size },
+  } as Storage
+}
+
+describe('vaultConfig', () => {
+  beforeEach(() => { installLocalStorage() })
+
+  it('returns null when nothing is stored', () => {
+    expect(getVaultConfig()).toBeNull()
+    expect(isVaultEnabled()).toBe(false)
+  })
+
+  it('saves and loads a full config round-trip', () => {
+    const cfg = {
+      enabled: true,
+      vaultUrl: 'https://vault.glance-apps.com',
+      vaultToken: 'tok_abc123',
+      accountId: 'household-42',
+    }
+    setVaultConfig(cfg)
+    expect(getVaultConfig()).toEqual(cfg)
+    expect(isVaultEnabled()).toBe(true)
+  })
+
+  it('clears the config when passed null', () => {
+    setVaultConfig({ enabled: true, vaultUrl: 'u', vaultToken: 't', accountId: 'a' })
+    setVaultConfig(null)
+    expect(getVaultConfig()).toBeNull()
+    expect(isVaultEnabled()).toBe(false)
+  })
+
+  it('treats a disabled or incomplete config as not enabled', () => {
+    setVaultConfig({ enabled: false, vaultUrl: 'u', vaultToken: 't', accountId: 'a' })
+    expect(isVaultEnabled()).toBe(false)
+
+    setVaultConfig({ enabled: true, vaultUrl: '', vaultToken: 't', accountId: 'a' })
+    expect(isVaultEnabled()).toBe(false)
+  })
+
+  it('tolerates malformed stored JSON', () => {
+    localStorage.setItem('lastglance-vault-config', '{not valid json')
+    expect(getVaultConfig()).toBeNull()
+  })
+})

--- a/src/sync/vaultConfig.ts
+++ b/src/sync/vaultConfig.ts
@@ -1,0 +1,45 @@
+// GLANCEvault (DB transport) connection config.
+//
+// This lives entirely separate from the file-tier WebDAV config (which is
+// stored under SYNC_FOLDER_KEY and managed by the file engine). The vault
+// transport is additive and reversible: when this config is absent or its
+// `enabled` flag is false, the app behaves exactly as before and only the file
+// engine runs. Clearing it reverts to the file tier instantly.
+
+const VAULT_CONFIG_KEY = 'lastglance-vault-config'
+
+export interface VaultConfig {
+  enabled: boolean
+  vaultUrl: string    // e.g. https://vault.glance-apps.com
+  vaultToken: string  // device bearer token
+  accountId: string   // household account id
+}
+
+// Reads the saved vault config, or null when none has been stored.
+export function getVaultConfig(): VaultConfig | null {
+  try {
+    const raw = localStorage.getItem(VAULT_CONFIG_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<VaultConfig>
+    return {
+      enabled: !!parsed.enabled,
+      vaultUrl: parsed.vaultUrl ?? '',
+      vaultToken: parsed.vaultToken ?? '',
+      accountId: parsed.accountId ?? '',
+    }
+  } catch {
+    return null
+  }
+}
+
+// Persists the vault config, or clears it when passed null.
+export function setVaultConfig(config: VaultConfig | null): void {
+  if (config) localStorage.setItem(VAULT_CONFIG_KEY, JSON.stringify(config))
+  else localStorage.removeItem(VAULT_CONFIG_KEY)
+}
+
+// True only when the vault transport is fully configured and turned on.
+export function isVaultEnabled(): boolean {
+  const c = getVaultConfig()
+  return !!(c && c.enabled && c.vaultUrl && c.vaultToken && c.accountId)
+}


### PR DESCRIPTION
## Summary

Wires lastGLANCE to the row-grained database (GLANCEvault) sync transport added in `@glance-apps/sync` 1.2.0. The cutover is **additive and reversible**: the DB engine runs alongside the existing file-tier WebDAV engine and only when the vault config is enabled. Clearing the config reverts to file tier instantly.

The file-tier engine is completely untouched: `src/sync/engine.ts` is not in the diff, so `buildPayload`, `mergePayloads`, `applyPayload`, `mergeArrayById`, the file config, its WebDAV payload, and its sync cycle are unchanged. The DB engine never reads or writes the WebDAV sync file, and `meUserSyncId` stays outside every entity's sync shape.

## Changes

- **Dependency:** bump `@glance-apps/sync` to `1.2.0` (and add `fake-indexeddb` as a dev dependency for Dexie tests).
- **Stable deviceId** (`src/sync/deviceId.ts`): reads/generates/persists `lastglance-device-id` for the engine's device cursor.
- **Vault config** (`src/sync/vaultConfig.ts`): `lastglance-vault-config` storage (`enabled`, `vaultUrl`, `vaultToken`, `accountId`) plus a "GLANCEvault (beta)" section in the sync settings modal (toggle + fields, shown and saved only when on; a config change reloads to reconstruct the engines).
- **DB engine wiring** (`src/sync/dbEngine.ts`): `createDbEngine` plus the five data callbacks: `getLocalEntity`, `applyRemoteEntity`, `applyRemoteDelete`, `isInsertOnly`, `getEntityLastModified`. Remote applies write Dexie directly (never through `queries.ts`), so they cannot loop back into a push.
- **markDirty bridge** (`src/sync/dirtyTracker.ts` + `src/db/queries.ts`): a decoupled `markDirty`/`markDeleted` bridge wired into every Dexie write site; no-op when the vault is disabled.
- **Triggers and passphrase** (`src/App.tsx`): `dbSyncCycle()` fires on the same triggers as the file engine (mount, visibility change, 5-minute interval); after `setupEncryptionKey` the DB root key is derived from the same passphrase via `ensureRootKey()` (the engine fetches or registers the per-account salt automatically).

## markDirty write sites

`createCategory`, `updateCategory`, `reorderCategories`, `createChore`, `updateChore`, `reorderChores`, `logCompletion` (insert-only, at creation), `updateCompletionNote`, `createUser`, `updateUser`, and `importBackup` (every restored record). `markDeleted` at the tombstone sites: `deleteCategory`, `deleteChore`, `deleteCompletion`, `deleteUser`. The DB engine resolves deletions by absence (markDirty + a `getLocalEntity` that returns null pushes a soft-delete); v1.2.0 exposes no dedicated delete call. Intentionally not marked: `deduplicateUsers` (local cleanup, no tombstone) and the seed `populate`/migrations (run before any engine exists).

## Notes

- Completion events are insert-only in both transports: an edited note reaches fresh devices on first pull but does not overwrite the copy on devices that already hold the event. This matches the file tier and is documented inline in `updateCompletionNote`.

## Testing

- `npm test`: 34 tests pass, covering `getDeviceId` stability, `getLocalEntity` lookups across all four tables, `isInsertOnly`, `getEntityLastModified`, and vault config load/save.
- `npm run build` (`tsc -b && vite build`) passes.
- `PHASE4_TESTING.md` documents manual verification against a live GLANCEvault (enable in the UI, make a change, verify via `curl GET /sync/lastglance/list`, confirm cross-device sync and deletions, and confirm the file tier is unaffected).

https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB)_