### PR TITLE
GLANCEvault follow-ups: passphrase bootstrap, toggle fix, v1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.1-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ import { getAllCompletionCounts } from '@/db/queries'
 import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
 import { createDbEngine } from '@/sync/dbEngine'
 import { registerDbEngine } from '@/sync/dirtyTracker'
+import { isVaultEnabled } from '@/sync/vaultConfig'
+import { hasDbRootKey, initDbRootKey, getSyncPassphrase } from '@glance-apps/sync'
 import type { SyncEngine, SyncStatus, DbSyncEngine } from '@glance-apps/sync'
 import { syncSharedUsers } from '@/multiuser/sharedUsers'
 import { getUsersPath, getMultiUserEnabled } from '@/multiuser/settings'
@@ -162,7 +164,18 @@ function AppInner() {
   // Initialize sync engine on mount
   useEffect(() => {
     navigator.storage?.persist?.()
-    initSessionKey(CRYPTO_CONFIG).catch(() => {/* non-fatal */})
+    initSessionKey(CRYPTO_CONFIG)
+      .catch(() => false)
+      .then(async () => {
+        // First-time vault bootstrap needs the passphrase to derive the root key.
+        // On returning loads the root key is restored from lastglance-crypto-db
+        // via initDbRootKey, so the prompt is skipped. The in-memory hasDbRootKey
+        // is always false at mount, so we attempt the restore before deciding.
+        if (!isVaultEnabled()) return
+        const hasRoot = hasDbRootKey() || await initDbRootKey(CRYPTO_CONFIG)
+        if (!hasRoot && getSyncPassphrase() === null) setShowPassphrase(true)
+      })
+      .catch(() => {/* non-fatal */})
     const engine = createEngine(import.meta.env.VITE_WEBDAV_PROXY_URL, {
       onStatusChange: (status) => {
         setSyncStatus(status)

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -421,8 +421,8 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
             <p className="text-xs text-amber-600 dark:text-amber-400">
               ⚠️ Experimental. Requires a self-hosted GLANCEvault server. Not recommended for most users.
             </p>
-            <div className="flex items-center justify-between py-1">
-              <div>
+            <div className="flex items-center justify-between gap-3 py-1">
+              <div className="min-w-0">
                 <p className="text-sm text-slate-700 dark:text-slate-300">Sync via GLANCEvault</p>
                 <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
                   Row-grained database sync. Runs alongside your existing WebDAV sync. Your WebDAV data is never modified.
@@ -431,7 +431,7 @@ export function SyncSettingsModal({ engine, onClose }: Props) {
               <button
                 type="button"
                 onClick={() => setVaultEnabled(v => !v)}
-                className={`relative w-10 h-6 rounded-full transition-colors ${vaultEnabled ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
+                className={`relative shrink-0 w-10 h-6 rounded-full transition-colors ${vaultEnabled ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
                 aria-checked={vaultEnabled}
                 role="switch"
               >


### PR DESCRIPTION
## Summary

Two small follow-up fixes to the GLANCEvault (DB) transport, plus a patch version bump.

## 1. Prompt for passphrase to bootstrap the vault root key on first-time enable

When encryption was set up before the vault was enabled, the file engine restores its session key silently on startup via `initSessionKey` and never needs the passphrase again, so it never fires `onPassphraseRequired`. The DB engine, however, needs the passphrase the first time to derive its per-account root key. The result was that the vault could be enabled but never bootstrap its root key, failing every cycle silently (the error is only logged).

This adds a check after `initSessionKey` resolves on mount: when the vault is enabled, no DB root key can be restored, and there is no session passphrase, it opens the passphrase modal so the root key can be derived.

- Only fires on first-time bootstrap. On returning loads the root key is restored from `lastglance-crypto-db`, so the prompt is skipped.
- The in-memory `hasDbRootKey()` is always false at mount (module state resets on a page load), so the check attempts `initDbRootKey(CRYPTO_CONFIG)` to restore the persisted key before deciding. This also pre-loads the key for the concurrent `dbSyncCycle`.
- No behavior change when the vault is disabled.

## 2. Fix the GLANCEvault toggle thumb overflow

The toggle sits in a `flex justify-between` row and had no `shrink-0`. The GLANCEvault description is longer than the other toggles' text, so flex compressed the 40px track while the absolutely-positioned 20px thumb kept its fixed size and 16px translate, overflowing the right edge in the on state.

Fix: `shrink-0` on the toggle button (root cause), plus `gap-3` on the row and `min-w-0` on the text block so the longer description wraps cleanly instead of crowding the control.

## 3. Version bump

- `package.json`: `1.8.0` -> `1.8.1` (patch: bug fixes only)
- `package-lock.json`: regenerated via `npm install`
- `README.md`: version badge `1.8.0` -> `1.8.1`

## Testing

- `tsc -b` passes.

https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB