### PR TITLE
v1.8.4: debounced vault sync + @glance-apps/sync 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.3-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.4-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "lastglance",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dependencies": {
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.2.1",
+        "@glance-apps/sync": "1.3.2",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.2.1.tgz",
-      "integrity": "sha512-CvFhk85y01dGvDk8ci3EXvCFy7G/kfDqhu2MSBZ1E1bnBP7oAHUQ1+DWT0m7iG+ckXat8Kx1IZDpvULHYVX2pQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.3.2.tgz",
+      "integrity": "sha512-49Wh24nMQaiGOvgmm6dVXCqCeuXhxx/zjNGGy+VnMnyqUyFEUYy6KYr53E3gTluFMvRxjsoY/ofFIh3OP36kVw==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.3",
+  "version": "1.8.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.2.1",
+    "@glance-apps/sync": "1.3.2",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",

--- a/src/sync/dirtyTracker.test.ts
+++ b/src/sync/dirtyTracker.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { registerDbEngine, markDirty, markDeleted } from './dirtyTracker'
+import type { DbSyncEngine } from '@glance-apps/sync'
+
+describe('dirtyTracker debounced push', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { registerDbEngine(null); vi.useRealTimers() })
+
+  it('does nothing when no engine is registered', () => {
+    registerDbEngine(null)
+    markDirty('a') // must not throw
+    vi.advanceTimersByTime(10_000)
+    expect(true).toBe(true)
+  })
+
+  it('marks dirty immediately and pushes once after the debounce window', async () => {
+    const marked: string[] = []
+    let cycles = 0
+    const engine = {
+      markDirty: (id: string) => { marked.push(id) },
+      dbSyncCycle: () => { cycles++; return Promise.resolve() },
+    } as unknown as DbSyncEngine
+    registerDbEngine(engine)
+
+    markDirty('a')
+    expect(marked).toEqual(['a']) // synchronous
+    expect(cycles).toBe(0)        // push is deferred
+
+    vi.advanceTimersByTime(2999)
+    expect(cycles).toBe(0)
+    vi.advanceTimersByTime(1)
+    expect(cycles).toBe(1)
+  })
+
+  it('collapses a burst of writes into a single push', () => {
+    const marked: string[] = []
+    let cycles = 0
+    const engine = {
+      markDirty: (id: string) => { marked.push(id) },
+      dbSyncCycle: () => { cycles++; return Promise.resolve() },
+    } as unknown as DbSyncEngine
+    registerDbEngine(engine)
+
+    markDirty('a')
+    vi.advanceTimersByTime(1000)
+    markDirty('b')
+    vi.advanceTimersByTime(1000)
+    markDeleted('c')
+    expect(marked).toEqual(['a', 'b', 'c'])
+    expect(cycles).toBe(0)
+
+    // Only after the window elapses with no further writes does it fire once.
+    vi.advanceTimersByTime(3000)
+    expect(cycles).toBe(1)
+  })
+
+  it('cancels a pending push when the engine is detached', () => {
+    let cycles = 0
+    const engine = {
+      markDirty: () => {},
+      dbSyncCycle: () => { cycles++; return Promise.resolve() },
+    } as unknown as DbSyncEngine
+    registerDbEngine(engine)
+
+    markDirty('a')
+    registerDbEngine(null) // detach before the timer fires
+    vi.advanceTimersByTime(10_000)
+    expect(cycles).toBe(0)
+  })
+})

--- a/src/sync/dirtyTracker.ts
+++ b/src/sync/dirtyTracker.ts
@@ -5,23 +5,55 @@
 // sole input is markDirty(entityId). This module lets the data layer signal
 // dirtiness without importing the engine or React, and is a no-op whenever the
 // vault transport is disabled (no engine registered).
+//
+// It also schedules a debounced vault sync after writes so changes upload
+// promptly instead of waiting for the next cadence trigger (load, focus, or the
+// 5 minute interval). This is vault only: the file engine keeps its cadence
+// model, which is deliberate given its full-payload upload cost.
 
 import type { DbSyncEngine } from '@glance-apps/sync'
 
+// Wait this long after the last write before pushing, so a burst of writes
+// (e.g. reordering, a restore, logging several completions) collapses into one
+// sync rather than firing per row.
+const PUSH_DEBOUNCE_MS = 3000
+
 let dbEngine: DbSyncEngine | null = null
+let pushTimer: ReturnType<typeof setTimeout> | null = null
+
+function cancelScheduledPush(): void {
+  if (pushTimer != null) {
+    clearTimeout(pushTimer)
+    pushTimer = null
+  }
+}
+
+// Debounced vault sync. Each call resets the timer; the cycle runs once the
+// writes settle. dbSyncCycle has its own in-flight guard, so this never overlaps
+// a cadence-triggered cycle.
+function schedulePush(): void {
+  if (!dbEngine) return
+  cancelScheduledPush()
+  pushTimer = setTimeout(() => {
+    pushTimer = null
+    dbEngine?.dbSyncCycle().catch(() => {/* surfaced via the engine onError */})
+  }, PUSH_DEBOUNCE_MS)
+}
 
 // Called by App on startup (and on config changes) to wire the active DB engine,
 // or null to detach it (vault disabled).
 export function registerDbEngine(engine: DbSyncEngine | null): void {
+  cancelScheduledPush()
   dbEngine = engine
 }
 
-// Mark an entity changed so the DB transport pushes it on the next cycle.
-// Safe to call from inside the app's own write path: it is synchronous and
+// Mark an entity changed so the DB transport pushes it, and schedule a debounced
+// sync. Safe to call from inside the app's own write path: it is synchronous and
 // idempotent, and does nothing when the vault transport is off.
 export function markDirty(syncId: string | null | undefined): void {
   if (!syncId || !dbEngine) return
   dbEngine.markDirty(syncId)
+  schedulePush()
 }
 
 // Mark an entity deleted. The DB engine resolves deletions by absence: a dirty
@@ -32,4 +64,5 @@ export function markDirty(syncId: string | null | undefined): void {
 export function markDeleted(syncId: string | null | undefined): void {
   if (!syncId || !dbEngine) return
   dbEngine.markDirty(syncId)
+  schedulePush()
 }


### PR DESCRIPTION
## Summary

The v1.8.4 release. Two things:

1. **Debounced vault sync after local writes** (Fix #1), and
2. **`@glance-apps/sync` 1.2.1 -> 1.3.2.**

## 1. Debounced vault sync after local writes

Local writes only called `markDirty`, which records the entity in the dirty set; the actual push waited for a cadence trigger (load, tab focus, or the 5 minute interval). Because background tabs are throttled, edits on one device could sit un-pushed until the app was reopened, and another device could not pull what was never pushed (matching a real report: completions logged on desktop did not reach an iPad until the desktop app was reopened).

- `markDirty` / `markDeleted` in `src/sync/dirtyTracker.ts` now schedule a debounced `dbSyncCycle` (3s after the last write); a burst of writes collapses into a single sync.
- `dbSyncCycle`'s in-flight guard prevents overlap with cadence-triggered cycles; detaching the engine cancels any pending push.
- **GLANCEvault only.** The file (WebDAV) engine keeps its cadence model (its full-payload upload makes push-on-write costly and conflict-prone, and it is the mature path). The debounce lives at the `markDirty` choke point, which only acts when a vault engine is registered, so this is a no-op when the vault is disabled and the file tier is untouched. Pull cadence is unchanged.

## 2. Dependency: @glance-apps/sync 1.2.1 -> 1.3.2

The 1.3.x line only changes functions lastGLANCE does not use, so no application code changes were needed:

- 1.3.0: multi-user roster merge in `mergeSyncData` (lastGLANCE uses its own `mergePayloads` with `mergeArrayById`, not `mergeSyncData`).
- 1.3.1 / 1.3.2: `mergeRoutineDefinitions` chip-collision fixes (a dayGLANCE routines helper lastGLANCE does not import).

Verified that `src` references neither `mergeSyncData` nor `mergeRoutineDefinitions`.

## Version

- `package.json`: `1.8.3` -> `1.8.4`
- `package-lock.json`: regenerated via `npm install` (also pulls in sync 1.3.2)
- `README.md`: version badge `1.8.3` -> `1.8.4`

## Testing

- `tsc -b` passes.
- `npm test`: 46 tests pass (4 new debounce tests in `dirtyTracker.test.ts`: no-op without an engine; marks dirty synchronously but pushes only after the 3s window; collapses a burst into one push; cancels a pending push on detach).

https://claude.ai/code/session_01C4MqQwjAYNPUxqBQrqcrJB