### PR TITLE
Defer orphaned completion events instead of dropping them (v1.8.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.6-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.7-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.6",
+  "version": "1.8.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -10,10 +10,11 @@ import {
   createDbEngine,
 } from './dbEngine'
 import { getDeferredChores } from './deferredChores'
+import { getDeferredCompletions } from './deferredCompletions'
 import { setVaultConfig } from './vaultConfig'
 import type { DbSyncEngine } from '@glance-apps/sync'
 import type { Category, Chore, CompletionEvent, User } from '@/types'
-import type { SyncCategory, SyncChore } from './types'
+import type { SyncCategory, SyncChore, SyncCompletionEvent } from './types'
 
 // Minimal in-memory localStorage for the node test environment (the deferred
 // chore buffer persists there).
@@ -181,6 +182,54 @@ describe('applyRemoteEntity out-of-order chore and category', () => {
   })
 })
 
+describe('applyRemoteEntity completion before its chore', () => {
+  // Regression guard for "received some completions, not all": a completion whose
+  // chore is not present yet (the chore was edited after the completion, so its
+  // row carries a higher seq and arrives later, or the chore is itself parked
+  // awaiting its category) must be parked and applied once the chore lands — never
+  // dropped, because an insert-only completion is never re-listed.
+  const ECAT_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+  const ECHORE_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+  const EEVENT_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+
+  const remoteCategory: SyncCategory = {
+    id: ECAT_ID, name: 'Yard', sortOrder: 7, icon: 'Tree',
+    parentId: null, assignedUserSyncIds: [], updatedAt: '2026-06-10T00:00:00.000Z',
+  }
+  const remoteChore: SyncChore = {
+    id: ECHORE_ID, name: 'Mow', categorySyncId: ECAT_ID, sortOrder: 0,
+    targetCadenceDays: 14, notifyWhenOverdue: false, autoScheduleToDayglance: false,
+    preferredScheduleBehavior: null, seasonalStart: null, seasonalEnd: null,
+    icon: 'Scissors', assignedUserSyncIds: [],
+    createdAt: '2026-06-11T00:00:00.000Z', updatedAt: '2026-06-12T00:00:00.000Z',
+  }
+  const remoteEvent: SyncCompletionEvent = {
+    id: EEVENT_ID, choreSyncId: ECHORE_ID, completedAt: '2026-06-11T09:00:00.000Z',
+    note: null, source: 'manual', completedByUserSyncId: null,
+  }
+
+  it('parks a completion whose chore is absent, then applies it once the chore lands', async () => {
+    // Completion arrives first: chore not present, so it must be parked, not dropped.
+    await applyRemoteEntity(EEVENT_ID, remoteEvent)
+    expect(await db.completionEvents.where('sync_id').equals(EEVENT_ID).first()).toBeUndefined()
+    expect(getDeferredCompletions().map(e => e.id)).toContain(EEVENT_ID)
+
+    // Chore is still parked too (its category has not arrived): completion stays parked.
+    await applyRemoteEntity(ECHORE_ID, remoteChore)
+    expect(await db.completionEvents.where('sync_id').equals(EEVENT_ID).first()).toBeUndefined()
+    expect(getDeferredCompletions().map(e => e.id)).toContain(EEVENT_ID)
+
+    // Category lands: chore drains, and draining the chore drains the completion.
+    await applyRemoteEntity(ECAT_ID, remoteCategory)
+    const landedChore = await db.chores.where('sync_id').equals(ECHORE_ID).first()
+    expect(landedChore).toBeTruthy()
+    const landedEvent = await db.completionEvents.where('sync_id').equals(EEVENT_ID).first()
+    expect(landedEvent).toBeTruthy()
+    expect(landedEvent!.chore_id).toBe(landedChore!.id)
+    expect(getDeferredCompletions().map(e => e.id)).not.toContain(EEVENT_ID)
+  })
+})
+
 describe('applyRemoteEntity subcategory before its parent', () => {
   // Regression guard for the "all subcategories show as parent categories" bug:
   // the vault applies categories one row at a time in seq order, which is NOT
@@ -227,9 +276,10 @@ describe('applyRemoteEntity subcategory before its parent', () => {
   })
 })
 
-describe('createDbEngine stale pull-cursor recovery (≤1.3.x upgrade)', () => {
+describe('createDbEngine stale pull-cursor recovery', () => {
   const HWM_KEY = 'lastglance-db-sync-hwm'
-  const RECOVERY_FLAG = 'lastglance-db-sync-hwm-recovery-v140'
+  const RECOVERY_FLAG = 'lastglance-db-sync-hwm-recovery-gen'
+  const CURRENT_GEN = 2
 
   beforeAll(() => {
     setVaultConfig({
@@ -246,21 +296,30 @@ describe('createDbEngine stale pull-cursor recovery (≤1.3.x upgrade)', () => {
     localStorage.removeItem(RECOVERY_FLAG)
   })
 
-  it('resets a poisoned pull cursor to 0 exactly once, then leaves it alone', () => {
-    // Simulate a device whose KEY_HWM was advanced past unread peer rows by the
-    // 1.3.x push-advances-pull bug.
+  it('rewinds the pull cursor to 0 once per generation, then leaves it alone', () => {
+    // A device that has never run recovery (no flag).
     localStorage.setItem(HWM_KEY, '42')
     localStorage.removeItem(RECOVERY_FLAG)
 
     const engine = createDbEngine()
     expect(engine).not.toBeNull()
-    // The cursor is rewound so the next pull re-lists the full history.
+    // Cursor rewound so the next pull re-lists the full history.
     expect(engine!.getHighWaterMark()).toBe(0)
-    expect(localStorage.getItem(RECOVERY_FLAG)).not.toBeNull()
+    expect(localStorage.getItem(RECOVERY_FLAG)).toBe(String(CURRENT_GEN))
 
-    // Idempotent: a later cursor advance must NOT be rewound again.
+    // Idempotent within a generation: a later cursor advance is NOT rewound.
     engine!.setHighWaterMark(99)
     const engine2 = createDbEngine()
     expect(engine2!.getHighWaterMark()).toBe(99)
+  })
+
+  it('re-runs when the device is behind the current generation', () => {
+    // A device that already ran an earlier generation's recovery.
+    localStorage.setItem(HWM_KEY, '77')
+    localStorage.setItem(RECOVERY_FLAG, '1')
+
+    const engine = createDbEngine()
+    expect(engine!.getHighWaterMark()).toBe(0)
+    expect(localStorage.getItem(RECOVERY_FLAG)).toBe(String(CURRENT_GEN))
   })
 })

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -20,6 +20,12 @@ import type { SyncCategory, SyncChore, SyncCompletionEvent, SyncUser } from './t
 import { getVaultConfig, isVaultEnabled } from './vaultConfig'
 import { getDeviceId } from './deviceId'
 import { addDeferredChore, removeDeferredChore, getDeferredChores } from './deferredChores'
+import {
+  addDeferredCompletion,
+  removeDeferredCompletion,
+  removeDeferredCompletionsForChore,
+  getDeferredCompletions,
+} from './deferredCompletions'
 
 const APP_ID = 'lastglance'
 const CRYPTO_DB_NAME = 'lastglance-crypto'
@@ -236,8 +242,15 @@ async function applyChore(chore: SyncChore): Promise<void> {
     }
   })
   // Buffer the chore when skipped; clear it from the buffer once applied.
-  if (skipped) addDeferredChore(chore)
-  else removeDeferredChore(chore.id)
+  if (skipped) {
+    addDeferredChore(chore)
+  } else {
+    removeDeferredChore(chore.id)
+    // The chore is now present, so any completion events parked waiting on it can
+    // be applied. Chains correctly when this chore itself was drained after its
+    // category landed (applyCategory → drainDeferredChores → applyChore → here).
+    await drainDeferredCompletions()
+  }
 }
 
 // Re-apply parked chores whose category is now present locally. Called after a
@@ -255,12 +268,19 @@ async function drainDeferredChores(): Promise<void> {
 }
 
 async function applyCompletionEvent(evt: SyncCompletionEvent): Promise<void> {
+  let skipped = false
   await db.transaction('rw', db.completionEvents, db.chores, async () => {
     // Insert-only: if it is already present, leave it untouched.
     const existing = await db.completionEvents.where('sync_id').equals(evt.id).first()
     if (existing) return
     const chore = await db.chores.where('sync_id').equals(evt.choreSyncId).first()
-    if (!chore) return // chore was deleted; skip orphaned event
+    // The chore may not be present yet (it arrives later in seq order when it was
+    // edited after this completion, or it is itself parked awaiting its category),
+    // OR it may have been deleted. We cannot tell the two apart here, so park the
+    // event and let drainDeferredCompletions retry once a chore with this sync_id
+    // lands. A completion is insert-only and never re-listed, so dropping it here
+    // would lose it permanently — that was the "some completions never arrive" bug.
+    if (!chore) { skipped = true; return }
     await db.completionEvents.add({
       sync_id: evt.id,
       chore_id: chore.id,
@@ -270,6 +290,21 @@ async function applyCompletionEvent(evt: SyncCompletionEvent): Promise<void> {
       completed_by_user_sync_id: evt.completedByUserSyncId ?? null,
     } as CompletionEvent)
   })
+  // Buffer the event when skipped; clear it from the buffer once applied/present.
+  if (skipped) addDeferredCompletion(evt)
+  else removeDeferredCompletion(evt.id)
+}
+
+// Re-apply parked completions whose chore is now present locally. Called after a
+// chore is applied. applyCompletionEvent removes each from the buffer on success
+// and re-parks any that still cannot resolve, so this is safe to call repeatedly.
+async function drainDeferredCompletions(): Promise<void> {
+  const deferred = getDeferredCompletions()
+  if (deferred.length === 0) return
+  for (const evt of deferred) {
+    const chore = await db.chores.where('sync_id').equals(evt.choreSyncId).first()
+    if (chore) await applyCompletionEvent(evt)
+  }
 }
 
 async function applyUser(user: SyncUser): Promise<void> {
@@ -325,8 +360,12 @@ export async function applyRemoteDelete(entityId: string): Promise<void> {
       if (user) { await db.users.delete(user.id); return }
     },
   )
-  // Drop any parked copy so a deleted chore is never resurrected by a later drain.
+  // Drop any parked copy so a deleted entity is never resurrected by a later
+  // drain: the chore itself, a parked completion with this id, and any parked
+  // completions that belonged to a now-deleted chore (their chore will never land).
   removeDeferredChore(entityId)
+  removeDeferredCompletion(entityId)
+  removeDeferredCompletionsForChore(entityId)
   notifyApplied()
 }
 
@@ -358,20 +397,30 @@ export interface DbEngineCallbacks {
 //
 // Reset the pull cursor to 0 once so the next pull re-lists the full account
 // history. Every apply is idempotent (categories/chores/users upsert by sync_id
-// with last-writer-wins; completion events are insert-only and skip if present),
-// so a full re-pull only fills the holes and cannot clobber newer local data.
-// Guarded by a versioned flag so it runs at most once per device.
-const HWM_RECOVERY_FLAG = `${APP_ID}-db-sync-hwm-recovery-v140`
+// with last-writer-wins; completion events are insert-only and skip if present,
+// and orphaned rows are now parked rather than dropped), so a full re-pull only
+// fills the holes and cannot clobber newer local data.
+//
+// Tracked by a monotonic generation rather than a boolean: each generation that
+// requires devices to re-pull the full history once bumps RECOVERY_GENERATION,
+// and a device re-runs the reset whenever its stored generation is behind.
+//   gen 1 (v1.8.6): split-cursor poisoning from @glance-apps/sync ≤ 1.3.x.
+//   gen 2 (v1.8.7): re-pull so completions dropped on a not-yet-present chore by
+//                   the old applyCompletionEvent are re-listed and now parked.
+const RECOVERY_GENERATION = 2
+const HWM_RECOVERY_FLAG = `${APP_ID}-db-sync-hwm-recovery-gen`
 
 function recoverStalePullCursor(engine: DbSyncEngine): void {
   if (typeof localStorage === 'undefined') return
-  if (localStorage.getItem(HWM_RECOVERY_FLAG)) return
+  // NaN (absent / legacy timestamp value) is treated as behind, so it runs.
+  const done = Number(localStorage.getItem(HWM_RECOVERY_FLAG))
+  if (done >= RECOVERY_GENERATION) return
   try {
     if (engine.getHighWaterMark() > 0) engine.setHighWaterMark(0)
   } catch (err) {
     console.warn('[lastglance] vault pull-cursor recovery failed:', err)
   } finally {
-    localStorage.setItem(HWM_RECOVERY_FLAG, new Date().toISOString())
+    localStorage.setItem(HWM_RECOVERY_FLAG, String(RECOVERY_GENERATION))
   }
 }
 

--- a/src/sync/deferredCompletions.ts
+++ b/src/sync/deferredCompletions.ts
@@ -1,0 +1,70 @@
+// Deferred-completion buffer for the GLANCEvault DB transport.
+//
+// Mirror of deferredChores, one level down the dependency chain. applyCompletion
+// Event cannot insert a completion until its chore exists locally (the schema
+// needs a numeric chore_id). Vault seq order does NOT guarantee a chore arrives
+// before its completions: editing a chore bumps its seq above older completion
+// rows, the chore may itself be parked awaiting its category, and writes
+// interleave across devices and pull pages. A completion event is insert-only
+// and is never re-written, so once the pull cursor advances past it the engine
+// never re-lists it — dropping it on a missing chore loses it permanently. That
+// was the "received some completions, not all" bug.
+//
+// So when applyCompletionEvent has to skip, the completion's sync shape is parked
+// here, keyed by sync_id, and re-applied once its chore shows up (see
+// drainDeferredCompletions in dbEngine.ts). Persisted in localStorage so it
+// survives the reload between pull cycles.
+
+import type { SyncCompletionEvent } from './types'
+
+const KEY = 'lastglance-db-deferred-completions'
+
+type Buffer = Record<string, SyncCompletionEvent>
+
+function read(): Buffer {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as Buffer) : {}
+  } catch {
+    return {}
+  }
+}
+
+function write(buf: Buffer): void {
+  if (Object.keys(buf).length === 0) localStorage.removeItem(KEY)
+  else localStorage.setItem(KEY, JSON.stringify(buf))
+}
+
+// Park a completion whose chore is not present yet.
+export function addDeferredCompletion(evt: SyncCompletionEvent): void {
+  const buf = read()
+  buf[evt.id] = evt
+  write(buf)
+}
+
+// Drop a completion from the buffer once it has been applied (or deleted).
+export function removeDeferredCompletion(syncId: string): void {
+  const buf = read()
+  if (syncId in buf) {
+    delete buf[syncId]
+    write(buf)
+  }
+}
+
+// Drop every parked completion that belongs to the given chore. Used when a
+// chore is deleted, so its orphaned completions are not retained forever.
+export function removeDeferredCompletionsForChore(choreSyncId: string): void {
+  const buf = read()
+  let changed = false
+  for (const [id, evt] of Object.entries(buf)) {
+    if (evt.choreSyncId === choreSyncId) { delete buf[id]; changed = true }
+  }
+  if (changed) write(buf)
+}
+
+// All currently parked completions.
+export function getDeferredCompletions(): SyncCompletionEvent[] {
+  return Object.values(read())
+}


### PR DESCRIPTION
Follow-up to #122 (v1.8.6). That release fixed flattened subcategories and reset poisoned pull cursors, but a user reported the iOS PWA **still** wasn't receiving completions after updating — and the iPad had received "some completions, not all" even on a fresh full pull. A fresh device pulls from seq 0, so a stuck cursor can't explain dropped rows: something was discarding completions at apply time.

## Root cause

`applyCompletionEvent` dropped any completion whose chore wasn't present locally, assuming the chore had been deleted:

```js
const chore = await db.chores.where('sync_id').equals(evt.choreSyncId).first()
if (!chore) return // chore was deleted; skip orphaned event
```

But a missing chore is usually **not-yet-arrived**, not deleted. The vault delivers rows in seq (write) order, and **editing a chore bumps its row's seq above completions logged earlier**, so a completion routinely arrives before its chore. The chore can also be parked itself, awaiting its category. Completions are insert-only and never re-listed, so dropping one loses it permanently — and the v1.8.6 cursor reset re-pulled them only to have them dropped again.

## Fix

- New `deferredCompletions` buffer (mirrors the existing `deferredChores`): a completion whose chore is absent is **parked**, not dropped, and re-applied once a chore with the matching `sync_id` lands.
- `drainDeferredCompletions` runs after every successful chore apply, so it chains through the full dependency: `category lands → drainDeferredChores → applyChore → drainDeferredCompletions`.
- `applyRemoteDelete` purges parked completions for a deleted chore (and a parked copy of a deleted completion), so the buffer can't leak.
- Cursor recovery is now a **monotonic generation** (bumped to gen 2): devices that already ran the v1.8.6 reset re-pull the full history once more, this time parking the previously-dropped completions instead of losing them.

## Testing

- New regression test: a completion arriving before its chore is parked, stays parked while the chore itself is parked awaiting its category, then applies once the category → chore → completion chain resolves.
- Recovery test extended: re-runs when a device is behind the current generation.
- Full suite green, `tsc` clean, build OK. Version bumped to 1.8.7 (lockfile + README).

## Caveat

This recovers completions **that actually reached GLANCEvault**. If the desktop's vault push of them never succeeded (vs. its WebDAV push), they aren't in the vault and no client-side fix can recover them — that would be the next thing to confirm if a device still misses them after updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaNwTo1BPT2T2kPnUHA4Bt)_