### PR TITLE
Status bar: trim top padding + full-screen in landscape

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensur
 import { createDbEngine } from '@/sync/dbEngine'
 import { registerDbEngine } from '@/sync/dirtyTracker'
 import { isVaultEnabled } from '@/sync/vaultConfig'
-import { applyStatusBarTheme } from '@/native/statusBar'
+import { applyStatusBarTheme, initFullScreenInLandscape } from '@/native/statusBar'
 import { hasDbRootKey, initDbRootKey, getSyncPassphrase } from '@glance-apps/sync'
 import type { SyncEngine, SyncStatus, DbSyncEngine } from '@glance-apps/sync'
 import { syncSharedUsers } from '@/multiuser/sharedUsers'
@@ -162,6 +162,9 @@ function AppInner() {
     localStorage.setItem('theme', isDark ? 'dark' : 'light')
     applyStatusBarTheme(isDark)
   }, [isDark])
+
+  // Full-screen (hide the status bar) in landscape, restore it in portrait.
+  useEffect(() => initFullScreenInLandscape(), [])
 
   // Initialize sync engine on mount
   useEffect(() => {
@@ -341,13 +344,21 @@ function AppInner() {
     <div
       className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col"
       style={{
-        // Edge-to-edge: the background fills behind the transparent status bar
-        // and gesture nav; these insets keep content out from under them.
-        paddingTop: 'env(safe-area-inset-top)',
+        // Edge-to-edge: the background fills behind the transparent gesture nav;
+        // this keeps content clear of it. (The status-bar inset is handled on
+        // the header so it doesn't stack with the header's own top padding.)
         paddingBottom: 'env(safe-area-inset-bottom)',
       }}
     >
-      <header className="shrink-0 px-5 pt-5 pb-4 border-b border-slate-200 dark:border-slate-800/80 flex items-end justify-between gap-4">
+      <header
+        className="shrink-0 px-5 pb-4 border-b border-slate-200 dark:border-slate-800/80 flex items-end justify-between gap-4"
+        style={{
+          // Clear the status bar without doubling the gap: the larger of the
+          // normal padding (pt-5 = 1.25rem) and the safe-area inset. In landscape
+          // the bar is hidden so the inset collapses to the 1.25rem default.
+          paddingTop: 'max(1.25rem, env(safe-area-inset-top))',
+        }}
+      >
         {/* Logo + heatmap */}
         <div className="flex items-end gap-5 min-w-0">
           <div className="shrink-0">

--- a/src/native/statusBar.ts
+++ b/src/native/statusBar.ts
@@ -21,3 +21,16 @@ export async function applyStatusBarTheme(isDark: boolean): Promise<void> {
     // Plugin unavailable or transient failure — leave the OS default.
   }
 }
+
+// Hide the status bar in landscape for a full-screen view; show it in portrait.
+// Registers an orientation listener and returns a cleanup function. No-op on web.
+export function initFullScreenInLandscape(): () => void {
+  if (!Capacitor.isNativePlatform()) return () => {}
+  const mq = window.matchMedia('(orientation: landscape)')
+  const apply = () => {
+    (mq.matches ? StatusBar.hide() : StatusBar.show()).catch(() => {})
+  }
+  apply()
+  mq.addEventListener('change', apply)
+  return () => mq.removeEventListener('change', apply)
+}


### PR DESCRIPTION
Two on-device refinements after the edge-to-edge status bar (#113).

### 1. Trim the top padding
The header sat too low because the safe-area inset was applied to the root **and** the header still had its own `pt-5`, so they stacked. Now the inset lives only on the header as `max(1.25rem, env(safe-area-inset-top))` — it clears the status bar without doubling, and the browser/PWA is unchanged (inset resolves to 0, so it stays the original `1.25rem`).

### 2. Full-screen in landscape
`initFullScreenInLandscape()` hides the status bar in landscape and restores it in portrait via an `orientation` media-query listener (wired from an `App.tsx` mount effect). No-op on web.

`npm run build` clean, 46/46 tests pass, `cap sync` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS)_