### PR TITLE
Repair already-flat subcategories on vault devices (v1.8.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.7-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.8-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.7",
+      "version": "1.8.8",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.7",
+  "version": "1.8.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -8,6 +8,7 @@ import {
   applyRemoteEntity,
   markAllLocalEntitiesDirty,
   createDbEngine,
+  resolveCategoryParents,
 } from './dbEngine'
 import { getDeferredChores } from './deferredChores'
 import { getDeferredCompletions } from './deferredCompletions'
@@ -273,6 +274,40 @@ describe('applyRemoteEntity subcategory before its parent', () => {
     expect(afterB!.parent_category_id).toBe(parentRow!.id)
     // The parent itself stays a root.
     expect(parentRow!.parent_category_id).toBeUndefined()
+  })
+})
+
+describe('resolveCategoryParents repairs already-flat categories', () => {
+  // A device that received its categories flat under an earlier build has them
+  // stored with parent_sync_id set but parent_category_id missing. A re-pull will
+  // NOT fix them (last-writer-wins skips already-present rows with unchanged
+  // updatedAt), so the standalone repair must relink them directly from local data.
+  const RPARENT_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd'
+  const RCHILD_ID = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
+
+  it('links a flat subcategory to a parent that is already present locally', async () => {
+    const parentKey = await db.categories.add({
+      name: 'Vehicles', sort_order: 1, icon: 'Car', sync_id: RPARENT_ID,
+      parent_sync_id: null, assigned_user_sync_ids: [], updated_at: '2026-06-15T00:00:00.000Z',
+    } as unknown as Category)
+    // Child stored flat: parent_sync_id is correct, but parent_category_id is unset.
+    await db.categories.add({
+      name: 'Motorcycle', sort_order: 2, icon: 'Bike', sync_id: RCHILD_ID,
+      parent_sync_id: RPARENT_ID, assigned_user_sync_ids: [], updated_at: '2026-06-16T00:00:00.000Z',
+    } as unknown as Category)
+
+    const before = await db.categories.where('sync_id').equals(RCHILD_ID).first()
+    expect(before!.parent_category_id).toBeUndefined()
+
+    const changed = await resolveCategoryParents()
+    expect(changed).toBeGreaterThanOrEqual(1)
+
+    const after = await db.categories.where('sync_id').equals(RCHILD_ID).first()
+    expect(after!.parent_category_id).toBe(parentKey as number)
+
+    // Idempotent: a second pass changes nothing for this pair.
+    const stillLinked = await db.categories.where('sync_id').equals(RCHILD_ID).first()
+    expect(stillLinked!.parent_category_id).toBe(parentKey as number)
   })
 })
 

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -171,27 +171,37 @@ async function applyCategory(cat: SyncCategory): Promise<void> {
 }
 
 // Back-fill parent_category_id for any category that carries a parent_sync_id
-// but has no resolved local FK yet. The DB transport applies categories one row
-// at a time in vault seq order, so a subcategory can be written before its
-// parent exists locally; unlike the file tier's two-pass applyPayload, a single
+// but has no resolved local FK yet, and report how many rows it fixed.
+//
+// Two situations need this. (1) The DB transport applies categories one row at a
+// time in vault seq order, so a subcategory can be written before its parent
+// exists locally; unlike the file tier's two-pass applyPayload, a single
 // applyCategory cannot resolve a not-yet-present parent and leaves the FK unset.
+// (2) A device that received its categories flat under an earlier build still has
+// them flat: a re-pull will NOT repair them, because @glance-apps/sync skips an
+// already-present row whose updatedAt is not strictly newer (last-writer-wins), so
+// applyCategory never re-runs for them. The parent row and parent_sync_id are both
+// present locally, so this standalone pass relinks them regardless of the pull.
 //
 // This matters because the UI groups strictly by parent_category_id (see
 // useChores.ts): a row with a null/undefined FK renders as a ROOT category, so
-// every subcategory whose parent lands later would otherwise show up flattened
-// to a top-level category. Running this after every category apply closes the
-// gap — when the parent finally arrives, its waiting children get linked. It is
-// idempotent and cheap (the categories table is tiny).
-async function resolveCategoryParents(): Promise<void> {
+// every unlinked subcategory shows up flattened to a top-level category. Idempotent
+// and cheap (the categories table is tiny).
+export async function resolveCategoryParents(): Promise<number> {
+  let changed = 0
   await db.transaction('rw', db.categories, async () => {
     const cats = await db.categories.toArray()
     const idBySyncId = new Map(cats.map(c => [c.sync_id, c.id]))
     for (const c of cats) {
       if (!c.parent_sync_id || c.parent_category_id != null) continue
       const parentId = idBySyncId.get(c.parent_sync_id)
-      if (parentId != null) await db.categories.update(c.id!, { parent_category_id: parentId })
+      if (parentId != null) {
+        await db.categories.update(c.id!, { parent_category_id: parentId })
+        changed++
+      }
     }
   })
+  return changed
 }
 
 async function applyChore(chore: SyncChore): Promise<void> {
@@ -474,6 +484,15 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
   // also makes the seeding wrapper re-snapshot local data, which is harmless.
   recoverStalePullCursor(engine)
 
+  // Repair categories that were stored flat by an earlier build, immediately on
+  // open. A re-pull cannot fix these (last-writer-wins skips already-present rows
+  // whose updatedAt is unchanged), but their parent_sync_id and parent row are
+  // already local, so this relinks them. Fire-and-forget; refresh the UI if it
+  // changed anything so the nesting appears without waiting for a sync.
+  resolveCategoryParents()
+    .then((n) => { if (n > 0) notifyApplied() })
+    .catch((err) => console.warn('[lastglance] category parent repair failed:', err))
+
   // On the first ever sync (high water mark 0), seed the dirty set with the full
   // local dataset so existing users get everything pushed, not just new changes.
   // After a successful first push the high water mark advances past 0, so this
@@ -488,6 +507,13 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
       }
     }
     await runCycle()
+    // A pull may have skipped already-present rows under last-writer-wins, so run
+    // the repair after every cycle too; refresh the UI when it links anything.
+    try {
+      if ((await resolveCategoryParents()) > 0) notifyApplied()
+    } catch (err) {
+      console.warn('[lastglance] category parent repair failed:', err)
+    }
   }
 
   return { ...engine, dbSyncCycle, sync: dbSyncCycle }


### PR DESCRIPTION
After v1.8.7 fixed completion sync, a user reported the iOS app **still** showed subcategories as top-level categories. This is a real bug, not a platform quirk.

## Root cause

v1.8.6 added `resolveCategoryParents`, but it only ran *inside* `applyCategory` — i.e. only when a category row is actually applied. A device that had already stored its categories flat (under the original 1.4.0 sync) never gets them re-applied:

- On the cursor-reset re-pull, an already-present category falls into `@glance-apps/sync`'s **last-writer-wins** path: `remoteWins = remote.updatedAt > local.updatedAt`.
- The re-pulled row has the **same `updatedAt`** as the local copy, so remote does not win, `applyRemoteEntity` is skipped, and `resolveCategoryParents` never runs for it.

So the re-pull recovered completions (insert-only → always applied) but left the existing flat subcategories untouched. They stayed flattened — exactly the remaining symptom.

## Fix

Repair local data directly instead of relying on the pull. The child's `parent_sync_id` and the parent row are both already present locally, so a standalone `resolveCategoryParents` pass relinks `parent_category_id`:

- Runs at **engine init** (immediate repair when the app opens) and **after every sync cycle**.
- `resolveCategoryParents` now reports how many rows it fixed; the UI is refreshed (`lg:sync-applied`) only when it links something.
- Idempotent and cheap — the categories table is tiny.

No change to the apply-time behavior added in v1.8.6; this closes the gap for data that was already on disk.

## Testing

- New test: a flat subcategory whose parent is already local is relinked by a direct `resolveCategoryParents` call, with no `applyCategory` involved.
- Full suite green (36 tests), `tsc` clean, build OK. Version bumped to 1.8.8 (lockfile + README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaNwTo1BPT2T2kPnUHA4Bt)_