### PR TITLE
Bump version to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.7.1-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Bumps lastGLANCE to **1.8.0** following the merge of the Phase 4 GLANCEvault DB transport (PR #104).

This is a **minor** version bump per semver: the GLANCEvault work was an additive, backward-compatible feature (opt-in, behind an experimental toggle, with the file-tier WebDAV engine untouched), so it warrants a minor bump rather than a patch, and nothing breaks so it is not a major.

## Changes

- `package.json`: `1.7.1` -> `1.8.0`
- `package-lock.json`: regenerated via `npm install`
- `README.md`: version badge `1.7.1` -> `1.8.0`

https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB)_