### PR TITLE
Status bar: add breathing room below the bar in portrait

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -34,7 +34,9 @@
    bar is hidden (see initFullScreenInLandscape), so trim the floor down while
    still honoring any display cutout via the safe-area inset. */
 .app-safe-top {
-  padding-top: max(1.25rem, env(safe-area-inset-top));
+  /* inset + a small gap so the header isn't flush against the status bar; the
+     1.5rem floor applies on the web/PWA where there's no inset. */
+  padding-top: max(1.5rem, calc(env(safe-area-inset-top) + 0.375rem));
 }
 @media (orientation: landscape) {
   .app-safe-top {


### PR DESCRIPTION
Portrait header felt a touch tight against the status bar. Because `max(1.25rem, env(safe-area-inset-top))` lets the inset win on devices where the status bar is taller than `1.25rem`, the header ended up flush against the bar with no gap below it.

Changes the portrait rule to `max(1.5rem, calc(env(safe-area-inset-top) + 0.375rem))`:
- **On device:** status-bar inset **+ 0.375rem** breathing room below the bar.
- **Web/PWA (no inset):** `1.5rem` floor (was effectively `1.25rem`).

Landscape (status bar hidden) is unchanged. `npm run build` clean, 46/46 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhth4ru2nDtNpGfRVyb4GS)_