### PR TITLE
Bump Gradle wrapper to 9.3.1 (JDK 25 support)

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Capacitor 8 scaffolded the Android project with **Gradle 8.14.3**, which predates JDK 25 support and fails to start on it:

```
Unsupported class file major version 69
```

dayGLANCE already runs **Gradle 9.3.1** (which supports JDK 25), so this bumps lastGLANCE to match — giving the GLANCE family a consistent toolchain and letting the Android build run on a current JDK without installing an older one.

- `android/gradle/wrapper/gradle-wrapper.properties`: `gradle-8.14.3` → `gradle-9.3.1`
- **AGP stays 8.13.0**, which is compatible with Gradle 9.3.1 (same combination dayGLANCE builds with).

Changing `distributionUrl` directly (rather than via `./gradlew wrapper`) is deliberate: the old 8.14.3 wrapper can't launch on JDK 25, so the version had to be edited by hand to break the chicken-and-egg.

> Not runnable in CI here (no Android SDK); verified by parity with dayGLANCE's working 9.3.1 + AGP 8.13 setup. First local `./build-android.sh` on JDK 25 is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS)_