### PR TITLE
Status bar: trim header top padding in landscape

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,15 +350,7 @@ function AppInner() {
         paddingBottom: 'env(safe-area-inset-bottom)',
       }}
     >
-      <header
-        className="shrink-0 px-5 pb-4 border-b border-slate-200 dark:border-slate-800/80 flex items-end justify-between gap-4"
-        style={{
-          // Clear the status bar without doubling the gap: the larger of the
-          // normal padding (pt-5 = 1.25rem) and the safe-area inset. In landscape
-          // the bar is hidden so the inset collapses to the 1.25rem default.
-          paddingTop: 'max(1.25rem, env(safe-area-inset-top))',
-        }}
-      >
+      <header className="app-safe-top shrink-0 px-5 pb-4 border-b border-slate-200 dark:border-slate-800/80 flex items-end justify-between gap-4">
         {/* Logo + heatmap */}
         <div className="flex items-end gap-5 min-w-0">
           <div className="shrink-0">

--- a/src/index.css
+++ b/src/index.css
@@ -29,3 +29,15 @@
     display: none;
   }
 }
+
+/* Top inset that clears the status bar in portrait. In landscape the status
+   bar is hidden (see initFullScreenInLandscape), so trim the floor down while
+   still honoring any display cutout via the safe-area inset. */
+.app-safe-top {
+  padding-top: max(1.25rem, env(safe-area-inset-top));
+}
+@media (orientation: landscape) {
+  .app-safe-top {
+    padding-top: max(0.5rem, env(safe-area-inset-top));
+  }
+}


### PR DESCRIPTION
Follow-up to #114. In landscape the status bar is hidden, so `env(safe-area-inset-top)` is ~0 — but the header's `max(1.25rem, …)` still forced a `1.25rem` floor, leaving a visible top gap with nothing above it.

Moves the inset into an `.app-safe-top` class with an orientation-aware floor:
- **Portrait:** `max(1.25rem, env(safe-area-inset-top))` — clears the status bar (unchanged).
- **Landscape:** `max(0.5rem, env(safe-area-inset-top))` — trims the gap while still honoring a display cutout if one is on the top edge.

Done as a CSS class (not inline) so the `@media (orientation: landscape)` override actually applies. Browser/PWA unchanged.

`npm run build` clean (class confirmed in the CSS bundle), 46/46 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS)_