### PR TITLE
v1.8.9 — @glance-apps/sync 1.5.2 vault safeguards, typed sync error codes, native storage-warning gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.8.8-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.8.9-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/ios": "^8.4.0",
         "@capacitor/status-bar": "^8.0.2",
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.5.0",
+        "@glance-apps/sync": "^1.5.2",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -2795,9 +2795,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.0.tgz",
-      "integrity": "sha512-Sm1WLT+x/1fxBZ1rkN+/OQif2w3padII1pAppnP6IJQXVmGs5PlPmpjjIP8e5kJnI+Hs0Qo8pyzDP8J+PkWmlA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.2.tgz",
+      "integrity": "sha512-S+O/bsGxtkDzcVBPhI8DlTiy89cfOwe9XGFaZoD3G1m2kZzOW9RnKNqHYuPSP2+Auy0RFPBQla+45nhm6WuN+A==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/ios": "^8.4.0",
         "@capacitor/status-bar": "^8.0.2",
         "@glance-apps/intents": "^1.3.3",
-        "@glance-apps/sync": "1.4.0",
+        "@glance-apps/sync": "1.5.0",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -2795,9 +2795,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.4.0.tgz",
-      "integrity": "sha512-qk5H5ExPrHVH3VLlCBJLG29A5AGK4djwzslr9ENLqmSqvi6ubN52weNY66Jz3CqFKOVF//gwdMH9hOiNd3WSqQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.0.tgz",
+      "integrity": "sha512-Sm1WLT+x/1fxBZ1rkN+/OQif2w3padII1pAppnP6IJQXVmGs5PlPmpjjIP8e5kJnI+Hs0Qo8pyzDP8J+PkWmlA==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/ios": "^8.4.0",
     "@capacitor/status-bar": "^8.0.2",
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.4.0",
+    "@glance-apps/sync": "1.5.0",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/ios": "^8.4.0",
     "@capacitor/status-bar": "^8.0.2",
     "@glance-apps/intents": "^1.3.3",
-    "@glance-apps/sync": "1.5.0",
+    "@glance-apps/sync": "^1.5.2",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.8.8",
+  "version": "1.8.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
 import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
-import { createDbEngine } from '@/sync/dbEngine'
+import { createDbEngine, vaultErrorMessage } from '@/sync/dbEngine'
 import { registerDbEngine } from '@/sync/dirtyTracker'
 import { isVaultEnabled } from '@/sync/vaultConfig'
 import { applyStatusBarTheme, initFullScreenInLandscape } from '@/native/statusBar'
@@ -113,12 +113,6 @@ function HeaderHeatmap({ weeks }: { weeks: HeatDay[][] }) {
 }
 
 // ── App ───────────────────────────────────────────────────────────────────────
-
-// @glance-apps/sync 1.5.0 surfaces a wrong derived root key as a typed
-// KEY_MISMATCH error (the engine aborts BEFORE uploading anything, so the account
-// is never polluted). Replace the raw crypto text with a clear, actionable line.
-const VAULT_KEY_MISMATCH_MESSAGE =
-  'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
 
 function AppInner() {
   const { t } = useTranslation()
@@ -228,9 +222,18 @@ function AppInner() {
     // is enabled. It shares the local data but uses an entirely separate cycle.
     const dbEngine = createDbEngine({
       onError: (msg, code) => {
-        // A wrong passphrase/salt now fails fast with KEY_MISMATCH and uploads
-        // NOTHING — show the plain-language reason instead of the raw crypto text.
-        const display = code === 'KEY_MISMATCH' ? VAULT_KEY_MISMATCH_MESSAGE : msg
+        // A missing passphrase isn't a sync failure — prompt for it the same way
+        // the file engine's onPassphraseRequired does, and surface no error.
+        if (code === 'PASSPHRASE_REQUIRED') {
+          setVaultSyncError(null)
+          setShowPassphrase(true)
+          return
+        }
+        // Map the typed DB-transport codes (KEY_MISMATCH / VERIFIER_UNSUPPORTED /
+        // ACCOUNT_ID_REQUIRED) to plain-language text; other codes pass through.
+        // A wrong key fails fast and uploads NOTHING, so the account is never
+        // polluted; ACCOUNT_ID_REQUIRED is retryable and phrased as "not ready yet".
+        const display = vaultErrorMessage(msg, code)
         setVaultSyncError(display)
         if (display) console.warn('[lastglance] vault sync error:', display)
       },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { PassphraseModal } from '@/components/PassphraseModal/PassphraseModal'
 import { HelpModal } from '@/components/HelpModal/HelpModal'
 import { ShortcutsModal } from '@/components/ShortcutsModal/ShortcutsModal'
 import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal'
-import { ToastProvider } from '@/components/Toast/Toast'
+import { ToastProvider, useToast } from '@/components/Toast/Toast'
 import { UsersModal } from '@/components/UsersModal/UsersModal'
 import { UsersContext } from '@/multiuser/UsersContext'
 import { useUsers } from '@/multiuser/useUsers'
@@ -114,8 +114,15 @@ function HeaderHeatmap({ weeks }: { weeks: HeatDay[][] }) {
 
 // ── App ───────────────────────────────────────────────────────────────────────
 
+// @glance-apps/sync 1.5.0 surfaces a wrong derived root key as a typed
+// KEY_MISMATCH error (the engine aborts BEFORE uploading anything, so the account
+// is never polluted). Replace the raw crypto text with a clear, actionable line.
+const VAULT_KEY_MISMATCH_MESSAGE =
+  'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
+
 function AppInner() {
   const { t } = useTranslation()
+  const { showToast } = useToast()
   useNotifications()
   const { refreshConfig } = useIntents()
   const usersCtx = useUsers()
@@ -152,13 +159,28 @@ function AppInner() {
   // dbSyncCycle swallows errors internally and reports them here rather than
   // throwing, so this is how the Cloud Sync modal shows what went wrong.
   const [vaultSyncError, setVaultSyncError] = useState<string | null>(null)
+  // Durable count of rows the last vault cycle could not decrypt (1.5.0 per-row
+  // quarantine). Survives after the transient toast dismisses so a key mismatch on
+  // some rows stays visible in the Cloud Sync settings panel.
+  const [vaultSkipped, setVaultSkipped] = useState(0)
+
+  // showToast is stable, but the mount effect that builds the engine reads it from
+  // a ref so the onRowsSkipped closure always calls the live one.
+  const showToastRef = useRef(showToast)
+  showToastRef.current = showToast
 
   // Runs one DB sync cycle when the vault transport is enabled. No-op otherwise.
   // Fired on the same triggers as the file engine; errors are surfaced through
-  // the engine's onError callback (logged, non-fatal to the file tier).
+  // the engine's onError callback (logged, non-fatal to the file tier). The cycle
+  // resolves to { applied, skipped, ... }; mirror its skip count into the durable
+  // signal so a clean cycle clears it and a quarantining one keeps it visible.
   const runDbSync = useCallback(() => {
     const eng = dbEngineRef.current
-    if (eng) eng.dbSyncCycle().catch(() => {/* surfaced via onError */})
+    if (eng) {
+      eng.dbSyncCycle()
+        .then(res => setVaultSkipped(res?.skipped ?? 0))
+        .catch(() => {/* surfaced via onError */})
+    }
   }, [])
 
   useEffect(() => {
@@ -205,9 +227,21 @@ function AppInner() {
     // Construct the DB transport engine alongside the file engine when the vault
     // is enabled. It shares the local data but uses an entirely separate cycle.
     const dbEngine = createDbEngine({
-      onError: (msg) => {
-        setVaultSyncError(msg)
-        if (msg) console.warn('[lastglance] vault sync error:', msg)
+      onError: (msg, code) => {
+        // A wrong passphrase/salt now fails fast with KEY_MISMATCH and uploads
+        // NOTHING — show the plain-language reason instead of the raw crypto text.
+        const display = code === 'KEY_MISMATCH' ? VAULT_KEY_MISMATCH_MESSAGE : msg
+        setVaultSyncError(display)
+        if (display) console.warn('[lastglance] vault sync error:', display)
+      },
+      onRowsSkipped: (count) => {
+        // Durable: keep the count visible in the sync settings panel after the toast.
+        setVaultSkipped(count)
+        // Transient: nudge the user toward the settings where the count lives.
+        showToastRef.current({
+          title: `${count} ${count === 1 ? 'item' : 'items'} couldn’t be read`,
+          body: 'Some synced rows couldn’t be decrypted. Check Cloud Sync settings.',
+        })
       },
     })
     dbEngineRef.current = dbEngine
@@ -539,6 +573,7 @@ function AppInner() {
           dbEngine={dbEngineRef.current}
           syncError={syncError}
           vaultSyncError={vaultSyncError}
+          vaultSkipped={vaultSkipped}
           onClose={() => { setShowSyncSettings(false); runSharedUserSync() }}
         />
       )}

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { X, HelpCircle, ExternalLink } from 'lucide-react'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
+import { isNativePlatform } from '@/sync/nativeHttp'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -36,6 +37,12 @@ export function HelpModal({ onClose, onOpenShortcuts }: Props) {
         setStorage({ used: est.usage, quota: est.quota })
       }
     }).catch(() => {})
+    // The persistent-storage prompt only applies to the browser, where the OS may
+    // evict an unpersisted origin. On the native (Capacitor) iOS/Android shells the
+    // app's data store is durably owned by the app, so navigator.storage.persisted()
+    // is irrelevant there (and may report false) — skip the check so the warning
+    // never shows. Mirrors the gating dayGLANCE uses for the same notice.
+    if (isNativePlatform) return
     navigator.storage?.persisted?.().then(p => setPersisted(p ?? null)).catch(() => {})
   }, [])
 

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -16,13 +16,17 @@ interface Props {
   // reason a manual sync failed.
   syncError: string | null
   vaultSyncError: string | null
+  // Count of rows the last vault cycle could not decrypt (1.5.0 per-row
+  // quarantine). Shown as a durable amber note so a key mismatch on some rows is
+  // visible after the transient toast dismisses.
+  vaultSkipped: number
   onClose: () => void
 }
 
 type TestStatus = 'idle' | 'testing' | 'ok' | 'fail'
 type SyncResult = 'idle' | 'ok' | 'error'
 
-export function SyncSettingsModal({ engine, dbEngine, syncError, vaultSyncError, onClose }: Props) {
+export function SyncSettingsModal({ engine, dbEngine, syncError, vaultSyncError, vaultSkipped, onClose }: Props) {
   const { t } = useTranslation()
   const existingConfig = engine?.getConfig() ?? null
   const initFolder = localStorage.getItem(SYNC_FOLDER_KEY) ?? DEFAULT_SYNC_FOLDER
@@ -592,6 +596,16 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, vaultSyncError,
                       ? t('sync.lastSynced', { date: formatLastSynced(vaultLastSynced) })
                       : 'Save & reload to activate GLANCEvault sync.'}
                   </p>
+                )}
+                {vaultSkipped > 0 && (
+                  <div className="flex items-start gap-2 p-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/40">
+                    <AlertTriangle size={14} className="text-amber-500 shrink-0 mt-0.5" />
+                    <p className="text-xs text-amber-700 dark:text-amber-300">
+                      {vaultSkipped} {vaultSkipped === 1 ? 'item' : 'items'} couldn’t be read on the last sync.
+                      This usually means a wrong sync passphrase on some rows. They’re skipped and retried
+                      automatically on later syncs — nothing was lost or overwritten.
+                    </p>
+                  </div>
                 )}
               </div>
             )}

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -9,6 +9,10 @@ import {
   markAllLocalEntitiesDirty,
   createDbEngine,
   resolveCategoryParents,
+  vaultErrorMessage,
+  VAULT_KEY_MISMATCH_MESSAGE,
+  VAULT_VERIFIER_UNSUPPORTED_MESSAGE,
+  VAULT_ACCOUNT_ID_REQUIRED_MESSAGE,
 } from './dbEngine'
 import { getDeferredChores } from './deferredChores'
 import { getDeferredCompletions } from './deferredCompletions'
@@ -356,5 +360,37 @@ describe('createDbEngine stale pull-cursor recovery', () => {
     const engine = createDbEngine()
     expect(engine!.getHighWaterMark()).toBe(0)
     expect(localStorage.getItem(RECOVERY_FLAG)).toBe(String(CURRENT_GEN))
+  })
+})
+
+// The single onError funnel in App.tsx routes the typed DB-transport codes
+// (1.5.0–1.5.2) through this pure mapper; assert each code's user-facing text.
+describe('vaultErrorMessage typed code mapping', () => {
+  it('maps KEY_MISMATCH to the wrong-passphrase message', () => {
+    expect(vaultErrorMessage('aes-gcm decrypt failed', 'KEY_MISMATCH'))
+      .toBe(VAULT_KEY_MISMATCH_MESSAGE)
+  })
+
+  it('maps VERIFIER_UNSUPPORTED to the server-update message', () => {
+    expect(vaultErrorMessage('404 on __glance_keycheck', 'VERIFIER_UNSUPPORTED'))
+      .toBe(VAULT_VERIFIER_UNSUPPORTED_MESSAGE)
+  })
+
+  it('maps the retryable ACCOUNT_ID_REQUIRED to a "not ready yet" message', () => {
+    expect(vaultErrorMessage('missing accountId', 'ACCOUNT_ID_REQUIRED'))
+      .toBe(VAULT_ACCOUNT_ID_REQUIRED_MESSAGE)
+  })
+
+  it('passes through the raw message for unmapped / unknown codes', () => {
+    expect(vaultErrorMessage('boom', 'NETWORK_ERROR')).toBe('boom')
+    expect(vaultErrorMessage('boom', null)).toBe('boom')
+    expect(vaultErrorMessage(null, 'NETWORK_ERROR')).toBeNull()
+  })
+
+  it('leaves PASSPHRASE_REQUIRED to the caller (returns the raw message, no remap)', () => {
+    // App.tsx intercepts PASSPHRASE_REQUIRED before calling this and prompts
+    // instead of surfacing text, so the mapper must not invent a message for it.
+    expect(vaultErrorMessage('enter passphrase', 'PASSPHRASE_REQUIRED'))
+      .toBe('enter passphrase')
   })
 })

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -30,6 +30,45 @@ import {
 const APP_ID = 'lastglance'
 const CRYPTO_DB_NAME = 'lastglance-crypto'
 
+// ── User-facing messages for the typed vault (DB transport) error codes ───────
+// These codes only occur on transportMode: 'database' (the GLANCEvault tier).
+
+// KEY_MISMATCH: the derived root key does not match the account's existing data.
+// The engine aborts BEFORE any upload, so a wrong key never pollutes the account.
+// Not silently retried — the user must fix the passphrase.
+export const VAULT_KEY_MISMATCH_MESSAGE =
+  'Wrong sync passphrase — it must exactly match the passphrase used on your other devices.'
+
+// VERIFIER_UNSUPPORTED: the GLANCEvault server is too old to host the key
+// verifier. A server problem, not a user error.
+export const VAULT_VERIFIER_UNSUPPORTED_MESSAGE =
+  'Your sync server needs to be updated to support key verification.'
+
+// ACCOUNT_ID_REQUIRED: a row-scoped call ran before the account id was populated.
+// Retryable — the next cycle (focus / interval) re-attempts once it is available,
+// so this is phrased as "not ready yet" rather than a hard failure.
+export const VAULT_ACCOUNT_ID_REQUIRED_MESSAGE =
+  'Finishing sync setup — try again in a moment.'
+
+// Map a vault onError (message, code) to the string to surface, or null for
+// nothing. PASSPHRASE_REQUIRED is handled by the caller (it prompts for the
+// passphrase instead of showing a message), so it is left untouched here.
+export function vaultErrorMessage(
+  message: string | null,
+  code: SyncErrorCode | null,
+): string | null {
+  switch (code) {
+    case 'KEY_MISMATCH':
+      return VAULT_KEY_MISMATCH_MESSAGE
+    case 'VERIFIER_UNSUPPORTED':
+      return VAULT_VERIFIER_UNSUPPORTED_MESSAGE
+    case 'ACCOUNT_ID_REQUIRED':
+      return VAULT_ACCOUNT_ID_REQUIRED_MESSAGE
+    default:
+      return message
+  }
+}
+
 // ── Entity-shape helpers (pure; safe to unit test without a DB) ──────────────
 
 type EntityKind = 'category' | 'chore' | 'completionEvent' | 'user'

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -13,7 +13,7 @@
 // remote applies never call markDirty and cannot loop back into a push.
 
 import { createDbSyncEngine } from '@glance-apps/sync'
-import type { DbSyncEngine, SyncStatus, SyncErrorCode } from '@glance-apps/sync'
+import type { DbSyncEngine, DbSyncResult, SyncStatus, SyncErrorCode } from '@glance-apps/sync'
 import { db } from '@/db/client'
 import type { Category, Chore, CompletionEvent, User } from '@/types'
 import type { SyncCategory, SyncChore, SyncCompletionEvent, SyncUser } from './types'
@@ -391,6 +391,10 @@ function notifyApplied(): void {
 export interface DbEngineCallbacks {
   onStatusChange?: (status: SyncStatus) => void
   onError?: (message: string | null, code: SyncErrorCode | null) => void
+  // Fired once per cycle that skipped > 0 undecryptable rows (@glance-apps/sync
+  // 1.5.0 per-row quarantine). We keep using the engine's own dbSyncCycle, so the
+  // engine invokes this for us; we only forward it to the UI signal.
+  onRowsSkipped?: (count: number, entityIds: string[]) => void
 }
 
 // One-time recovery for devices upgrading from @glance-apps/sync ≤ 1.3.x.
@@ -477,6 +481,7 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
     getEntityLastModified,
     onStatusChange: callbacks.onStatusChange,
     onError: callbacks.onError,
+    onRowsSkipped: callbacks.onRowsSkipped,
   })
 
   // Recover devices whose pull cursor was poisoned by the ≤1.3.x push/pull bug
@@ -498,7 +503,7 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
   // After a successful first push the high water mark advances past 0, so this
   // runs once. Seeding failures are non-fatal: the normal cycle still proceeds.
   const runCycle = engine.dbSyncCycle.bind(engine)
-  const dbSyncCycle = async (): Promise<void> => {
+  const dbSyncCycle = async (): Promise<DbSyncResult> => {
     if (engine.getHighWaterMark() === 0) {
       try {
         await markAllLocalEntitiesDirty(engine)
@@ -506,7 +511,10 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
         console.warn('[lastglance] vault initial snapshot failed:', err)
       }
     }
-    await runCycle()
+    // The engine's own dbSyncCycle fires config.onRowsSkipped for any quarantined
+    // rows and resolves to { applied, skipped, skippedEntityIds }; pass that result
+    // straight through so callers can surface the per-cycle skip count.
+    const result = await runCycle()
     // A pull may have skipped already-present rows under last-writer-wins, so run
     // the repair after every cycle too; refresh the UI when it links anything.
     try {
@@ -514,6 +522,7 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
     } catch (err) {
       console.warn('[lastglance] category parent repair failed:', err)
     }
+    return result
   }
 
   return { ...engine, dbSyncCycle, sync: dbSyncCycle }


### PR DESCRIPTION
## Summary

Pulls the @glance-apps/sync **1.5.x** GLANCEvault (DB transport) hardening into lastGLANCE and surfaces its new user-facing signals. UI/presentation only — no data-model or sync-logic changes. Releases as **v1.8.9**.

## Changes

### 1. `@glance-apps/sync` → `^1.5.2`
Pinned/bumped through `1.5.0` then `^1.5.2`; lockfile updated.

### 2. Key verifier + per-row quarantine (1.5.0)
- **`KEY_MISMATCH`** — before syncing, the engine proves the derived root key matches the account's existing data. A wrong passphrase/salt fails fast and uploads **NOTHING** (no poison rows). Mapped in the existing vault `onError` funnel to a plain-language message instead of raw crypto text.
- **Per-row quarantine** — a single undecryptable row is skipped, counted, and retried on later cycles instead of wedging the whole sync. Wired `onRowsSkipped(count, entityIds)` → transient toast (*"N item(s) couldn't be read"*) + a durable amber count threaded through `SyncSettingsModal`. The wrapper `dbSyncCycle` now resolves to `{ applied, skipped, skippedEntityIds }` for parity.

### 3. Typed DB-transport error codes (1.5.0–1.5.2)
Centralized the code→message mapping in a pure, tested helper (`vaultErrorMessage`) used by the **single existing** `onError(message, code, isHardStop)` handler — no parallel error path:
- `KEY_MISMATCH` → "Wrong sync passphrase — it must exactly match the passphrase used on your other devices." (no silent retry; account never polluted)
- `VERIFIER_UNSUPPORTED` → "Your sync server needs to be updated to support key verification." (server issue, not user error)
- `ACCOUNT_ID_REQUIRED` → "Finishing sync setup — try again in a moment." (retryable; re-attempted on the next focus/interval cycle)
- `PASSPHRASE_REQUIRED` → intercepted before mapping to prompt for the passphrase (matches the file engine's `onPassphraseRequired`); no error surfaced

### 4. Gate the persistent-storage warning to web only
The Help (`?`) screen's "persistent storage" notice + "Allow persistent storage" prompt only apply to the browser (where the OS can evict an unpersisted origin). On the native Capacitor iOS/Android shells the app owns its data store durably and `navigator.storage.persisted()` is irrelevant (often reports `false`), so the warning was a false alarm. Now skipped when `isNativePlatform` is true. Mirrors dayGLANCE's gating.

### 5. Version → 1.8.9
`package.json`, `package-lock.json`, README badge.

## Testing
- `npm run build` passes.
- Full suite **58/58 green**, including the in-memory two-device vault harness (which now round-trips the reserved `__glance_keycheck` verifier row) and new unit tests for `vaultErrorMessage`.
- `npm run lint` fails repo-wide on a pre-existing missing `eslint.config.js` (ESLint v9 migration), unrelated to this change; type safety is covered by the passing `tsc -b` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MH3V7wCgWKHCJqH9tRP42e