### PR TITLE
Release v1.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.4-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.5-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.4",
+  "version": "1.8.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps the app to **v1.8.5** (package.json, lockfile, README badge) and rolls up the web/PWA work on this branch since v1.8.4.

## Highlights

**New**
- **Collapsible mobile FAB cluster** — the Soon / Mine / Search buttons can be minimized via a handle, with a staggered fade/slide animation; the choice persists across loads.

**Improved**
- **Cloud Sync modal** — the WebDAV **Sync now** button + status moved into the WEBDAV CONNECTION section next to Test connection; a new **Sync now** added to the GLANCEvault section with its own last-synced/error status.
- **Manual sync now surfaces real errors** — both engines previously swallowed sync failures and could falsely show "Synced"; the buttons now report the actual error and only show success when the sync truly completed.
- **Header controls de-cluttered** — theme toggle moved into the bottom controls row (`SYNC | INTENTS | MULTI | THEME | ARCHIVE | HELP`); heatmap breakpoints raised (52→26 weeks at 1140px, hidden under 828px) to give the controls more room.

**Fixed**
- **Masonry overlap glitch** — toggling the Soon/Mine filter could permanently stack category cards on top of each other; cards are now re-measured synchronously so packing never runs on stale heights.
- **Header top padding** no longer disappears on wide desktop windows (the landscape status-bar trim is now scoped to native builds only).
- **Wordmark** no longer shrinks at 768px — it now only steps down with the mobile layout under 640px.

## Notes
- Mobile (iOS/Android) work present in the branch history is intentionally **not** included in the release notes — those apps aren't ready for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt8JiM3YM4eoB4SPVkMd9m)_