### PR TITLE
Status bar: edge-to-edge so the app background shows through

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -16,9 +16,11 @@ const config: CapacitorConfig = {
     },
     // Initial status bar appearance (brand defaults to dark); the app then
     // keeps it in sync with the live theme via src/native/statusBar.ts.
+    // overlaysWebView draws the app background behind a transparent bar
+    // (required on Android 15 / targetSdk 36, which ignores a bar color).
     StatusBar: {
       style: 'DARK',
-      backgroundColor: '#020617',
+      overlaysWebView: true,
     },
   },
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#05081A" />
     <meta name="color-scheme" content="dark" />
     <meta name="description" content="When did you last...? A last-done tracker for the things that matter. No deadlines, no nagging, just information." />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -338,7 +338,15 @@ function AppInner() {
 
   return (
     <UsersContext.Provider value={usersCtx}>
-    <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col">
+    <div
+      className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col"
+      style={{
+        // Edge-to-edge: the background fills behind the transparent status bar
+        // and gesture nav; these insets keep content out from under them.
+        paddingTop: 'env(safe-area-inset-top)',
+        paddingBottom: 'env(safe-area-inset-bottom)',
+      }}
+    >
       <header className="shrink-0 px-5 pt-5 pb-4 border-b border-slate-200 dark:border-slate-800/80 flex items-end justify-between gap-4">
         {/* Logo + heatmap */}
         <div className="flex items-end gap-5 min-w-0">

--- a/src/native/statusBar.ts
+++ b/src/native/statusBar.ts
@@ -1,21 +1,21 @@
 import { Capacitor } from '@capacitor/core'
 import { StatusBar, Style } from '@capacitor/status-bar'
 
-// Status bar background colors, matched to the app's Tailwind root backgrounds
-// (dark:bg-slate-950 / bg-slate-50) so the bar blends into the header.
-const DARK_BG = '#020617' // slate-950
-const LIGHT_BG = '#f8fafc' // slate-50
-
 // Sync the native status bar with the app's light/dark theme. No-op in the
 // browser/PWA, and any plugin error is swallowed (non-fatal cosmetic concern).
+//
+// On Android, targetSdk 36 forces edge-to-edge (Android 15+), where
+// setBackgroundColor is ignored. So instead of coloring the bar we make it
+// transparent and overlay the WebView, letting the app's own background paint
+// behind it — paired with viewport-fit=cover + env(safe-area-inset-top) padding
+// in the layout so content isn't drawn under the bar.
 export async function applyStatusBarTheme(isDark: boolean): Promise<void> {
   if (!Capacitor.isNativePlatform()) return
   try {
     // Style.Dark = light icons (for a dark bar); Style.Light = dark icons.
     await StatusBar.setStyle({ style: isDark ? Style.Dark : Style.Light })
-    // Background color is Android-only; on iOS the bar tracks the web content.
     if (Capacitor.getPlatform() === 'android') {
-      await StatusBar.setBackgroundColor({ color: isDark ? DARK_BG : LIGHT_BG })
+      await StatusBar.setOverlaysWebView({ overlay: true })
     }
   } catch {
     // Plugin unavailable or transient failure — leave the OS default.


### PR DESCRIPTION
Follow-up to #112. The base status-bar theming only changed the icon color on Android 15 because `targetSdk 36` forces edge-to-edge and **ignores `setStatusBarColor`** — the bar stayed system gray.

This makes the app draw its own background *behind* a transparent status bar so the bar visually matches the screen:

- `src/native/statusBar.ts`: overlay the WebView on Android (drop the no-op `setBackgroundColor`).
- `capacitor.config.ts`: `StatusBar.overlaysWebView` for the initial paint.
- `index.html`: `viewport-fit=cover` so `env(safe-area-inset-*)` resolves to real values.
- `src/App.tsx`: pad the root by safe-area top/bottom insets so content isn't drawn under the bar / gesture nav.

Result: the status bar takes on the app's `slate-950` / `slate-50` background and follows light/dark, instead of the default gray.

Browser/PWA unchanged; `npm run build` clean, 46/46 tests pass.

> Scope note: only the main screen root is padded. If a full-screen modal shows content under the status bar, the same `env(safe-area-inset-top)` inset can be added there in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS)_