### PR TITLE
Android native features: plan + Phase 0 (snapshot bridge + heatmap widget)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,17 @@
             android:grantUriPermissions="true">
             <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_paths" />
         </provider>
+
+        <receiver
+            android:name=".HeatmapWidgetProvider"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/heatmap_widget_info" />
+        </receiver>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/lastglance/app/HeatmapWidgetProvider.java
+++ b/android/app/src/main/java/com/lastglance/app/HeatmapWidgetProvider.java
@@ -1,0 +1,137 @@
+package com.lastglance.app;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Configuration;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.net.Uri;
+import android.util.DisplayMetrics;
+import android.widget.RemoteViews;
+
+import org.json.JSONObject;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+
+// GitHub-style contribution heatmap of completion activity. Renders a Canvas
+// bitmap from the snapshot the web app pushed via WidgetBridge; no database
+// access happens here. Tapping opens the app to the "Soon" view.
+public class HeatmapWidgetProvider extends AppWidgetProvider {
+
+    private static final int WEEKS = 18;
+    private static final int DAYS = 7;
+
+    @Override
+    public void onUpdate(Context context, AppWidgetManager manager, int[] appWidgetIds) {
+        RemoteViews views = buildViews(context);
+        for (int id : appWidgetIds) {
+            manager.updateAppWidget(id, views);
+        }
+    }
+
+    // Re-render every placed instance. Called by WidgetBridgePlugin on each
+    // snapshot push.
+    static void refreshAll(Context context) {
+        AppWidgetManager manager = AppWidgetManager.getInstance(context);
+        ComponentName component = new ComponentName(context, HeatmapWidgetProvider.class);
+        int[] ids = manager.getAppWidgetIds(component);
+        if (ids == null || ids.length == 0) return;
+        RemoteViews views = buildViews(context);
+        for (int id : ids) {
+            manager.updateAppWidget(id, views);
+        }
+    }
+
+    private static RemoteViews buildViews(Context context) {
+        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_heatmap);
+        views.setImageViewBitmap(R.id.widget_heatmap_image, renderHeatmap(context));
+
+        Intent intent = new Intent(context, MainActivity.class);
+        intent.setAction(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse("lastglance://filter/soon"));
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+        PendingIntent pending = PendingIntent.getActivity(context, 0, intent, flags);
+        views.setOnClickPendingIntent(R.id.widget_heatmap_root, pending);
+        return views;
+    }
+
+    private static boolean isNight(Context context) {
+        int mode = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        return mode == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    private static Bitmap renderHeatmap(Context context) {
+        boolean night = isNight(context);
+        DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+        float density = metrics.density;
+        int cell = Math.round(11 * density);
+        int gap = Math.round(3 * density);
+        int pad = Math.round(2 * density);
+
+        int width = pad * 2 + WEEKS * (cell + gap) - gap;
+        int height = pad * 2 + DAYS * (cell + gap) - gap;
+
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+        int empty = night ? Color.parseColor("#2d333b") : Color.parseColor("#ebedf0");
+        int[] scale = new int[] {
+            Color.parseColor("#9be9a8"),
+            Color.parseColor("#40c463"),
+            Color.parseColor("#30a14e"),
+            Color.parseColor("#216e39"),
+        };
+
+        JSONObject heatmap = readHeatmap(context);
+
+        SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+        cal.set(Calendar.MINUTE, 0);
+        cal.set(Calendar.SECOND, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        // Back up to this week's Sunday, then to the oldest visible week.
+        cal.add(Calendar.DAY_OF_YEAR, -(cal.get(Calendar.DAY_OF_WEEK) - 1));
+        cal.add(Calendar.DAY_OF_YEAR, -(WEEKS - 1) * 7);
+
+        float radius = cell * 0.22f;
+        for (int col = 0; col < WEEKS; col++) {
+            for (int row = 0; row < DAYS; row++) {
+                String key = fmt.format(cal.getTime());
+                int count = heatmap != null ? heatmap.optInt(key, 0) : 0;
+                int color;
+                if (count <= 0) color = empty;
+                else if (count <= 1) color = scale[0];
+                else if (count <= 3) color = scale[1];
+                else if (count <= 5) color = scale[2];
+                else color = scale[3];
+                paint.setColor(color);
+                float left = pad + col * (cell + gap);
+                float top = pad + row * (cell + gap);
+                canvas.drawRoundRect(left, top, left + cell, top + cell, radius, radius, paint);
+                cal.add(Calendar.DAY_OF_YEAR, 1);
+            }
+        }
+        return bitmap;
+    }
+
+    private static JSONObject readHeatmap(Context context) {
+        try {
+            String json = SharedDataStore.readSnapshot(context);
+            if (json == null) return null;
+            return new JSONObject(json).optJSONObject("heatmap");
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -1,5 +1,14 @@
 package com.lastglance.app;
 
+import android.os.Bundle;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        // Register app-local plugins before the bridge starts.
+        registerPlugin(WidgetBridgePlugin.class);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
+++ b/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
@@ -1,0 +1,27 @@
+package com.lastglance.app;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+// Single SharedPreferences store shared between the Capacitor bridge (writer)
+// and the home-screen widgets (readers). Kept tiny on purpose: the web app is
+// the source of truth, this is just the hand-off surface.
+public final class SharedDataStore {
+
+    private static final String PREFS = "lastglance_shared";
+    private static final String KEY_SNAPSHOT = "snapshot";
+
+    private SharedDataStore() {}
+
+    private static SharedPreferences prefs(Context context) {
+        return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    public static void writeSnapshot(Context context, String json) {
+        prefs(context).edit().putString(KEY_SNAPSHOT, json).apply();
+    }
+
+    public static String readSnapshot(Context context) {
+        return prefs(context).getString(KEY_SNAPSHOT, null);
+    }
+}

--- a/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
@@ -1,0 +1,24 @@
+package com.lastglance.app;
+
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+// Receives the denormalized snapshot from the web app and persists it for the
+// home-screen widgets to render. Registered in MainActivity.
+@CapacitorPlugin(name = "WidgetBridge")
+public class WidgetBridgePlugin extends Plugin {
+
+    @PluginMethod
+    public void updateSnapshot(PluginCall call) {
+        String json = call.getString("json");
+        if (json == null) {
+            call.reject("missing json");
+            return;
+        }
+        SharedDataStore.writeSnapshot(getContext(), json);
+        HeatmapWidgetProvider.refreshAll(getContext());
+        call.resolve();
+    }
+}

--- a/android/app/src/main/res/drawable-night/widget_background.xml
+++ b/android/app/src/main/res/drawable-night/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#1c2128" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android/app/src/main/res/drawable/widget_background.xml
+++ b/android/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#ffffff" />
+    <corners android:radius="16dp" />
+</shape>

--- a/android/app/src/main/res/layout/widget_heatmap.xml
+++ b/android/app/src/main/res/layout/widget_heatmap.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_heatmap_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/widget_background"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/widget_heatmap_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"
+        android:textColor="@color/widget_fg"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="8dp" />
+
+    <ImageView
+        android:id="@+id/widget_heatmap_image"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:adjustViewBounds="true"
+        android:scaleType="fitCenter"
+        android:contentDescription="@string/heatmap_widget_description" />
+
+</LinearLayout>

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widget_fg">#adbac7</color>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widget_fg">#57606a</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="title_activity_main">lastGLANCE</string>
     <string name="package_name">com.lastglance.app</string>
     <string name="custom_url_scheme">com.lastglance.app</string>
+    <string name="heatmap_widget_description">Your recent completion activity at a glance.</string>
 </resources>

--- a/android/app/src/main/res/xml/heatmap_widget_info.xml
+++ b/android/app/src/main/res/xml/heatmap_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="0"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/widget_heatmap"
+    android:previewImage="@mipmap/ic_launcher"
+    android:description="@string/heatmap_widget_description" />

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -260,9 +260,11 @@ sync round-trip.
   Maximum control, proven exact behavior, more code to maintain.
 
 **Fall back to B if** Path A can't guarantee `setExactAndAllowWhileIdle`-grade
-timing under Doze, doesn't expose the exact-alarm permission flow, or doesn't
-survive reboot reliably. The snapshot bridge, widgets, and router are identical
-either way — only the alarm layer swaps.
+timing under Doze, doesn't expose the exact-alarm permission flow, doesn't
+survive reboot reliably, **or** OEM-killer testing proves we need the WorkManager
+re-arm backstop (see §6 — that backstop needs native ownership of the alarm set,
+which Path A doesn't provide). The snapshot bridge, widgets, and router are
+identical either way — only the alarm layer swaps.
 
 ---
 
@@ -271,10 +273,29 @@ either way — only the alarm layer swaps.
 - **Widget ↔ ChoreRow visual parity:** "clearly same family" is cheap; pixel-parity
   is ongoing maintenance (fonts, color bar, icon set as vectors). Decide the bar
   per widget.
-- **OEM background killers** (Samsung/Xiaomi) can clear alarms; dayGLANCE's only
-  defense is a 15-min WorkManager backstop (and even that doesn't re-arm task
-  reminders). Decide whether to add a WorkManager re-arm of reminders and/or a
-  battery-optimization exemption prompt.
+- **OEM background killers** (Samsung/Xiaomi) can clear alarms. dayGLANCE now
+  defends with a 15-min WorkManager backstop that **re-registers task reminders**
+  (its earlier version only re-armed widgets/Up-Next). The pattern to copy:
+  - One shared, **idempotent** `reregisterPersistedReminders()` that reads the
+    same persisted `scheduledReminders` JSON that `syncReminders` maintains,
+    skips already-fired entries, and re-schedules with `FLAG_UPDATE_CURRENT`
+    keyed on `id.hashCode()` — so repeated runs update alarms in place and
+    **never resurrect one the JS layer cancelled**.
+  - Both the `BOOT_COMPLETED` receiver and the 15-min `WidgetUpdateWorker`
+    delegate to that one method (no duplicated re-registration loop).
+  - **A-vs-B implication:** this backstop requires native code that *owns the
+    persisted alarm set and can re-register it without JS*. That's a Path B
+    trait. With Path A (`@capacitor/local-notifications`) the plugin owns
+    scheduling state and survives reboot itself, but does **not** expose a
+    "re-register the set" hook a WorkManager job could call — so true OEM-killer
+    resilience pulls toward owning the alarm layer (B) or a hybrid that keeps our
+    own persisted reminder JSON + native re-register. Keep the agreed posture:
+    don't build the backstop until on-device testing shows alarms actually get
+    cleared; if it does, treat that as a concrete signal to move the alarm layer
+    to B.
+- Battery-optimization exemption prompt: intentionally **not** planned for v1
+  (intrusive, Play-policy-sensitive, off-brand). Reconsider only if testing on
+  real OEM devices proves `setExactAndAllowWhileIdle` + the backstop insufficient.
 - **Timezone/DST:** dayGLANCE has no `TIMEZONE_CHANGED` receiver and re-syncs on
   open — a known gap. Cheap to add a receiver that re-runs `syncReminders`.
 - **Snapshot freshness while closed:** elapsed time keeps moving but the snapshot is

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -1,0 +1,304 @@
+# Android Native Features — Implementation Plan
+
+Widgets, actionable notifications, and shortcuts for the lastGLANCE Android
+app, designed so all three share one data bridge and one action router.
+
+This plan was informed by a teardown of how the sibling app **dayGLANCE**
+solved timely closed-app notifications (its process is referenced throughout).
+Where lastGLANCE differs from dayGLANCE, it is called out explicitly.
+
+---
+
+## 1. Context & the core constraint
+
+lastGLANCE is a **Capacitor 8** app: the UI is a WebView, and all data lives in
+**IndexedDB (Dexie)** *inside* the WebView (`src/db/client.ts`). Native
+home-screen widgets and `AlarmManager`-driven notifications run in a **separate
+process** and **cannot read IndexedDB**. So every native feature needs an
+explicit bridge to the data.
+
+Two bridges cover everything:
+
+1. **Snapshot bridge** (read path): the WebView writes a denormalized JSON
+   snapshot to native `SharedPreferences` whenever relevant state changes.
+   Widgets and any native notification logic read *that*, never the DB.
+2. **Pre-scheduled alarms** (notification path): the WebView computes each
+   reminder's absolute trigger time and hands the full set to native, which
+   registers exact alarms. Native never reads data to *decide* what to fire —
+   the alarm's extras are the payload.
+
+Both are validated patterns: dayGLANCE ships exactly this shape (SharedPreferences
+snapshot + pre-scheduled `setExactAndAllowWhileIdle` alarms), with **no** native
+SQLite mirror, **no** headless JS runtime, and **no** headless WebView.
+
+### What this means: no background data runtime needed (for v1)
+
+A scheduler (AlarmManager/WorkManager) only answers *"when do I wake up."* It does
+**not** give native code a way to run Dexie. Because reminders are fully
+pre-scheduled and widgets read a snapshot, **no v1 feature needs background access
+to the DB.** The only feature that would is closed-app *remote* CRDT sync —
+deliberately out of scope (dayGLANCE doesn't do it either; it reconciles on next
+foreground, same as lastGLANCE today).
+
+---
+
+## 2. The data-model mapping (the one real divergence)
+
+dayGLANCE tasks are **time-anchored** (a task has an absolute scheduled time), so
+"pre-schedule today's triggers" is natural. lastGLANCE chores are
+**cadence-anchored** (recency since last done). The resolution:
+
+> A chore's overdue moment **is** an absolute time, knowable the instant it is
+> completed: `last_completed_at + target_cadence_days`.
+
+So every eligible chore contributes **0 or 1 future alarm** at its next-overdue
+instant. The dayGLANCE model maps over cleanly — we just recompute a chore's
+alarm on completion / cadence edit / app open rather than re-pushing a daily list.
+
+**Eligibility** for an overdue alarm (mirrors `useNotifications.ts` today):
+- `notify_when_overdue === true`
+- `target_cadence_days != null`
+- has at least one completion (`last_completed_at != null`)
+- not currently out of its seasonal window (`seasonal_start`/`seasonal_end`)
+- (multi-user) owned by me — unassigned or assigned to `meId`
+  (`utils/choreFilter.ts: ownedByMe`)
+
+**Brand fit — fire once, don't nag.** dayGLANCE re-nudges daily. lastGLANCE's
+ethos is *"information, not guilt"* (README). Schedule a **single** alarm at the
+overdue moment per chore. Simpler (no daily repeat) and on-brand. Re-arming only
+happens when the chore is completed (next-overdue moves forward) or its
+cadence/seasonal/notify settings change.
+
+---
+
+## 3. Shared infrastructure (build once, the spine)
+
+### 3a. Capacitor plugin: `WidgetBridge` (custom, local)
+
+Thin Kotlin plugin exposing JS-callable methods. dayGLANCE uses
+`addJavascriptInterface`; on Capacitor we wrap the same logic as a plugin.
+
+| Method | Purpose |
+|---|---|
+| `updateSnapshot({ json })` | Persist snapshot to `SharedPreferences("lastglance_shared")`, trigger widget update |
+| `syncReminders({ reminders })` | Diff-replace the alarm set (see 3c) |
+| `getPendingActions()` | Drain queued widget/notification actions into JS |
+| `clearPendingActions({ ids })` | Ack drained actions |
+
+JS wrappers live in `src/native/widgetBridge.ts`, null-safe / no-op on web+PWA
+(guard with `Capacitor.isNativePlatform()`, like `src/native/statusBar.ts`).
+
+### 3b. Snapshot schema (`SharedPreferences` key `snapshot`)
+
+Written by the WebView; the single source of truth for native reads.
+
+```jsonc
+{
+  "version": 1,
+  "generatedAt": "2026-06-20T12:00:00Z",
+  "counts": { "overdue": 3, "soon": 5 },
+  "heatmap": { "2026-06-19": 2, "2026-06-20": 1 },   // last ~120 days
+  "chores": [
+    {
+      "syncId": "uuid",
+      "name": "Water plants",
+      "icon": "droplet",                  // lucide name → mapped to a vector drawable
+      "categoryName": "Home",
+      "lastCompletedAt": "2026-06-15T09:00:00Z",
+      "elapsedDays": 5.2,
+      "targetCadenceDays": 7,
+      "ratio": 0.74,                       // elapsed / target (getFillRatio)
+      "color": "#f59e0b",                  // getCadenceColor(ratio)
+      "state": "soon"                      // fresh | soon | overdue | none
+    }
+  ]
+}
+```
+
+Generated by a new `src/native/snapshot.ts` from existing queries
+(`getCategories` + `getChoresForCategory`, `getAllCompletionCounts`) and existing
+helpers (`getFillRatio`, `getCadenceColor`, `needsAttention` in `utils/cadence.ts`).
+Pushed:
+- on app start
+- on `lg:chore-logged`, `lg:sync-applied` events (already emitted; see
+  `App.tsx:333`/`338`)
+- on `visibilitychange` → hidden (app pausing), so the snapshot is fresh for the
+  launcher
+
+### 3c. Reminder payload (`syncReminders`)
+
+```jsonc
+{
+  "id": "overdue:<choreSyncId>",        // stable → PendingIntent request code = id.hashCode()
+  "choreSyncId": "uuid",
+  "title": "Water plants",
+  "body": "Overdue — last done 7 days ago",
+  "triggerAtMillis": 1750000000000,     // last_completed_at + cadence
+  "deepLink": "lastglance://chore/<choreSyncId>"
+}
+```
+
+Native turns each into `setExactAndAllowWhileIdle(RTC_WAKEUP, …)` (the load-bearing
+call — fires precisely and pierces Doze) to a `BroadcastReceiver` that renders the
+notification from the alarm's own extras. **Diff-replace, not cancel-all**: compare
+stored vs new set, only touch changed entries (dayGLANCE's race-avoidance lesson).
+
+Notification id = `choreSyncId.hashCode()` so a re-fired reminder for the same
+chore replaces rather than stacks.
+
+### 3d. Action router (collapse to one path)
+
+dayGLANCE's hindsight advice: route widgets + notification actions + shortcuts all
+through the **shared `@glance-apps/intents` dispatcher** instead of a second
+ad-hoc channel. lastGLANCE already depends on `@glance-apps/intents` (^1.3.3) and
+already has the receive half in `processNotifyEnvelope.ts` /
+`useIntentsPoller.ts`.
+
+URI scheme, two verb classes:
+
+| URI | Verb | Effect |
+|---|---|---|
+| `lastglance://chore/<syncId>` | navigate | open app, focus chore (reuse `lg:open-chore` event, `useNotifications.ts:72`) |
+| `lastglance://filter/soon` | navigate | open app with attention filter on (`setAttentionOnly`, `App.tsx:124`) |
+| `lastglance://complete/<syncId>` | act | log completion (idempotent, see Phase 2) |
+
+Native components can't call JS directly, so "act" intents land in a **pending
+queue** in `SharedPreferences`; JS drains via `getPendingActions()` on
+`visibilitychange` (same shape as the existing intents poller).
+
+---
+
+## 4. Phases
+
+### Phase 0 — Snapshot bridge + heatmap widget (read-only)
+
+**Goal:** prove the whole pipeline with zero write-back risk.
+
+- `WidgetBridge` plugin with `updateSnapshot` only.
+- `src/native/snapshot.ts` + wire its triggers (start / `lg:chore-logged` /
+  `lg:sync-applied` / pause).
+- One **Glance** (Jetpack Compose) widget rendering the activity heatmap from
+  `snapshot.heatmap`. Honors light/dark (existing `drawable-night`).
+- Tap → `lastglance://filter/soon` (navigate only).
+
+**Exit criteria:** heatmap on the home screen reflects completions within one app
+foreground cycle; survives reboot (re-renders from persisted snapshot).
+
+### Phase 1 — Exact-alarm overdue notifications (Path A)
+
+**Goal:** replace the WebView-timer notifications that silently don't fire when
+closed (`useNotifications.ts:106` is the exact "fire from JS loop" anti-pattern
+dayGLANCE's war story warns about).
+
+- Add **`@capacitor/local-notifications`**. Verify it schedules with
+  `allowWhileIdle` / exact delivery; if it can't guarantee
+  `setExactAndAllowWhileIdle`, fall back to Path B (custom Kotlin) for the alarm
+  layer only.
+- New `src/native/reminders.ts`: compute the eligible set (section 2), build the
+  payload (3c), call `syncReminders` (diff-replace). Re-run on the same triggers
+  as the snapshot.
+- Keep `useNotifications.ts`'s in-app branch (toast when
+  `visibilityState === 'visible'`) — that loop stays for in-app toasts/sound
+  only; native owns closed-app delivery. Remove its closed-app
+  `fireBrowserNotification` path on native.
+- **Permissions / manifest:** `POST_NOTIFICATIONS` (runtime, API 33+),
+  `SCHEDULE_EXACT_ALARM` (declared **and** actively prompted via
+  `ACTION_REQUEST_SCHEDULE_EXACT_ALARM` — the prompt is load-bearing),
+  `RECEIVE_BOOT_COMPLETED` (re-register alarms on reboot — they don't survive it),
+  notification channel created at app start.
+- Tap → `lastglance://chore/<syncId>`.
+
+**Exit criteria:** kill the app, advance a chore past its cadence, alarm fires on
+time (test on Doze via `adb shell dumpsys deviceidle force-idle`).
+
+### Phase 2 — Action widgets + optimistic tap-to-complete
+
+**Goal:** the marquee widgets, with completion that *feels instant* and is
+*safe*.
+
+- **Overdue/"Soon" list widget** (Glance `LazyColumn` from `snapshot.chores`
+  filtered to `state ∈ {soon, overdue}`) and **single-chore widget** (configurable
+  `choreSyncId`). Both styled to read as the same family as the in-app `ChoreRow`
+  (recency color bar + elapsed text); lucide icons shipped as vector drawables.
+- **Tap-to-complete, two layers:**
+  1. *Perceived* (pure native, instant): tap handler mutates the snapshot entry
+     (→ "just now", green) and re-renders the widget. No WebView, no delay.
+  2. *Durable* (idempotent queue): the **native side mints the completion's
+     `sync_id` (UUID)** and enqueues `{ choreSyncId, syncId, completedAt }`. JS
+     drains on next foreground and replays via
+     `logCompletion(choreId, { syncId })` — which **already accepts a caller
+     `syncId`** (`db/queries.ts:228`), making it idempotent and CRDT-safe even if
+     drained twice or synced from two devices.
+- Completion is **silent** — no need to foreground the app (an improvement over
+  dayGLANCE's "Mark Complete" which calls `startActivity`).
+
+**Exit criteria:** tapping complete on the widget updates it immediately offline;
+reopening the app shows exactly one completion logged; no double-count across a
+sync round-trip.
+
+### Phase 3 — Notifications actions, shortcuts, (optional) background sync
+
+- **Actionable notifications:** "Mark done" / "Open" action buttons → emit the
+  same `lastglance://complete|chore` intents through the Phase 2 queue. Mostly
+  wiring once the router exists.
+- **App shortcuts** (`res/xml/shortcuts.xml`): "Soon", "Log a chore" → navigate
+  intents.
+- **Background CRDT sync (stretch):** the only feature needing a background data
+  runtime. Forces the headless-JS-vs-native-mirror decision. Defer until there's
+  real demand; current "sync on open" is unchanged behavior.
+
+---
+
+## 5. Path A vs Path B
+
+- **Path A (chosen):** `@capacitor/local-notifications` for the alarm/notification
+  primitive; replicate dayGLANCE's *model* on top (absolute-time scheduling,
+  diff-set, exact-alarm prompt, idempotent ids). Least native code,
+  Capacitor-idiomatic.
+- **Path B (backup):** port dayGLANCE's custom Kotlin (`NotificationBridge` /
+  `ReminderReceiver` / boot re-registration) into the `WidgetBridge` plugin.
+  Maximum control, proven exact behavior, more code to maintain.
+
+**Fall back to B if** Path A can't guarantee `setExactAndAllowWhileIdle`-grade
+timing under Doze, doesn't expose the exact-alarm permission flow, or doesn't
+survive reboot reliably. The snapshot bridge, widgets, and router are identical
+either way — only the alarm layer swaps.
+
+---
+
+## 6. Open questions / risks
+
+- **Widget ↔ ChoreRow visual parity:** "clearly same family" is cheap; pixel-parity
+  is ongoing maintenance (fonts, color bar, icon set as vectors). Decide the bar
+  per widget.
+- **OEM background killers** (Samsung/Xiaomi) can clear alarms; dayGLANCE's only
+  defense is a 15-min WorkManager backstop (and even that doesn't re-arm task
+  reminders). Decide whether to add a WorkManager re-arm of reminders and/or a
+  battery-optimization exemption prompt.
+- **Timezone/DST:** dayGLANCE has no `TIMEZONE_CHANGED` receiver and re-syncs on
+  open — a known gap. Cheap to add a receiver that re-runs `syncReminders`.
+- **Snapshot freshness while closed:** elapsed time keeps moving but the snapshot is
+  static; a daily (midnight) WorkManager/AlarmManager re-render keeps "Xd ago"
+  honest without polling.
+
+---
+
+## 7. File touch list (first two phases)
+
+**New**
+- `android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.kt`
+- `android/app/src/main/java/com/lastglance/app/widget/…` (Glance widgets, receivers)
+- `android/app/src/main/java/com/lastglance/app/data/SharedDataStore.kt`
+- `src/native/widgetBridge.ts` (JS wrappers)
+- `src/native/snapshot.ts` (snapshot builder + triggers)
+- `src/native/reminders.ts` (eligible-set + `syncReminders`)
+
+**Modified**
+- `android/app/src/main/AndroidManifest.xml` (permissions, receivers, widget provider)
+- `capacitor.config.ts` (LocalNotifications config if needed)
+- `src/App.tsx` (wire snapshot/reminder triggers alongside existing
+  `loadHeatmap` listeners)
+- `src/hooks/useNotifications.ts` (keep in-app toast branch; drop closed-app web
+  notification on native)
+- `package.json` (`@capacitor/local-notifications`)
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { UsersModal } from '@/components/UsersModal/UsersModal'
 import { UsersContext } from '@/multiuser/UsersContext'
 import { useUsers } from '@/multiuser/useUsers'
 import { useNotifications } from '@/hooks/useNotifications'
+import { useWidgetSnapshot } from '@/hooks/useWidgetSnapshot'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
@@ -118,6 +119,7 @@ function AppInner() {
   const { t } = useTranslation()
   const { showToast } = useToast()
   useNotifications()
+  useWidgetSnapshot()
   const { refreshConfig } = useIntents()
   const usersCtx = useUsers()
   const reloadUsers = usersCtx.reload

--- a/src/hooks/useWidgetSnapshot.ts
+++ b/src/hooks/useWidgetSnapshot.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { pushSnapshot } from '@/native/snapshot'
+
+// Keeps the native widget snapshot fresh. Pushes on mount, whenever a chore is
+// logged or a sync is applied (the same signals the in-app heatmap listens to),
+// and when the app is being backgrounded so the launcher sees current data.
+// No-op off Android (pushSnapshot guards the platform internally).
+export function useWidgetSnapshot(): void {
+  useEffect(() => {
+    pushSnapshot()
+
+    const onChange = () => { pushSnapshot() }
+    window.addEventListener('lg:chore-logged', onChange)
+    window.addEventListener('lg:sync-applied', onChange)
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') pushSnapshot()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      window.removeEventListener('lg:chore-logged', onChange)
+      window.removeEventListener('lg:sync-applied', onChange)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [])
+}

--- a/src/native/snapshot.ts
+++ b/src/native/snapshot.ts
@@ -1,0 +1,100 @@
+import { getCategories, getChoresForCategory, getAllCompletionCounts } from '@/db/queries'
+import { getFillRatio, getCadenceColor, needsAttention } from '@/utils/cadence'
+import { pushWidgetSnapshot } from './widgetBridge'
+import dayjs from 'dayjs'
+
+// How many days of completion history to ship to the heatmap widget.
+const HEATMAP_DAYS = 120
+
+export type ChoreState = 'fresh' | 'soon' | 'overdue' | 'none'
+
+export interface SnapshotChore {
+  syncId: string
+  name: string
+  icon: string | null
+  categoryName: string | null
+  lastCompletedAt: string | null
+  elapsedDays: number | null
+  targetCadenceDays: number | null
+  ratio: number | null
+  color: string | null
+  state: ChoreState
+}
+
+export interface WidgetSnapshot {
+  version: 1
+  generatedAt: string
+  counts: { overdue: number; soon: number }
+  heatmap: Record<string, number>
+  chores: SnapshotChore[]
+}
+
+function choreState(target: number | null, elapsed: number | null): ChoreState {
+  if (target == null || elapsed == null) return 'none'
+  if (getFillRatio(elapsed, target) >= 1) return 'overdue'
+  if (needsAttention(target, elapsed)) return 'soon'
+  return 'fresh'
+}
+
+export async function buildSnapshot(): Promise<WidgetSnapshot> {
+  const categories = await getCategories()
+  const choresByCat = await Promise.all(categories.map(c => getChoresForCategory(c.id)))
+  const catName = new Map(categories.map(c => [c.id, c.name]))
+
+  const chores: SnapshotChore[] = []
+  let overdue = 0
+  let soon = 0
+
+  for (const list of choresByCat) {
+    for (const ch of list) {
+      const state = choreState(ch.target_cadence_days, ch.elapsed_days)
+      if (state === 'overdue') overdue++
+      else if (state === 'soon') soon++
+
+      const ratio =
+        ch.target_cadence_days != null && ch.elapsed_days != null
+          ? getFillRatio(ch.elapsed_days, ch.target_cadence_days)
+          : null
+
+      chores.push({
+        syncId: ch.sync_id,
+        name: ch.name,
+        icon: ch.icon ?? null,
+        categoryName: catName.get(ch.category_id) ?? null,
+        lastCompletedAt: ch.last_completed_at,
+        elapsedDays: ch.elapsed_days,
+        targetCadenceDays: ch.target_cadence_days,
+        ratio: ratio != null ? Math.round(ratio * 100) / 100 : null,
+        color: ratio != null ? getCadenceColor(ratio) : null,
+        state,
+      })
+    }
+  }
+
+  // Trim the global completion counts to the heatmap window.
+  const counts = await getAllCompletionCounts()
+  const cutoff = dayjs().subtract(HEATMAP_DAYS - 1, 'day').startOf('day')
+  const heatmap: Record<string, number> = {}
+  for (const [date, n] of counts) {
+    if (!dayjs(date).isBefore(cutoff)) heatmap[date] = n
+  }
+
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    counts: { overdue, soon },
+    heatmap,
+    chores,
+  }
+}
+
+// Build the snapshot and hand it to native. Safe to call anywhere; no-ops off
+// Android and never throws.
+export async function pushSnapshot(): Promise<void> {
+  try {
+    const snapshot = await buildSnapshot()
+    await pushWidgetSnapshot(JSON.stringify(snapshot))
+  } catch {
+    // Snapshot generation is best-effort; failures must not affect the app.
+  }
+}

--- a/src/native/widgetBridge.ts
+++ b/src/native/widgetBridge.ts
@@ -1,0 +1,22 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+// Native bridge to the Android home-screen widgets. The web app owns the data
+// (IndexedDB lives in the WebView), so it pushes a denormalized JSON snapshot
+// to native SharedPreferences; the widgets render from that snapshot and never
+// touch the database. No-op on web/PWA and iOS (no plugin registered there).
+export interface WidgetBridgePlugin {
+  // Persist the snapshot JSON and refresh any placed widgets.
+  updateSnapshot(options: { json: string }): Promise<void>
+}
+
+const WidgetBridge = registerPlugin<WidgetBridgePlugin>('WidgetBridge')
+
+export async function pushWidgetSnapshot(json: string): Promise<void> {
+  if (Capacitor.getPlatform() !== 'android') return
+  try {
+    await WidgetBridge.updateSnapshot({ json })
+  } catch {
+    // Plugin unavailable or transient failure — widgets are a cosmetic extra,
+    // so swallow rather than disrupt the app.
+  }
+}


### PR DESCRIPTION
## Summary

Kicks off native Android features (widgets first, notifications/shortcuts later). This PR contains the **implementation plan** plus **Phase 0**: the data bridge and the first, read-only widget.

The plan is informed by a teardown of how the sibling app **dayGLANCE** solved timely closed-app notifications, adapted to lastGLANCE's Capacitor + Dexie/IndexedDB stack.

## What's here

**Docs**
- `docs/android-native-features-plan.md` — phased plan (snapshot bridge → exact-alarm notifications → interactive widgets + tap-to-complete → shortcuts), the cadence→alarm mapping, a shared `@glance-apps/intents` action router, and the Path A (`@capacitor/local-notifications`) vs Path B (custom Kotlin) decision with explicit fallback triggers. Includes dayGLANCE's idempotent WorkManager reminder re-arm pattern.

**Phase 0 — snapshot bridge + heatmap widget (read-only)**
- **Web:** `src/native/snapshot.ts` builds a denormalized JSON snapshot (counts, 120-day heatmap, per-chore state/color) by reusing existing `getChoresForCategory` / `getAllCompletionCounts` queries and the `getCadenceColor` / `needsAttention` helpers — so widget colors match the app by construction. `src/native/widgetBridge.ts` (Capacitor plugin wrapper, no-op off Android) and `src/hooks/useWidgetSnapshot.ts` push the snapshot on mount, on `lg:chore-logged` / `lg:sync-applied`, and on app background.
- **Native (Java):** `WidgetBridgePlugin` (registered in `MainActivity`) + `SharedDataStore` persist the snapshot to `SharedPreferences`; `HeatmapWidgetProvider` renders a GitHub-style contribution heatmap as a Canvas bitmap (RemoteViews, light/dark aware). Tapping opens the app to `lastglance://filter/soon` (the router that *acts* on that URI lands in a later phase; for now it just opens the app).

## Design notes / decisions to confirm

- **RemoteViews + Canvas bitmap instead of Jetpack Glance for the heatmap** — zero new dependencies, no Kotlin/Gradle changes, and a drawn bitmap suits a non-interactive heatmap. Glance is still planned for the interactive Phase 2 list widget. **Open question:** keep RemoteViews here / adopt Glance at Phase 2, or unify on Glance now.
- The snapshot already includes the full chore list (not just heatmap data) so Phases 1–2 need no schema change.

## Testing

- ✅ Web build green (`tsc -b` + `vite build`); **58/58** unit tests pass. New TS type-checks.
- ⚠️ **Android not compiled in CI/this environment** (no SDK). The Java references only resources added here, but it needs an **on-device smoke test**: `npm run cap:android`, add the widget, log a chore, confirm the heatmap updates and the tap opens the app.
- Note: `npm run lint` is broken repo-wide (no tracked `eslint.config.js`) — pre-existing, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_