### PR TITLE
Update @glance-apps/sync to 1.2.1, bump to v1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.1-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.2-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lastglance",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.2.0",
+        "@glance-apps/sync": "1.2.1",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.2.0.tgz",
-      "integrity": "sha512-Iq370ZJ/b6d+es8hhEouxPPsuAydryhDQMSCSwl0WYCTRPkYCiL091o4mjAuQP9p0GAuua0VOnN3RLfC6FDTsw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.2.1.tgz",
+      "integrity": "sha512-CvFhk85y01dGvDk8ci3EXvCFy7G/kfDqhu2MSBZ1E1bnBP7oAHUQ1+DWT0m7iG+ckXat8Kx1IZDpvULHYVX2pQ==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.2.0",
+    "@glance-apps/sync": "1.2.1",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",


### PR DESCRIPTION
## Summary

Pulls in `@glance-apps/sync` 1.2.1 and bumps lastGLANCE to 1.8.2.

## Changes

- **Dependency:** `@glance-apps/sync` `1.2.0` -> `1.2.1`. This is an internal fix in the DB transport: the vault row field was renamed `ciphertext` -> `envelope` to match the GLANCEvault batch and list endpoints (rows are now `{ entityId, envelope, createdAt }`). The base64 encoding is unchanged. lastGLANCE never references that field directly (our callbacks operate on decrypted entities), so no application code changes were needed.
- `package.json`: version `1.8.1` -> `1.8.2` (patch)
- `package-lock.json`: regenerated via `npm install`
- `README.md`: version badge `1.8.1` -> `1.8.2`

## Testing

- `tsc -b` passes.
- `npm test`: 34 tests pass against sync 1.2.1.

https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB)_