### PR TITLE
build-android: produce signed .aab for Play Store uploads

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -3,11 +3,12 @@ set -e
 
 # lastGLANCE Android build — ported from the dayGLANCE build script.
 # Differences: the Capacitor project dir is android/ (not renamed), and this
-# builds a single APK (no play/github flavors, no AAB yet).
+# builds a single APK (no play/github flavors).
 #
 # Usage:
 #   ./build-android.sh            debug APK + install on a connected device
-#   ./build-android.sh --release  signed release APK -> outputs/lastglance.apk
+#   ./build-android.sh --release  signed release APK + .aab for the Play Store
+#                                 -> outputs/lastglance.apk, outputs/lastglance.aab
 #   ./build-android.sh --clean    full gradle clean + wipe dist/ first
 # Flags combine, e.g. ./build-android.sh --clean --release
 
@@ -67,15 +68,22 @@ if $RELEASE; then
   cd "$SCRIPT_DIR"
   npm run build:android
 
-  echo "==> Building release APK..."
+  # Build the release APK (for sideloading/testing) and the AAB (App Bundle)
+  # that the Play Store requires for uploads, in a single Gradle invocation.
+  echo "==> Building release APK + AAB..."
   cd "$ANDROID_DIR"
-  ./gradlew assembleRelease
+  ./gradlew assembleRelease bundleRelease
 
   cp "app/build/outputs/apk/release/lastglance.apk" "$OUT_DIR/lastglance.apk"
   echo "    APK (release) → outputs/lastglance.apk"
 
+  # The bundle task ignores the APK outputFileName rename in build.gradle, so
+  # the .aab keeps its default name (app-release.aab); copy it to a stable path.
+  cp "app/build/outputs/bundle/release/app-release.aab" "$OUT_DIR/lastglance.aab"
+  echo "    AAB (release) → outputs/lastglance.aab"
+
   # Verify the APK carries a valid signature (catches a misconfigured or
-  # missing keystore.properties that would otherwise ship an unsigned APK).
+  # missing keystore.properties that would otherwise ship an unsigned APK/AAB).
   SDK_DIR="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
   APKSIGNER="$(command -v apksigner || true)"
   if [ -z "$APKSIGNER" ] && [ -n "$SDK_DIR" ]; then


### PR DESCRIPTION
## Problem

`build-android.sh --release` only ran Gradle's `assembleRelease` task, which emits an **APK**. The Play Store requires an **Android App Bundle (`.aab`)**, produced by the separate `bundleRelease` task that the script never invoked. (The header comment even noted "no AAB yet.")

## Fix

The `--release` path now runs both tasks in one Gradle invocation and copies the bundle to a stable output path:

```
./gradlew assembleRelease bundleRelease
...
cp "app/build/outputs/bundle/release/app-release.aab" "$OUT_DIR/lastglance.aab"
```

`./build-android.sh --release` now produces:
- `outputs/lastglance.apk` — for sideloading/testing (unchanged)
- `outputs/lastglance.aab` — the signed bundle for Play Store upload (new)

## Notes

- **Signing just works.** The `.aab` is signed by the same `signingConfig.release` already wired to the `release` build type in `app/build.gradle`, so it uses `keystore.properties` exactly like the APK does.
- **Bundle filename.** The `output.outputFileName = "lastglance.apk"` rename in `build.gradle` only affects APK outputs — bundle tasks ignore it — so the `.aab` keeps its default `app-release.aab` source name, which the script copies to `lastglance.aab`.
- The existing `apksigner verify` check still runs against the APK; since both artifacts share one keystore, a passing check confirms the bundle is signed too.
- If `keystore.properties` is missing, the `.aab` (like the APK) is unsigned and the script already warns about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017aQWQE6fccVuWdjXDsdSTY)_