### PR TITLE
DB sync robustness: out-of-order chores + first-sync full snapshot (v1.8.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.2-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.3-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
         "@glance-apps/sync": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.2",
+  "version": "1.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -5,8 +5,26 @@ import {
   getLocalEntity,
   isInsertOnly,
   getEntityLastModified,
+  applyRemoteEntity,
 } from './dbEngine'
+import { getDeferredChores } from './deferredChores'
 import type { Category, Chore, CompletionEvent, User } from '@/types'
+import type { SyncCategory, SyncChore } from './types'
+
+// Minimal in-memory localStorage for the node test environment (the deferred
+// chore buffer persists there).
+function installLocalStorage(): void {
+  const store = new Map<string, string>()
+  ;(globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size },
+  } as Storage
+}
+installLocalStorage()
 
 // Stable ids for the records we seed and look up.
 const USER_ID = '11111111-1111-1111-1111-111111111111'
@@ -108,5 +126,38 @@ describe('getEntityLastModified', () => {
     expect(getEntityLastModified(cat)).toBe('2026-02-02T00:00:00.000Z')
     expect(getEntityLastModified(chore)).toBe('2026-03-04T00:00:00.000Z')
     expect(getEntityLastModified(user)).toBe('2026-01-01T00:00:00.000Z')
+  })
+})
+
+describe('applyRemoteEntity out-of-order chore and category', () => {
+  // A custom category that does not exist locally yet, and a chore under it.
+  const DCAT_ID = '55555555-5555-5555-5555-555555555555'
+  const DCHORE_ID = '66666666-6666-6666-6666-666666666666'
+
+  const remoteCategory: SyncCategory = {
+    id: DCAT_ID, name: 'Workshop', sortOrder: 5, icon: 'Wrench',
+    parentId: null, assignedUserSyncIds: [], updatedAt: '2026-05-01T00:00:00.000Z',
+  }
+  const remoteChore: SyncChore = {
+    id: DCHORE_ID, name: 'Oil the bench', categorySyncId: DCAT_ID, sortOrder: 0,
+    targetCadenceDays: 30, notifyWhenOverdue: false, autoScheduleToDayglance: false,
+    preferredScheduleBehavior: null, seasonalStart: null, seasonalEnd: null,
+    icon: 'Droplet', assignedUserSyncIds: [],
+    createdAt: '2026-05-02T00:00:00.000Z', updatedAt: '2026-05-02T00:00:00.000Z',
+  }
+
+  it('parks a chore whose category has not arrived, then applies it once the category lands', async () => {
+    // Chore arrives first: its category is not present, so it must be parked.
+    await applyRemoteEntity(DCHORE_ID, remoteChore)
+    expect(await db.chores.where('sync_id').equals(DCHORE_ID).first()).toBeUndefined()
+    expect(getDeferredChores().map(c => c.id)).toContain(DCHORE_ID)
+
+    // Category arrives next: draining must apply the parked chore and clear it.
+    await applyRemoteEntity(DCAT_ID, remoteCategory)
+    const landed = await db.chores.where('sync_id').equals(DCHORE_ID).first()
+    expect(landed).toBeTruthy()
+    const cat = await db.categories.where('sync_id').equals(DCAT_ID).first()
+    expect(landed!.category_id).toBe(cat!.id)
+    expect(getDeferredChores().map(c => c.id)).not.toContain(DCHORE_ID)
   })
 })

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -6,8 +6,10 @@ import {
   isInsertOnly,
   getEntityLastModified,
   applyRemoteEntity,
+  markAllLocalEntitiesDirty,
 } from './dbEngine'
 import { getDeferredChores } from './deferredChores'
+import type { DbSyncEngine } from '@glance-apps/sync'
 import type { Category, Chore, CompletionEvent, User } from '@/types'
 import type { SyncCategory, SyncChore } from './types'
 
@@ -126,6 +128,21 @@ describe('getEntityLastModified', () => {
     expect(getEntityLastModified(cat)).toBe('2026-02-02T00:00:00.000Z')
     expect(getEntityLastModified(chore)).toBe('2026-03-04T00:00:00.000Z')
     expect(getEntityLastModified(user)).toBe('2026-01-01T00:00:00.000Z')
+  })
+})
+
+describe('markAllLocalEntitiesDirty', () => {
+  it('marks every local entity across all four tables dirty', async () => {
+    const marked: string[] = []
+    const fakeEngine = { markDirty: (id: string) => { marked.push(id) } } as unknown as DbSyncEngine
+    await markAllLocalEntitiesDirty(fakeEngine)
+    // The records seeded in beforeAll, one per table.
+    expect(marked).toContain(USER_ID)
+    expect(marked).toContain(CAT_ID)
+    expect(marked).toContain(CHORE_ID)
+    expect(marked).toContain(EVENT_ID)
+    // Seed categories/chores populated on first open are included too.
+    expect(marked.length).toBeGreaterThan(4)
   })
 })
 

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -317,6 +317,25 @@ export interface DbEngineCallbacks {
   onError?: (message: string | null, code: SyncErrorCode | null) => void
 }
 
+// Marks every local entity dirty so the next push sends a complete snapshot.
+// Used for the first ever sync on a device (high water mark 0): existing users
+// who enable the vault have data that predates dirty tracking, so without this
+// only future changes would be pushed. pushDirtyRows then snapshots each id via
+// getLocalEntity. markDirty is idempotent, so repeating this before a successful
+// first push is harmless.
+export async function markAllLocalEntitiesDirty(engine: DbSyncEngine): Promise<void> {
+  const [cats, chores, events, users] = await Promise.all([
+    db.categories.toArray(),
+    db.chores.toArray(),
+    db.completionEvents.toArray(),
+    db.users.toArray(),
+  ])
+  for (const c of cats) engine.markDirty(c.sync_id)
+  for (const c of chores) engine.markDirty(c.sync_id)
+  for (const e of events) engine.markDirty(e.sync_id)
+  for (const u of users) engine.markDirty(u.sync_id)
+}
+
 // Builds the DB engine when the vault is enabled and fully configured, else
 // returns null (file tier only). The root key is derived from the same sync
 // passphrase the file engine holds; the engine fetches or registers the salt
@@ -325,7 +344,7 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
   if (!isVaultEnabled()) return null
   const cfg = getVaultConfig()!
 
-  return createDbSyncEngine({
+  const engine = createDbSyncEngine({
     storageKeyPrefix: APP_ID,
     appId: APP_ID,
     vaultApp: APP_ID,
@@ -342,4 +361,23 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
     onStatusChange: callbacks.onStatusChange,
     onError: callbacks.onError,
   })
+
+  // On the first ever sync (high water mark 0), seed the dirty set with the full
+  // local dataset so existing users get everything pushed, not just new changes.
+  // After a successful first push the high water mark advances past 0, so this
+  // runs once. Seeding failures are non-fatal: the normal cycle still proceeds.
+  const runCycle = engine.dbSyncCycle.bind(engine)
+  const dbSyncCycle = async (): Promise<void> => {
+    if (engine.getHighWaterMark() === 0) {
+      try {
+        await markAllLocalEntitiesDirty(engine)
+      } catch (err) {
+        console.warn('[lastglance] vault initial snapshot failed:', err)
+      }
+    }
+    await runCycle()
+  }
+
+  return { ...engine, dbSyncCycle, sync: dbSyncCycle }
 }
+

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -19,6 +19,7 @@ import type { Category, Chore, CompletionEvent, User } from '@/types'
 import type { SyncCategory, SyncChore, SyncCompletionEvent, SyncUser } from './types'
 import { getVaultConfig, isVaultEnabled } from './vaultConfig'
 import { getDeviceId } from './deviceId'
+import { addDeferredChore, removeDeferredChore, getDeferredChores } from './deferredChores'
 
 const APP_ID = 'lastglance'
 const CRYPTO_DB_NAME = 'lastglance-crypto'
@@ -156,9 +157,12 @@ async function applyCategory(cat: SyncCategory): Promise<void> {
       } as Category)
     }
   })
+  // A newly present category may unblock chores that arrived before it.
+  await drainDeferredChores()
 }
 
 async function applyChore(chore: SyncChore): Promise<void> {
+  let skipped = false
   await db.transaction('rw', db.chores, db.categories, async () => {
     const cat = chore.categorySyncId
       ? await db.categories.where('sync_id').equals(chore.categorySyncId).first()
@@ -182,8 +186,9 @@ async function applyChore(chore: SyncChore): Promise<void> {
         updated_at: chore.updatedAt,
       })
     } else {
-      // Category was deleted locally; skip rather than store a dangling id.
-      if (category_id == null) return
+      // Category not present yet (arrived out of seq order) or deleted: do not
+      // store a dangling id. Park the chore and retry when a category lands.
+      if (category_id == null) { skipped = true; return }
       await db.chores.add({
         sync_id: chore.id,
         name: chore.name,
@@ -203,6 +208,23 @@ async function applyChore(chore: SyncChore): Promise<void> {
       } as Chore)
     }
   })
+  // Buffer the chore when skipped; clear it from the buffer once applied.
+  if (skipped) addDeferredChore(chore)
+  else removeDeferredChore(chore.id)
+}
+
+// Re-apply parked chores whose category is now present locally. Called after a
+// category is applied. applyChore removes each from the buffer on success and
+// re-parks any that still cannot resolve, so this is safe to call repeatedly.
+async function drainDeferredChores(): Promise<void> {
+  const deferred = getDeferredChores()
+  if (deferred.length === 0) return
+  for (const chore of deferred) {
+    const cat = chore.categorySyncId
+      ? await db.categories.where('sync_id').equals(chore.categorySyncId).first()
+      : undefined
+    if (cat) await applyChore(chore)
+  }
 }
 
 async function applyCompletionEvent(evt: SyncCompletionEvent): Promise<void> {
@@ -276,6 +298,8 @@ export async function applyRemoteDelete(entityId: string): Promise<void> {
       if (user) { await db.users.delete(user.id); return }
     },
   )
+  // Drop any parked copy so a deleted chore is never resurrected by a later drain.
+  removeDeferredChore(entityId)
   notifyApplied()
 }
 

--- a/src/sync/deferredChores.test.ts
+++ b/src/sync/deferredChores.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { addDeferredChore, removeDeferredChore, getDeferredChores } from './deferredChores'
+import type { SyncChore } from './types'
+
+function installLocalStorage(): void {
+  const store = new Map<string, string>()
+  ;(globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size },
+  } as Storage
+}
+
+function makeChore(id: string): SyncChore {
+  return {
+    id, name: 'Chore ' + id, categorySyncId: 'cat-' + id, sortOrder: 0,
+    targetCadenceDays: 7, notifyWhenOverdue: false, autoScheduleToDayglance: false,
+    preferredScheduleBehavior: null, seasonalStart: null, seasonalEnd: null,
+    icon: undefined, assignedUserSyncIds: [],
+    createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+describe('deferredChores buffer', () => {
+  beforeEach(() => { installLocalStorage() })
+
+  it('starts empty', () => {
+    expect(getDeferredChores()).toEqual([])
+  })
+
+  it('adds and reads back a parked chore', () => {
+    const c = makeChore('a')
+    addDeferredChore(c)
+    expect(getDeferredChores()).toEqual([c])
+  })
+
+  it('dedupes by sync_id, keeping the latest version', () => {
+    addDeferredChore(makeChore('a'))
+    const updated = { ...makeChore('a'), name: 'renamed' }
+    addDeferredChore(updated)
+    const all = getDeferredChores()
+    expect(all).toHaveLength(1)
+    expect(all[0].name).toBe('renamed')
+  })
+
+  it('removes a chore and clears storage when empty', () => {
+    addDeferredChore(makeChore('a'))
+    removeDeferredChore('a')
+    expect(getDeferredChores()).toEqual([])
+    expect(localStorage.getItem('lastglance-db-deferred-chores')).toBeNull()
+  })
+
+  it('removing an absent id is a no-op', () => {
+    addDeferredChore(makeChore('a'))
+    removeDeferredChore('does-not-exist')
+    expect(getDeferredChores().map(c => c.id)).toEqual(['a'])
+  })
+
+  it('tolerates malformed stored JSON', () => {
+    localStorage.setItem('lastglance-db-deferred-chores', '{not json')
+    expect(getDeferredChores()).toEqual([])
+  })
+})

--- a/src/sync/deferredChores.ts
+++ b/src/sync/deferredChores.ts
@@ -1,0 +1,57 @@
+// Deferred-chore buffer for the GLANCEvault DB transport.
+//
+// The DB engine pulls rows incrementally and advances a high water mark, so a
+// row is only ever seen once. applyChore cannot insert a new chore until its
+// category exists locally (the schema needs a numeric category_id and the app
+// queries chores by it). Vault seq order does not guarantee a category arrives
+// before its chores: editing a category bumps its seq above older chore rows,
+// and writes interleave across devices and pull pages. Without a buffer a chore
+// that arrives before its category would be skipped permanently.
+//
+// So when applyChore has to skip, the chore's sync shape is parked here, keyed
+// by sync_id, and re-applied once its category shows up (see drainDeferredChores
+// in dbEngine.ts). The buffer is persisted in localStorage so it survives the
+// reload between pull cycles.
+
+import type { SyncChore } from './types'
+
+const KEY = 'lastglance-db-deferred-chores'
+
+type Buffer = Record<string, SyncChore>
+
+function read(): Buffer {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as Buffer) : {}
+  } catch {
+    return {}
+  }
+}
+
+function write(buf: Buffer): void {
+  if (Object.keys(buf).length === 0) localStorage.removeItem(KEY)
+  else localStorage.setItem(KEY, JSON.stringify(buf))
+}
+
+// Park a chore whose category is not present yet.
+export function addDeferredChore(chore: SyncChore): void {
+  const buf = read()
+  buf[chore.id] = chore
+  write(buf)
+}
+
+// Drop a chore from the buffer once it has been applied (or deleted).
+export function removeDeferredChore(syncId: string): void {
+  const buf = read()
+  if (syncId in buf) {
+    delete buf[syncId]
+    write(buf)
+  }
+}
+
+// All currently parked chores.
+export function getDeferredChores(): SyncChore[] {
+  return Object.values(read())
+}


### PR DESCRIPTION
## Summary

Two robustness fixes for the GLANCEvault (DB) transport, released as 1.8.3.

## Fix 1: buffer out-of-order chores so they are not dropped

`applyChore` cannot insert a new chore until its category exists locally (the schema needs a numeric `category_id`, and the app queries chores by it). The DB engine pulls rows incrementally and advances a high water mark, so each row is seen only once. Vault `seq` order does not guarantee a category arrives before its chores (editing a category bumps its seq above older chore rows; writes interleave across devices; pagination can split them). Previously such a chore was skipped permanently. This was a regression versus the file tier, whose `applyPayload` self-heals by re-applying the full payload every cycle.

- New `src/sync/deferredChores.ts`: a localStorage-backed buffer (`lastglance-db-deferred-chores`) keyed by `sync_id`, persisted across cycles.
- `applyChore` parks a chore when it must skip and clears it once applied.
- `applyCategory` drains the buffer after upserting, applying any parked chore whose category now resolves.
- `applyRemoteDelete` removes any parked copy so a deleted chore is not resurrected by a later drain.

## Fix 2: push a full local snapshot on the first ever sync

Existing users who enable the vault have local data that predates dirty tracking. Without a full initial push, only changes made after enabling would ever reach the vault.

- In `createDbEngine`, `dbSyncCycle` is wrapped so that when the high water mark is 0 (first ever sync on the device), `markAllLocalEntitiesDirty` seeds the dirty set with every local entity across all four tables before the normal cycle runs. `pushDirtyRows` then snapshots each id via `getLocalEntity` and uploads it.
- Runs once: the high water mark advances past 0 after a successful first push. `markDirty` is idempotent, and seeding failures are non-fatal (the normal cycle still proceeds).

## Version

- `package.json`: `1.8.2` -> `1.8.3` (patch)
- `package-lock.json`: regenerated via `npm install`
- `README.md`: version badge `1.8.2` -> `1.8.3`

## Testing

- `tsc -b` passes.
- `npm test`: 42 tests pass (8 new).
  - `deferredChores.test.ts`: buffer add/read/dedupe/remove/empty-clear/malformed-JSON.
  - `dbEngine.test.ts`: out-of-order chore-before-category integration test; `markAllLocalEntitiesDirty` marks every local entity across all four tables.

## Note

A parked chore whose category is never delivered (e.g. deleted upstream) stays in the buffer indefinitely. It is bounded and harmless, but a future cleanup could prune stale entries.

https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB