### PR TITLE
Fix GLANCEvault flattened subcategories + stuck completion sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.5-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.6-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.5",
+  "version": "1.8.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -1,5 +1,5 @@
 import 'fake-indexeddb/auto'
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { db } from '@/db/client'
 import {
   getLocalEntity,
@@ -7,8 +7,10 @@ import {
   getEntityLastModified,
   applyRemoteEntity,
   markAllLocalEntitiesDirty,
+  createDbEngine,
 } from './dbEngine'
 import { getDeferredChores } from './deferredChores'
+import { setVaultConfig } from './vaultConfig'
 import type { DbSyncEngine } from '@glance-apps/sync'
 import type { Category, Chore, CompletionEvent, User } from '@/types'
 import type { SyncCategory, SyncChore } from './types'
@@ -176,5 +178,89 @@ describe('applyRemoteEntity out-of-order chore and category', () => {
     const cat = await db.categories.where('sync_id').equals(DCAT_ID).first()
     expect(landed!.category_id).toBe(cat!.id)
     expect(getDeferredChores().map(c => c.id)).not.toContain(DCHORE_ID)
+  })
+})
+
+describe('applyRemoteEntity subcategory before its parent', () => {
+  // Regression guard for the "all subcategories show as parent categories" bug:
+  // the vault applies categories one row at a time in seq order, which is NOT
+  // guaranteed parents-first. A subcategory whose parent has not arrived yet must
+  // still end up linked once the parent lands, because the UI groups strictly by
+  // parent_category_id — an unresolved (null/undefined) FK renders as a ROOT.
+  const PARENT_ID = '77777777-7777-7777-7777-777777777777'
+  const CHILD_A_ID = '88888888-8888-8888-8888-888888888888'
+  const CHILD_B_ID = '99999999-9999-9999-9999-999999999999'
+
+  const parent: SyncCategory = {
+    id: PARENT_ID, name: 'Home', sortOrder: 1, icon: 'House',
+    parentId: null, assignedUserSyncIds: [], updatedAt: '2026-06-01T00:00:00.000Z',
+  }
+  const childA: SyncCategory = {
+    id: CHILD_A_ID, name: 'Kitchen', sortOrder: 2, icon: 'Fork',
+    parentId: PARENT_ID, assignedUserSyncIds: [], updatedAt: '2026-06-02T00:00:00.000Z',
+  }
+  const childB: SyncCategory = {
+    id: CHILD_B_ID, name: 'Bathroom', sortOrder: 3, icon: 'Bath',
+    parentId: PARENT_ID, assignedUserSyncIds: [], updatedAt: '2026-06-03T00:00:00.000Z',
+  }
+
+  it('back-fills parent_category_id for children that arrive before their parent', async () => {
+    // Both children arrive first: parent is absent, so the local FK is unset and
+    // they would (wrongly) render as roots.
+    await applyRemoteEntity(CHILD_A_ID, childA)
+    await applyRemoteEntity(CHILD_B_ID, childB)
+    const beforeA = await db.categories.where('sync_id').equals(CHILD_A_ID).first()
+    const beforeB = await db.categories.where('sync_id').equals(CHILD_B_ID).first()
+    expect(beforeA!.parent_sync_id).toBe(PARENT_ID)
+    expect(beforeA!.parent_category_id).toBeUndefined()
+    expect(beforeB!.parent_category_id).toBeUndefined()
+
+    // Parent lands: both waiting children must now be linked to it.
+    await applyRemoteEntity(PARENT_ID, parent)
+    const parentRow = await db.categories.where('sync_id').equals(PARENT_ID).first()
+    const afterA = await db.categories.where('sync_id').equals(CHILD_A_ID).first()
+    const afterB = await db.categories.where('sync_id').equals(CHILD_B_ID).first()
+    expect(afterA!.parent_category_id).toBe(parentRow!.id)
+    expect(afterB!.parent_category_id).toBe(parentRow!.id)
+    // The parent itself stays a root.
+    expect(parentRow!.parent_category_id).toBeUndefined()
+  })
+})
+
+describe('createDbEngine stale pull-cursor recovery (≤1.3.x upgrade)', () => {
+  const HWM_KEY = 'lastglance-db-sync-hwm'
+  const RECOVERY_FLAG = 'lastglance-db-sync-hwm-recovery-v140'
+
+  beforeAll(() => {
+    setVaultConfig({
+      enabled: true,
+      vaultUrl: 'https://vault.example.test',
+      vaultToken: 'test-token',
+      accountId: 'acct-test',
+    })
+  })
+
+  afterAll(() => {
+    setVaultConfig(null)
+    localStorage.removeItem(HWM_KEY)
+    localStorage.removeItem(RECOVERY_FLAG)
+  })
+
+  it('resets a poisoned pull cursor to 0 exactly once, then leaves it alone', () => {
+    // Simulate a device whose KEY_HWM was advanced past unread peer rows by the
+    // 1.3.x push-advances-pull bug.
+    localStorage.setItem(HWM_KEY, '42')
+    localStorage.removeItem(RECOVERY_FLAG)
+
+    const engine = createDbEngine()
+    expect(engine).not.toBeNull()
+    // The cursor is rewound so the next pull re-lists the full history.
+    expect(engine!.getHighWaterMark()).toBe(0)
+    expect(localStorage.getItem(RECOVERY_FLAG)).not.toBeNull()
+
+    // Idempotent: a later cursor advance must NOT be rewound again.
+    engine!.setHighWaterMark(99)
+    const engine2 = createDbEngine()
+    expect(engine2!.getHighWaterMark()).toBe(99)
   })
 })

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -157,8 +157,35 @@ async function applyCategory(cat: SyncCategory): Promise<void> {
       } as Category)
     }
   })
+  // A child can arrive before its parent (vault seq order is not parents-first),
+  // so back-fill any unresolved parent links now that this row has landed.
+  await resolveCategoryParents()
   // A newly present category may unblock chores that arrived before it.
   await drainDeferredChores()
+}
+
+// Back-fill parent_category_id for any category that carries a parent_sync_id
+// but has no resolved local FK yet. The DB transport applies categories one row
+// at a time in vault seq order, so a subcategory can be written before its
+// parent exists locally; unlike the file tier's two-pass applyPayload, a single
+// applyCategory cannot resolve a not-yet-present parent and leaves the FK unset.
+//
+// This matters because the UI groups strictly by parent_category_id (see
+// useChores.ts): a row with a null/undefined FK renders as a ROOT category, so
+// every subcategory whose parent lands later would otherwise show up flattened
+// to a top-level category. Running this after every category apply closes the
+// gap — when the parent finally arrives, its waiting children get linked. It is
+// idempotent and cheap (the categories table is tiny).
+async function resolveCategoryParents(): Promise<void> {
+  await db.transaction('rw', db.categories, async () => {
+    const cats = await db.categories.toArray()
+    const idBySyncId = new Map(cats.map(c => [c.sync_id, c.id]))
+    for (const c of cats) {
+      if (!c.parent_sync_id || c.parent_category_id != null) continue
+      const parentId = idBySyncId.get(c.parent_sync_id)
+      if (parentId != null) await db.categories.update(c.id!, { parent_category_id: parentId })
+    }
+  })
 }
 
 async function applyChore(chore: SyncChore): Promise<void> {
@@ -317,6 +344,37 @@ export interface DbEngineCallbacks {
   onError?: (message: string | null, code: SyncErrorCode | null) => void
 }
 
+// One-time recovery for devices upgrading from @glance-apps/sync ≤ 1.3.x.
+//
+// In 1.3.x a push advanced the SAME high-water mark that the pull resumes from,
+// so any cycle that pushed local dirty rows bumped the cursor to the highest seq
+// in the account — past unread, lower-seq peer rows, which were then skipped on
+// every subsequent pull. That is permanent for insert-only completion events
+// (they are never re-written, so a later pull never re-lists them). 1.4.0 splits
+// the cursors (KEY_HWM vs KEY_PUSH_ACK) to stop NEW pollution, but it inherits
+// the already-stored KEY_HWM as pull progress, so a device that was polluted
+// under 1.3.x stays stuck and never recovers the skipped rows — exactly the
+// "completions won't sync no matter what" symptom.
+//
+// Reset the pull cursor to 0 once so the next pull re-lists the full account
+// history. Every apply is idempotent (categories/chores/users upsert by sync_id
+// with last-writer-wins; completion events are insert-only and skip if present),
+// so a full re-pull only fills the holes and cannot clobber newer local data.
+// Guarded by a versioned flag so it runs at most once per device.
+const HWM_RECOVERY_FLAG = `${APP_ID}-db-sync-hwm-recovery-v140`
+
+function recoverStalePullCursor(engine: DbSyncEngine): void {
+  if (typeof localStorage === 'undefined') return
+  if (localStorage.getItem(HWM_RECOVERY_FLAG)) return
+  try {
+    if (engine.getHighWaterMark() > 0) engine.setHighWaterMark(0)
+  } catch (err) {
+    console.warn('[lastglance] vault pull-cursor recovery failed:', err)
+  } finally {
+    localStorage.setItem(HWM_RECOVERY_FLAG, new Date().toISOString())
+  }
+}
+
 // Marks every local entity dirty so the next push sends a complete snapshot.
 // Used for the first ever sync on a device (high water mark 0): existing users
 // who enable the vault have data that predates dirty tracking, so without this
@@ -361,6 +419,11 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
     onStatusChange: callbacks.onStatusChange,
     onError: callbacks.onError,
   })
+
+  // Recover devices whose pull cursor was poisoned by the ≤1.3.x push/pull bug
+  // before deciding whether this is a first-ever sync below. Resetting to 0 here
+  // also makes the seeding wrapper re-snapshot local data, which is harmless.
+  recoverStalePullCursor(engine)
 
   // On the first ever sync (high water mark 0), seed the dirty set with the full
   // local dataset so existing users get everything pushed, not just new changes.


### PR DESCRIPTION
## Summary

Two data-integrity bugs surfaced by the iPad iOS app's first GLANCEvault sync and the iOS PWA refusing new completions. **Neither GLANCEvault nor WebDAV is the culprit** — both bugs live in lastGLANCE's row-grained DB transport (`src/sync/dbEngine.ts`), the layer that bridges the vault to the Dexie tables.

## Bug 1 — Subcategories rendered as parent categories (iPad)

The vault applies entities **one row at a time in seq order**, which is *not* guaranteed parents-first. `applyCategory` only resolved a subcategory's local FK (`parent_category_id`) against categories already present, and — unlike the file tier's two-pass `applyPayload` — had no back-fill. So any child applied before its parent kept a null FK. The UI (`useChores.ts`) groups **strictly by `parent_category_id`**, so every such child rendered as a top-level category. The iPad was the first device to pull a *full* dataset through this path, which is why it surfaced now.

**Fix:** added `resolveCategoryParents()`, run after every category apply, to link waiting children once their parent lands. It scans the whole categories table, so already-flattened rows are repaired too.

## Bug 2 — Completions never arriving on a previously-synced device (iOS PWA)

`@glance-apps/sync` 1.3.x advanced the shared high-water mark on *push*, pushing the *pull* cursor past unread lower-seq peer rows and permanently skipping them (fatal for insert-only completion events). 1.4.0 splits the cursors but **inherits the already-poisoned `KEY_HWM` as pull progress**, so previously-affected devices stay stuck — "won't sync no matter what I do."

**Fix:** a one-time, versioned recovery (`recoverStalePullCursor`) that rewinds the pull cursor to 0 so the next pull re-lists the full history. All applies are idempotent (upsert + last-writer-wins; completions skip-if-present), so it only fills holes — it cannot clobber newer local data or duplicate rows.

## Self-healing behavior

Both fixes reinforce each other: the cursor reset forces a full re-pull on the next sync, which re-applies every category row (triggering the parent back-fill) and re-lists the previously-skipped completions. Both devices recover automatically on their first online sync after the update — no manual steps. The recovery is versioned/one-shot and harmless on unaffected devices.

## Testing

- New regression tests: subcategory-before-parent apply; one-shot cursor recovery + idempotency.
- Full suite green: **50/50 tests**, `tsc` clean, production build succeeds.

## Note for upstream

`@glance-apps/sync` 1.4.0's migration assumes the stored cursor was always pull-progress, which isn't true for clients coming from 1.3.x. This app-side reset works around that, but the package's migration is arguably where the underlying gap is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaNwTo1BPT2T2kPnUHA4Bt)_