### PR TITLE
intents: add app-owned GLANCEvault DB transport (+ settings toggle), alongside WebDAV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@capacitor/core": "^8.4.0",
         "@capacitor/ios": "^8.4.0",
         "@capacitor/status-bar": "^8.0.2",
-        "@glance-apps/intents": "^1.3.3",
+        "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "^1.5.2",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
@@ -2783,9 +2783,9 @@
       }
     },
     "node_modules/@glance-apps/intents": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.3.3.tgz",
-      "integrity": "sha512-WlXjS94OgEYy8qeqGNuEZqLOA9wpCZWa//LGcvduDy3IJ21xIVv6UuIYYUWny2eVrr2hgMeUAtRvjnNbvppWtw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/intents/-/intents-1.4.0.tgz",
+      "integrity": "sha512-MV4yXH0JhXBxnd/7vbba+b2PWJDOyelG7Bws5Zi///yVxXi8axQPWFYclAV47WzIDDG1xHEue5FkziFY/+SoDw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@capacitor/core": "^8.4.0",
     "@capacitor/ios": "^8.4.0",
     "@capacitor/status-bar": "^8.0.2",
-    "@glance-apps/intents": "^1.3.3",
+    "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "^1.5.2",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { useUsers } from '@/multiuser/useUsers'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useWidgetSnapshot } from '@/hooks/useWidgetSnapshot'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
+import { useDbIntentsPoller } from '@/hooks/useDbIntentsPoller'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
 import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
@@ -328,6 +329,9 @@ function AppInner() {
   }, [])
 
   useIntentsPoller(loadHeatmap)
+  // GLANCEvault DB intents transport — gated by isDbIntentsEnabled(); a no-op
+  // unless the per-user opt-in is on. WebDAV intents above remain the default.
+  useDbIntentsPoller(loadHeatmap)
 
   useEffect(() => { loadHeatmap() }, [loadHeatmap])
 

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Loader } from 'lucide-react'
 import { hasEncryptionReady, getSyncPassphrase } from '@glance-apps/sync'
@@ -9,6 +9,8 @@ import {
   clearActivityLog,
   getActivityLog,
 } from '@/intents/config'
+import { getDbIntentsConfig, saveDbIntentsConfig } from '@/intents/dbConfig'
+import { getVaultConfig } from '@/sync/vaultConfig'
 import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal'
 import { testConnection } from '@/intents/webdav'
 import { loadIntentsRootKey, clearIntentsRootKey } from '@/intents/intentsKeyStore'
@@ -46,6 +48,17 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
   const [passphraseInput, setPassphraseInput] = useState('')
   const [setupError, setSetupError] = useState('')
   const [saving, setSaving] = useState(false)
+
+  // GLANCEvault DB intents transport (beta). Independent of the WebDAV intents
+  // config above and of the vault SYNC toggle: this only flips the `enabled`
+  // flag in lg_db_intents_config. The connection (URL/token/accountId) is NOT
+  // entered here — the transport inherits it from the GLANCEvault sync config
+  // (getVaultConfig), so the UI shows whether that connection is present rather
+  // than duplicating the fields.
+  const [dbIntentsEnabled, setDbIntentsEnabled] = useState(() => getDbIntentsConfig().enabled)
+  const initialDbIntentsEnabled = useRef(getDbIntentsConfig().enabled)
+  const vaultConn = getVaultConfig()
+  const vaultConfigured = !!(vaultConn?.vaultUrl && vaultConn?.vaultToken && vaultConn?.accountId)
 
   const encReady = hasEncryptionReady()
 
@@ -112,8 +125,22 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
         setRootKeyReady(false)
       }
       saveIntentsConfig(localConfig)
+
+      // Persist the DB intents flag SEPARATELY, leaving the WebDAV intents config
+      // (saved just above) and the vault sync config untouched. Spread the
+      // existing config so ttlMs/pollIntervalMinutes are preserved and the
+      // written object matches the exact shape getDbIntentsConfig() reads.
+      const dbIntentsChanged = dbIntentsEnabled !== initialDbIntentsEnabled.current
+      saveDbIntentsConfig({ ...getDbIntentsConfig(), enabled: dbIntentsEnabled })
+
       onSaved()
       onClose()
+
+      // Reload on an enable change so useDbIntentsPoller remounts with the new
+      // config, mirroring how the vault sync toggle reloads to reconstruct its
+      // engine. (Sending already re-reads the gate per call; this is for the
+      // receive poller's cadence/startup.)
+      if (dbIntentsChanged) window.location.reload()
     } catch (err) {
       setSetupError(err instanceof Error ? err.message : t('integration.setupFailed'))
     } finally {
@@ -317,6 +344,48 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
 
             {setupError && (
               <p className="text-xs text-red-500 dark:text-red-400">{setupError}</p>
+            )}
+          </div>
+
+          {/* GLANCEvault intents (beta) — alternative transport to WebDAV above.
+              Independent toggle; inherits its connection from Sync settings. */}
+          <div className="space-y-3">
+            <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+              GLANCEvault intents (beta)
+            </h3>
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              ⚠️ Experimental. Sends and receives intents over your GLANCEvault server instead of WebDAV. Requires the GLANCEvault connection set up in Sync settings.
+            </p>
+            <div className="flex items-center justify-between gap-3 py-1">
+              <div className="min-w-0">
+                <p className="text-sm text-slate-700 dark:text-slate-300">Intents via GLANCEvault</p>
+                <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+                  Database-backed delivery using your GLANCEvault connection. Your WebDAV intents config is left intact.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setDbIntentsEnabled(v => !v)}
+                className={`relative shrink-0 w-10 h-6 rounded-full transition-colors ${dbIntentsEnabled ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
+                aria-checked={dbIntentsEnabled}
+                role="switch"
+              >
+                <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${dbIntentsEnabled ? 'translate-x-4' : ''}`} />
+              </button>
+            </div>
+
+            {dbIntentsEnabled && (
+              vaultConfigured ? (
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  Using your GLANCEvault connection (URL, device token, account ID) from Sync settings. Saved on close; the app reloads to start polling.
+                </p>
+              ) : (
+                <div className="flex items-start gap-2 p-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700/40">
+                  <p className="text-xs text-amber-700 dark:text-amber-300">
+                    No GLANCEvault connection found. Set up the GLANCEvault server in Sync settings (URL, device token, account ID) first — until then this transport stays inactive.
+                  </p>
+                </div>
+              )
             )}
           </div>
 

--- a/src/hooks/useDbIntentsPoller.ts
+++ b/src/hooks/useDbIntentsPoller.ts
@@ -17,8 +17,10 @@ import {
   isDbIntentsEnabled,
   getReceiveCursor,
   setReceiveCursor,
+  recordReceiveFailure,
+  clearReceiveFailure,
 } from '@/intents/dbConfig'
-import { listIntentsPage, receiveAllIntents } from '@/intents/dbTransport'
+import { listIntentsPage, receiveAllIntents, MAX_INTENT_RETRIES } from '@/intents/dbTransport'
 import { loadIntentsRootKey } from '@/intents/intentsKeyStore'
 import { processNotifyEnvelope } from '@/intents/processNotifyEnvelope'
 
@@ -45,19 +47,19 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
       if (isEncrypted) {
         const rootKey = await loadIntentsRootKey()
         if (!rootKey) {
-          addActivityEntry({ type: 'error', message: 'encrypted intent received but intents encryption not set up on this device' })
+          addActivityEntry({ type: 'error', message: `encrypted intent ${row.eventId} received but intents encryption not set up on this device` })
           return
         }
         let envelope
         try {
           envelope = await parseEncryptedEnvelope(data, (salt) => deriveEnvelopeKey(rootKey, salt))
         } catch (err) {
-          let message = 'Failed to decrypt intent'
-          if (err instanceof NoKeyError) message = 'No encryption key available to decrypt intent'
-          else if (err instanceof WrongKeyError) message = 'decryption failed (root key mismatch — try re-running intents encryption setup)'
-          else if (err instanceof NotEncryptedError) message = 'Intent is not encrypted as expected'
+          let message = `Failed to decrypt intent ${row.eventId}`
+          if (err instanceof NoKeyError) message = `No encryption key available to decrypt intent ${row.eventId}`
+          else if (err instanceof WrongKeyError) message = `decryption failed for intent ${row.eventId} (root key mismatch — try re-running intents encryption setup)`
+          else if (err instanceof NotEncryptedError) message = `Intent ${row.eventId} is not encrypted as expected`
           else if (err instanceof MalformedEnvelopeError) {
-            addActivityEntry({ type: 'warning', message: 'Malformed encrypted envelope', detail: err.message })
+            addActivityEntry({ type: 'warning', message: `Malformed encrypted envelope ${row.eventId}`, detail: err.message })
             return
           }
           addActivityEntry({ type: 'error', message, detail: err instanceof Error ? err.message : String(err) })
@@ -73,6 +75,7 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
       } catch {
         // Malformed plaintext envelope — skip this row but let the cursor advance
         // past it (it is consumed; re-listing would just hit the same bad row).
+        addActivityEntry({ type: 'warning', message: `Skipping malformed intent ${row.eventId}` })
         return
       }
       await processEnvelope(envelope)
@@ -97,6 +100,15 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
           setCursor: setReceiveCursor,
           listPage: (since) => listIntentsPage(since),
           processRow,
+          recordFailure: recordReceiveFailure,
+          clearFailure: clearReceiveFailure,
+          onGiveUp: (row, err, failures) => {
+            addActivityEntry({
+              type: 'error',
+              message: `Dropping intent ${row.eventId} after ${failures} failed attempts (limit ${MAX_INTENT_RETRIES})`,
+              detail: err instanceof Error ? err.message : String(err),
+            })
+          },
         })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/src/hooks/useDbIntentsPoller.ts
+++ b/src/hooks/useDbIntentsPoller.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+import {
+  parseEnvelope,
+  parseEncryptedEnvelope,
+  NoKeyError,
+  WrongKeyError,
+  NotEncryptedError,
+  MalformedEnvelopeError,
+  deriveEnvelopeKey,
+} from '@glance-apps/intents'
+import type { IntentEventRow } from '@glance-apps/intents'
+import { db } from '@/db/client'
+import { logCompletion } from '@/db/queries'
+import { addActivityEntry } from '@/intents/config'
+import {
+  getDbIntentsConfig,
+  isDbIntentsEnabled,
+  getReceiveCursor,
+  setReceiveCursor,
+} from '@/intents/dbConfig'
+import { listIntentsPage, receiveAllIntents } from '@/intents/dbTransport'
+import { loadIntentsRootKey } from '@/intents/intentsKeyStore'
+import { processNotifyEnvelope } from '@/intents/processNotifyEnvelope'
+
+// Drives the GLANCEvault DB intents receive poll on the SAME cadence the WebDAV
+// intents poller uses: once on startup, again whenever the tab becomes visible
+// (focus), and on a fixed interval. No push/real-time path is added here; if
+// GLANCEvault sync grows one, intents can piggyback on it later.
+//
+// This hook is gated by isDbIntentsEnabled(): when the DB intents transport is
+// off it does nothing, so it can be mounted alongside useIntentsPoller (the
+// WebDAV poller) and only the enabled transport runs.
+export function useDbIntentsPoller(onNewCompletion?: () => void): void {
+  const onNewCompletionRef = useRef<(() => void) | undefined>(onNewCompletion)
+  useEffect(() => { onNewCompletionRef.current = onNewCompletion }, [onNewCompletion])
+
+  useEffect(() => {
+    async function processRow(row: IntentEventRow): Promise<void> {
+      // parseIntentRow already decoded the base64 envelope into a structured
+      // object; route it by its `encrypted` flag exactly as the WebDAV read path
+      // does, then hand the validated envelope to the shared intent handler.
+      const data = row.envelope
+      const isEncrypted = typeof data === 'object' && data !== null && (data as Record<string, unknown>).encrypted === true
+
+      if (isEncrypted) {
+        const rootKey = await loadIntentsRootKey()
+        if (!rootKey) {
+          addActivityEntry({ type: 'error', message: 'encrypted intent received but intents encryption not set up on this device' })
+          return
+        }
+        let envelope
+        try {
+          envelope = await parseEncryptedEnvelope(data, (salt) => deriveEnvelopeKey(rootKey, salt))
+        } catch (err) {
+          let message = 'Failed to decrypt intent'
+          if (err instanceof NoKeyError) message = 'No encryption key available to decrypt intent'
+          else if (err instanceof WrongKeyError) message = 'decryption failed (root key mismatch — try re-running intents encryption setup)'
+          else if (err instanceof NotEncryptedError) message = 'Intent is not encrypted as expected'
+          else if (err instanceof MalformedEnvelopeError) {
+            addActivityEntry({ type: 'warning', message: 'Malformed encrypted envelope', detail: err.message })
+            return
+          }
+          addActivityEntry({ type: 'error', message, detail: err instanceof Error ? err.message : String(err) })
+          return
+        }
+        await processEnvelope(envelope)
+        return
+      }
+
+      let envelope
+      try {
+        envelope = parseEnvelope(data)
+      } catch {
+        // Malformed plaintext envelope — skip this row but let the cursor advance
+        // past it (it is consumed; re-listing would just hit the same bad row).
+        return
+      }
+      await processEnvelope(envelope)
+    }
+
+    async function processEnvelope(envelope: Awaited<ReturnType<typeof parseEnvelope>>) {
+      await processNotifyEnvelope(envelope, {
+        getChore: (syncId) => db.chores.where('sync_id').equals(syncId).first(),
+        logCompletion,
+        addActivityEntry,
+        isAlreadyLogged: (syncId) => db.completionEvents.where('sync_id').equals(syncId).count().then(n => n > 0),
+        dispatchChoreLogged: () => window.dispatchEvent(new CustomEvent('lg:chore-logged')),
+        onNewCompletion: () => onNewCompletionRef.current?.(),
+      })
+    }
+
+    async function poll() {
+      if (!isDbIntentsEnabled()) return
+      try {
+        await receiveAllIntents({
+          getCursor: getReceiveCursor,
+          setCursor: setReceiveCursor,
+          listPage: (since) => listIntentsPage(since),
+          processRow,
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        addActivityEntry({ type: 'error', message: 'Failed to poll GLANCEvault intents', detail: message })
+      }
+    }
+
+    poll()
+
+    const intervalMs = getDbIntentsConfig().pollIntervalMinutes * 60 * 1000
+    const interval = setInterval(poll, intervalMs)
+
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible') poll()
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+}

--- a/src/intents/buildCreateEnvelope.ts
+++ b/src/intents/buildCreateEnvelope.ts
@@ -1,0 +1,48 @@
+import { ACTIONS, SOURCE_APPS, buildEnvelope, buildEncryptedEnvelope, deriveEnvelopeKey } from '@glance-apps/intents'
+import type { Envelope, EncryptedEnvelope } from '@glance-apps/intents'
+import type { ChoreWithLastCompletion } from '@/types'
+import { loadIntentsRootKey } from './intentsKeyStore'
+import dayjs from 'dayjs'
+
+// Raised when an encrypted intent is requested but this device has not finished
+// intents-encryption setup (no root key). Both transports (WebDAV and the
+// GLANCEvault DB transport) catch this to surface the same "setup incomplete"
+// message rather than silently sending plaintext.
+export class IntentsKeyMissingError extends Error {
+  constructor() {
+    super('intents encryption setup incomplete')
+    this.name = 'IntentsKeyMissingError'
+  }
+}
+
+// Builds the outgoing CREATE envelope for a chore, encrypting it when intents
+// encryption is enabled. This is the single source of truth for the envelope
+// shape shared by every intents transport: WebDAV writes it to a file, the DB
+// transport encodes it into a vault row via buildIntentRow. The envelope itself
+// (and its stable event_id) is transport-agnostic, so re-sending the same chore
+// over either transport produces a byte-identical, idempotent envelope.
+export async function buildCreateEnvelope(
+  chore: ChoreWithLastCompletion,
+  encryptionEnabled: boolean,
+): Promise<Envelope | EncryptedEnvelope> {
+  const assignedUserIds = chore.assigned_user_sync_ids ?? []
+  const payload = {
+    title: chore.name,
+    due: dayjs().format('YYYY-MM-DD'),
+    all_day: true,
+    source_app: SOURCE_APPS.LASTGLANCE,
+    source_entity_id: chore.sync_id,
+    ...(assignedUserIds.length > 0 && { assigned_user_ids: assignedUserIds }),
+  }
+
+  if (encryptionEnabled) {
+    const rootKey = await loadIntentsRootKey()
+    if (!rootKey) throw new IntentsKeyMissingError()
+    return buildEncryptedEnvelope(
+      { action: ACTIONS.CREATE, payload, emittedBy: SOURCE_APPS.LASTGLANCE },
+      (salt) => deriveEnvelopeKey(rootKey, salt),
+    )
+  }
+
+  return buildEnvelope({ action: ACTIONS.CREATE, payload, emittedBy: SOURCE_APPS.LASTGLANCE })
+}

--- a/src/intents/dbConfig.ts
+++ b/src/intents/dbConfig.ts
@@ -77,3 +77,52 @@ export function getReceiveCursor(): number | null {
 export function setReceiveCursor(seq: number | null): void {
   localStorage.setItem(DB_INTENTS_RECEIVE_CURSOR_KEY, formatSince(seq))
 }
+
+// --- Receive failure counters (app-owned, persisted) ------------------------
+// Per-seq consecutive failure counts for the bounded-retry drain. A row whose
+// handler THROWS (typically a transient IndexedDB error) is retried across poll
+// cycles instead of either wedging the channel or being dropped; the count must
+// therefore survive reloads, so it lives in localStorage next to the cursor.
+// Only actively-failing seqs hold an entry — the count is cleared on success
+// AND on give-up, so the map stays empty in steady state.
+const DB_INTENTS_RECEIVE_FAILURES_KEY = 'lg_db_intents_receive_failures'
+
+type FailureMap = Record<string, number>
+
+function readFailures(): FailureMap {
+  try {
+    const raw = localStorage.getItem(DB_INTENTS_RECEIVE_FAILURES_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as FailureMap) : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeFailures(map: FailureMap): void {
+  if (Object.keys(map).length === 0) localStorage.removeItem(DB_INTENTS_RECEIVE_FAILURES_KEY)
+  else localStorage.setItem(DB_INTENTS_RECEIVE_FAILURES_KEY, JSON.stringify(map))
+}
+
+// Current consecutive failure count for a seq (0 when none recorded).
+export function getReceiveFailureCount(seq: number): number {
+  return readFailures()[String(seq)] ?? 0
+}
+
+// Increments and returns the new consecutive failure count for a seq.
+export function recordReceiveFailure(seq: number): number {
+  const map = readFailures()
+  const next = (map[String(seq)] ?? 0) + 1
+  map[String(seq)] = next
+  writeFailures(map)
+  return next
+}
+
+// Clears a seq's failure counter (on success or give-up).
+export function clearReceiveFailure(seq: number): void {
+  const map = readFailures()
+  if (map[String(seq)] === undefined) return
+  delete map[String(seq)]
+  writeFailures(map)
+}

--- a/src/intents/dbConfig.ts
+++ b/src/intents/dbConfig.ts
@@ -1,0 +1,79 @@
+// GLANCEvault (DB transport) config for INTENTS.
+//
+// This is the per-user opt-in gate for sending and receiving intents over the
+// GLANCEvault `intents` endpoints instead of WebDAV files. It is deliberately
+// SEPARATE from:
+//   - the WebDAV intents config (src/intents/config.ts), which remains the
+//     default and is fully intact — an app may run either transport; and
+//   - the GLANCEvault *sync* enablement (src/sync/vaultConfig.ts), which moves
+//     entity rows. Intents and sync are independent: enabling one does not
+//     enable the other.
+//
+// The vault *connection* (url, device bearer token, account id) is shared with
+// the sync transport and read from getVaultConfig() — intents reuse the same
+// device-token auth. This module only owns the intents-specific enablement
+// flag, the TTL/poll cadence, and the app-owned RECEIVE CURSOR.
+
+import { parseSince, formatSince } from '@glance-apps/intents'
+import { getVaultConfig } from '@/sync/vaultConfig'
+
+const DB_INTENTS_CONFIG_KEY = 'lg_db_intents_config'
+
+// The receive cursor lives in its OWN dedicated key, mirroring how the WebDAV
+// intents cursor (lg_intents_cursor) is stored. The send path NEVER touches it
+// (see dbTransport.sendCreateIntent): sending cannot advance what a device has
+// received. This is the critical separation from the GLANCEvault sync cursor.
+const DB_INTENTS_RECEIVE_CURSOR_KEY = 'lg_db_intents_receive_cursor'
+
+export interface DbIntentsConfig {
+  enabled: boolean
+  // TTL applied to each outgoing intent row. The server returns only non-expired
+  // rows, so this bounds how long a never-seen intent stays deliverable.
+  ttlMs: number
+  pollIntervalMinutes: number
+}
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
+
+export const DEFAULT_DB_INTENTS_CONFIG: DbIntentsConfig = {
+  enabled: false,
+  ttlMs: THIRTY_DAYS_MS,
+  pollIntervalMinutes: 15,
+}
+
+export function getDbIntentsConfig(): DbIntentsConfig {
+  try {
+    const raw = localStorage.getItem(DB_INTENTS_CONFIG_KEY)
+    if (!raw) return { ...DEFAULT_DB_INTENTS_CONFIG }
+    return { ...DEFAULT_DB_INTENTS_CONFIG, ...JSON.parse(raw) }
+  } catch {
+    return { ...DEFAULT_DB_INTENTS_CONFIG }
+  }
+}
+
+export function saveDbIntentsConfig(config: DbIntentsConfig): void {
+  localStorage.setItem(DB_INTENTS_CONFIG_KEY, JSON.stringify(config))
+}
+
+// True only when the DB intents transport is turned on AND the shared vault
+// connection is fully populated (the same fields isVaultEnabled() requires).
+// This is the single gate every send/receive path checks; when false the app
+// behaves exactly as before and only the WebDAV intents transport runs.
+export function isDbIntentsEnabled(): boolean {
+  const cfg = getDbIntentsConfig()
+  if (!cfg.enabled) return false
+  const vault = getVaultConfig()
+  return !!(vault && vault.vaultUrl && vault.vaultToken && vault.accountId)
+}
+
+// --- Receive cursor (app-owned) ---------------------------------------------
+// Stored as the codec's `since` string form. parseSince/formatSince are the
+// codec helpers; null/absent means "from the beginning" (full backlog).
+
+export function getReceiveCursor(): number | null {
+  return parseSince(localStorage.getItem(DB_INTENTS_RECEIVE_CURSOR_KEY))
+}
+
+export function setReceiveCursor(seq: number | null): void {
+  localStorage.setItem(DB_INTENTS_RECEIVE_CURSOR_KEY, formatSince(seq))
+}

--- a/src/intents/dbTransport.test.ts
+++ b/src/intents/dbTransport.test.ts
@@ -5,11 +5,29 @@ import {
   postIntentsBatch,
   sendCreateIntent,
   DEFAULT_LIST_LIMIT,
+  MAX_INTENT_RETRIES,
   type ListPage,
 } from './dbTransport'
-import { getReceiveCursor, setReceiveCursor } from './dbConfig'
+import {
+  getReceiveCursor,
+  setReceiveCursor,
+  getReceiveFailureCount,
+  recordReceiveFailure,
+  clearReceiveFailure,
+} from './dbConfig'
 import { setVaultConfig } from '@/sync/vaultConfig'
 import type { ChoreWithLastCompletion } from '@/types'
+
+// In-memory per-seq failure counters for driving the bounded-retry drain
+// without localStorage. Mirrors dbConfig's recordReceiveFailure/clearReceiveFailure.
+function memCounters() {
+  const counts = new Map<number, number>()
+  return {
+    recordFailure: (seq: number) => { const n = (counts.get(seq) ?? 0) + 1; counts.set(seq, n); return n },
+    clearFailure: (seq: number) => { counts.delete(seq) },
+    getCount: (seq: number) => counts.get(seq) ?? 0,
+  }
+}
 
 function installLocalStorage(): void {
   const store = new Map<string, string>()
@@ -64,11 +82,14 @@ describe('receiveAllIntents — pagination', () => {
 
     const seen: number[] = []
     let cursor: number | null = null
+    const mc = memCounters()
     const processed = await receiveAllIntents({
       getCursor: () => cursor,
       setCursor: (seq) => { cursor = seq },
       listPage,
       processRow: async (row) => { seen.push(row.seq) },
+      recordFailure: mc.recordFailure,
+      clearFailure: mc.clearFailure,
     })
 
     // Every row processed exactly once, in ascending order — nothing truncated.
@@ -87,15 +108,123 @@ describe('receiveAllIntents — pagination', () => {
     const rows = [makeRow(3), makeRow(4), makeRow(5)]
     const { listPage, sinceCalls } = makePagedServer(rows, DEFAULT_LIST_LIMIT)
     let cursor: number | null = null
+    const mc = memCounters()
     const processed = await receiveAllIntents({
       getCursor: () => cursor,
       setCursor: (seq) => { cursor = seq },
       listPage,
       processRow: async () => {},
+      recordFailure: mc.recordFailure,
+      clearFailure: mc.clearFailure,
     })
     expect(processed).toBe(3)
     expect(cursor).toBe(5)
     expect(sinceCalls).toEqual([0]) // single page, no re-list
+  })
+})
+
+describe('receiveAllIntents — bounded retry on handler throw', () => {
+  // A server that always lists every row with seq > since on one page. The drain
+  // is re-invoked once per "poll cycle" so retries span calls like real polls.
+  function singlePageServer(rows: IntentEventRow[]) {
+    return async (since: number): Promise<ListPage> => {
+      const after = [...rows].sort((a, b) => a.seq - b.seq).filter((r) => r.seq > since)
+      return { rows: after, hasMore: false }
+    }
+  }
+
+  it('(a) retries a row that throws once, then consumes it — not lost', async () => {
+    const rows = [makeRow(10), makeRow(11)]
+    const listPage = singlePageServer(rows)
+    const mc = memCounters()
+    let cursor: number | null = null
+    const seen: number[] = []
+    let shouldThrow = true
+    const processRow = async (row: IntentEventRow) => {
+      if (row.seq === 10 && shouldThrow) { shouldThrow = false; throw new Error('transient IndexedDB error') }
+      seen.push(row.seq)
+    }
+    const deps = {
+      getCursor: () => cursor,
+      setCursor: (s: number) => { cursor = s },
+      listPage,
+      processRow,
+      recordFailure: mc.recordFailure,
+      clearFailure: mc.clearFailure,
+    }
+
+    // Poll 1: seq 10 throws (count < MAX) -> whole drain stops, cursor unadvanced.
+    const p1 = await receiveAllIntents(deps)
+    expect(p1).toBe(0)
+    expect(cursor).toBeNull()        // held at the failing seq, not advanced past it
+    expect(mc.getCount(10)).toBe(1)  // one recorded failure
+    expect(seen).toEqual([])         // nothing consumed yet — 10 not dropped
+
+    // Poll 2: the SAME seq 10 now succeeds -> advance + clear, then 11 too.
+    const p2 = await receiveAllIntents(deps)
+    expect(p2).toBe(2)
+    expect(seen).toEqual([10, 11])   // 10 was retried, not lost
+    expect(cursor).toBe(11)
+    expect(mc.getCount(10)).toBe(0)  // counter CLEARED on success
+  })
+
+  it('(b) gives up after MAX_INTENT_RETRIES, logs the eventId, and skips so the channel does not wedge', async () => {
+    const rows = [makeRow(20), makeRow(21)]
+    const listPage = singlePageServer(rows)
+    const mc = memCounters()
+    const giveUps: Array<{ eventId: string; failures: number }> = []
+    let cursor: number | null = null
+    const seen: number[] = []
+    const processRow = async (row: IntentEventRow) => {
+      if (row.seq === 20) throw new Error('permanent handler failure')
+      seen.push(row.seq)
+    }
+    const deps = {
+      getCursor: () => cursor,
+      setCursor: (s: number) => { cursor = s },
+      listPage,
+      processRow,
+      recordFailure: mc.recordFailure,
+      clearFailure: mc.clearFailure,
+      onGiveUp: (row: IntentEventRow, _err: unknown, failures: number) => giveUps.push({ eventId: row.eventId, failures }),
+    }
+
+    // Polls below the threshold: each stops the drain with the cursor held.
+    for (let i = 1; i < MAX_INTENT_RETRIES; i++) {
+      const p = await receiveAllIntents(deps)
+      expect(p).toBe(0)
+      expect(cursor).toBeNull()
+      expect(mc.getCount(20)).toBe(i)
+      expect(giveUps).toEqual([])    // not given up yet
+      expect(seen).toEqual([])       // channel still wedged on 20 (by design, retrying)
+    }
+
+    // The MAX-th failure: give up — log with eventId, advance past 20, clear,
+    // then 21 is consumed (channel un-wedged).
+    const pFinal = await receiveAllIntents(deps)
+    expect(giveUps).toEqual([{ eventId: 'evt-20', failures: MAX_INTENT_RETRIES }])
+    expect(mc.getCount(20)).toBe(0)  // counter CLEARED on give-up
+    expect(seen).toEqual([21])       // 21 now flows — one bad row did not wedge the channel
+    expect(cursor).toBe(21)
+    expect(pFinal).toBe(2)           // 20 (given up) + 21 (success) advanced past
+  })
+
+  it('(c) the failure counter persists across a simulated reload', () => {
+    installLocalStorage()
+    // Use the REAL persisted counters (localStorage-backed), as the poller does.
+    expect(getReceiveFailureCount(77)).toBe(0)
+    expect(recordReceiveFailure(77)).toBe(1)
+    expect(recordReceiveFailure(77)).toBe(2)
+
+    // "Reload": dbConfig holds no in-memory state, so a fresh read goes back to
+    // localStorage, which survives a reload. The raw key holds the count.
+    expect(getReceiveFailureCount(77)).toBe(2)
+    expect(localStorage.getItem('lg_db_intents_receive_failures')).toBe(JSON.stringify({ '77': 2 }))
+
+    // Clearing removes the entry (and the key once empty), so steady state is clean.
+    clearReceiveFailure(77)
+    expect(getReceiveFailureCount(77)).toBe(0)
+    expect(localStorage.getItem('lg_db_intents_receive_failures')).toBeNull()
   })
 })
 

--- a/src/intents/dbTransport.test.ts
+++ b/src/intents/dbTransport.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { IntentEventRow } from '@glance-apps/intents'
+import {
+  receiveAllIntents,
+  postIntentsBatch,
+  sendCreateIntent,
+  DEFAULT_LIST_LIMIT,
+  type ListPage,
+} from './dbTransport'
+import { getReceiveCursor, setReceiveCursor } from './dbConfig'
+import { setVaultConfig } from '@/sync/vaultConfig'
+import type { ChoreWithLastCompletion } from '@/types'
+
+function installLocalStorage(): void {
+  const store = new Map<string, string>()
+  ;(globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size },
+  } as Storage
+}
+
+function makeRow(seq: number): IntentEventRow {
+  return {
+    eventId: `evt-${seq}`,
+    envelope: { schema_version: 1, seq },
+    seq,
+    expiresAt: '2026-12-31T00:00:00.000Z',
+    serverMtime: '2026-06-21T00:00:00.000Z',
+  }
+}
+
+// Pages an in-memory backlog the way the server does: rows with seq > since,
+// ascending, at most `pageSize` per call, hasMore when more remain. Records
+// every `since` it was asked for so the test can assert the loop re-listed.
+function makePagedServer(rows: IntentEventRow[], pageSize: number) {
+  const sinceCalls: number[] = []
+  const sorted = [...rows].sort((a, b) => a.seq - b.seq)
+  const listPage = async (since: number): Promise<ListPage> => {
+    sinceCalls.push(since)
+    const after = sorted.filter((r) => r.seq > since)
+    const page = after.slice(0, pageSize)
+    return { rows: page, hasMore: after.length > pageSize }
+  }
+  return { listPage, sinceCalls }
+}
+
+describe('receiveAllIntents — pagination', () => {
+  it('drains a >500 backlog completely across pages, advancing the cursor to the last seq', async () => {
+    // 1234 rows with NON-CONTIGUOUS seqs (a gap stands in for intents the server
+    // omitted because they expired before this device listed — a legitimate skip,
+    // not the sync cursor-skip bug).
+    const seqs: number[] = []
+    let s = 1
+    for (let i = 0; i < 1234; i++) {
+      s += i === 600 ? 50 : 1 // a 49-seq gap partway through
+      seqs.push(s)
+    }
+    const rows = seqs.map(makeRow)
+    const { listPage, sinceCalls } = makePagedServer(rows, DEFAULT_LIST_LIMIT)
+
+    const seen: number[] = []
+    let cursor: number | null = null
+    const processed = await receiveAllIntents({
+      getCursor: () => cursor,
+      setCursor: (seq) => { cursor = seq },
+      listPage,
+      processRow: async (row) => { seen.push(row.seq) },
+    })
+
+    // Every row processed exactly once, in ascending order — nothing truncated.
+    expect(processed).toBe(1234)
+    expect(seen).toEqual(seqs)
+    // Cursor ends at the last received seq (past the expiry gap — correct).
+    expect(cursor).toBe(seqs[seqs.length - 1])
+    // The loop re-listed: 1234 rows / 500 page = 3 list pages (2 full + 1 partial).
+    expect(sinceCalls.length).toBe(3)
+    expect(sinceCalls[0]).toBe(0)                 // first list from the beginning
+    expect(sinceCalls[1]).toBe(seqs[499])         // resumed from page-1's last seq
+    expect(sinceCalls[2]).toBe(seqs[999])         // resumed from page-2's last seq
+  })
+
+  it('stops after one page when hasMore is false', async () => {
+    const rows = [makeRow(3), makeRow(4), makeRow(5)]
+    const { listPage, sinceCalls } = makePagedServer(rows, DEFAULT_LIST_LIMIT)
+    let cursor: number | null = null
+    const processed = await receiveAllIntents({
+      getCursor: () => cursor,
+      setCursor: (seq) => { cursor = seq },
+      listPage,
+      processRow: async () => {},
+    })
+    expect(processed).toBe(3)
+    expect(cursor).toBe(5)
+    expect(sinceCalls).toEqual([0]) // single page, no re-list
+  })
+})
+
+describe('send path — cursor isolation and idempotency', () => {
+  const CHORE = {
+    id: 1,
+    name: 'Replace HVAC filter',
+    sync_id: 'chore-sync-1',
+    assigned_user_sync_ids: [],
+  } as unknown as ChoreWithLastCompletion
+
+  beforeEach(() => {
+    installLocalStorage()
+    setVaultConfig({ enabled: true, vaultUrl: 'https://vault.example', vaultToken: 'tok', accountId: 'acct-1' })
+  })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('sending an intent does NOT advance the receive cursor', async () => {
+    // Seed an existing receive cursor; the send path must never touch it.
+    setReceiveCursor(42)
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ written: 1, maxSeq: 99 }),
+    })))
+
+    const ok = await sendCreateIntent(CHORE)
+    expect(ok).toBe(true)
+    // maxSeq=99 came back from the WRITE, but the RECEIVE cursor stays at 42.
+    expect(getReceiveCursor()).toBe(42)
+  })
+
+  it('re-sending the same eventId is idempotent (server no-op)', async () => {
+    // Fake insert-only server: tracks eventIds; a re-sent id writes 0.
+    const stored = new Set<string>()
+    let nextSeq = 0
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { accountId: string; events: { eventId: string }[] }
+      let written = 0
+      for (const e of body.events) {
+        if (!stored.has(e.eventId)) { stored.add(e.eventId); written++; nextSeq++ }
+      }
+      return { ok: true, status: 200, text: async () => JSON.stringify({ written, maxSeq: nextSeq }) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Build one row, then POST it twice — the same eventId both times.
+    const row = { eventId: 'evt-stable', envelope: 'ZW52', expiresAt: '2026-12-31T00:00:00.000Z' }
+    const first = await postIntentsBatch([row])
+    const second = await postIntentsBatch([row])
+
+    expect(first).toEqual({ written: 1, maxSeq: 1 })
+    expect(second).toEqual({ written: 0, maxSeq: 1 }) // re-send was a no-op
+    expect(stored.size).toBe(1)
+
+    // And the batch wrapper on the wire is { accountId, events: [...] }.
+    const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(sentBody.accountId).toBe('acct-1')
+    expect(sentBody.events[0].eventId).toBe('evt-stable')
+  })
+})

--- a/src/intents/dbTransport.ts
+++ b/src/intents/dbTransport.ts
@@ -127,6 +127,13 @@ export async function listIntentsPage(since: number, limit = DEFAULT_LIST_LIMIT)
   }
 }
 
+// A handler that throws this many CONSECUTIVE times on the same seq is treated
+// as poison and given up on (advanced past), so a permanently-bad row cannot
+// wedge the channel forever. Below the threshold a throw is assumed transient
+// and the drain stops to retry from the same cursor next poll. Identical
+// name/value to dayGLANCE's intents drain.
+export const MAX_INTENT_RETRIES = 5
+
 export interface ReceiveDeps {
   // Reads the app-owned receive cursor (null = from the beginning / full backlog).
   getCursor: () => number | null
@@ -135,17 +142,36 @@ export interface ReceiveDeps {
   // Fetches one page from `since`. Injected so tests can drive the pagination
   // loop without a server; the poller passes listIntentsPage.
   listPage: (since: number) => Promise<ListPage | null>
-  // Handles one decoded row (route the envelope to the app's intent handling).
+  // Handles one decoded row. Returns normally on success OR on a decode/
+  // permanent-bad row (which it skip-logs internally). THROWS only when the
+  // handler itself failed (e.g. a transient IndexedDB error) — that throw drives
+  // the bounded-retry path below.
   processRow: (row: IntentEventRow) => Promise<void>
+  // Persisted per-seq failure counters (survive poll cycles / reloads). Inject
+  // so tests can drive retries in-memory; the poller wires the localStorage ones.
+  recordFailure: (seq: number) => number // increment, return new consecutive count
+  clearFailure: (seq: number) => void
+  // Called when a seq is given up on after MAX_INTENT_RETRIES, so the app can log
+  // loudly with the row's eventId. Optional (logging only).
+  onGiveUp?: (row: IntentEventRow, err: unknown, failures: number) => void
 }
 
-// RECEIVE with PAGINATION. Reading .rows once would silently truncate any
-// backlog over one page (default 500). So we LOOP: read .rows, process them,
-// advance the cursor to the last row's seq, and if hasMore is true immediately
-// list again from the new cursor — until hasMore is false.
+// RECEIVE with PAGINATION + BOUNDED RETRY. Reading .rows once would silently
+// truncate any backlog over one page (default 500). So we LOOP: read .rows,
+// process them, advance the cursor to the last row's seq, and if hasMore is true
+// immediately list again from the new cursor — until hasMore is false.
 //
-// Returns the number of rows processed. The cursor advances ONLY here, from
-// intents actually received and processed; nothing in the send path can move it.
+// Per-row handling is a three-way model so one bad row can neither abort the
+// drain nor wedge the channel:
+//   1. processRow returns       -> success / decode-skip: advance, clear, continue.
+//   2. processRow THROWS, count < MAX -> assumed transient: STOP the drain,
+//      cursor unadvanced, so the next poll retries this seq from here.
+//   3. processRow THROWS, count >= MAX -> poison: log, advance past it, clear,
+//      continue (the channel must not wedge on one permanently-bad row).
+//
+// Returns the number of rows consumed (advanced past — successes, decode-skips,
+// and give-ups). The cursor advances ONLY here, from intents actually received;
+// nothing in the send path can move it.
 export async function receiveAllIntents(deps: ReceiveDeps): Promise<number> {
   let cursor = deps.getCursor() ?? 0
   let processed = 0
@@ -155,13 +181,38 @@ export async function receiveAllIntents(deps: ReceiveDeps): Promise<number> {
     if (!page) break
 
     for (const row of page.rows) {
-      await deps.processRow(row)
-      // Advance the receive cursor to this row's seq. THE CURSOR MAY LEGITIMATELY
-      // ADVANCE PAST A SEQ WHOSE INTENT EXPIRED before this device listed it: the
-      // server returns only non-expired rows, so an expired intent is simply
-      // never delivered and its seq is skipped. THIS IS CORRECT AND INTENDED
-      // (TTL means a stale intent is meant to be missed) — it is NOT the sync
-      // cursor-skip bug and must not be "fixed" by re-listing from a lower seq.
+      try {
+        await deps.processRow(row)
+      } catch (err) {
+        // HANDLER THREW — catch so it can no longer abort the drain. Do NOT
+        // advance the cursor yet; bump this seq's persisted consecutive-failure
+        // count and decide retry vs give-up.
+        const failures = deps.recordFailure(row.seq)
+        if (failures >= MAX_INTENT_RETRIES) {
+          // Poison row: give up so the channel can't wedge forever. Log loudly
+          // (with eventId), advance past it, and clear its counter.
+          deps.onGiveUp?.(row, err, failures)
+          deps.clearFailure(row.seq)
+          cursor = row.seq
+          deps.setCursor(cursor)
+          processed++
+          continue
+        }
+        // Below the threshold — assume transient. Stop the WHOLE drain for this
+        // poll with the cursor unadvanced; the next poll resumes from this seq
+        // and retries it. Return cleanly (do not re-throw).
+        return processed
+      }
+
+      // No throw: success or a decode/permanent-bad skip. Advance past the row.
+      // Clear any failure counter for this seq (success path; a never-failed seq
+      // is a harmless no-op). THE CURSOR MAY LEGITIMATELY ADVANCE PAST A SEQ
+      // WHOSE INTENT EXPIRED before this device listed it: the server returns
+      // only non-expired rows, so an expired intent is simply never delivered
+      // and its seq is skipped. THIS IS CORRECT AND INTENDED (TTL means a stale
+      // intent is meant to be missed) — it is NOT the sync cursor-skip bug and
+      // must not be "fixed" by re-listing from a lower seq.
+      deps.clearFailure(row.seq)
       cursor = row.seq
       deps.setCursor(cursor)
       processed++

--- a/src/intents/dbTransport.ts
+++ b/src/intents/dbTransport.ts
@@ -1,0 +1,211 @@
+// App-owned GLANCEvault DB transport for INTENTS.
+//
+// @glance-apps/intents is a CODEC, not a transport: its src/vault/ helpers
+// (buildIntentRow / parseIntentRow / parseSince / formatSince) only encode and
+// decode the wire row. THIS module owns delivery — HTTP, the device-token auth,
+// pagination, and routing decoded envelopes into the app's existing intent
+// handling. It mirrors how the WebDAV intents transport is app-owned (poller,
+// cursor, HTTP) and uses the package only for the envelope codec.
+//
+// Server contract (authoritative):
+//   WRITE  POST {vaultUrl}/intents/batch
+//     body { accountId, events: [ { eventId, envelope(base64), expiresAt(ISO) } ] }
+//     resp { written, maxSeq }   — insert-only; a re-sent eventId is a no-op.
+//   LIST   GET  {vaultUrl}/intents/list?accountId=&since=&limit=
+//     resp { rows: [ { eventId, envelope(base64), seq, expiresAt, serverMtime } ], hasMore }
+//     seq > since, ascending; only non-expired rows are returned.
+//   Auth: same device-token bearer as the GLANCEvault sync transport.
+
+import { buildIntentRow, parseIntentRow } from '@glance-apps/intents'
+import type { OutboundIntentRow, IntentEventRow } from '@glance-apps/intents'
+import { isNativePlatform, nativeHttpFetch } from '@/sync/nativeHttp'
+import { getVaultConfig } from '@/sync/vaultConfig'
+import type { ChoreWithLastCompletion } from '@/types'
+import { getIntentsConfig, addActivityEntry } from './config'
+import { getDbIntentsConfig } from './dbConfig'
+import { buildCreateEnvelope, IntentsKeyMissingError } from './buildCreateEnvelope'
+
+// Server default list page size. The client never sends fewer; it just keeps
+// paging on `hasMore` until the backlog is drained (see receiveAllIntents).
+export const DEFAULT_LIST_LIMIT = 500
+
+const REQUEST_TIMEOUT_MS = 15_000
+
+interface VaultResponse {
+  status: number
+  ok: boolean
+  text: () => Promise<string>
+}
+
+interface VaultConn {
+  vaultUrl: string
+  vaultToken: string
+  accountId: string
+}
+
+// Resolves the shared GLANCEvault connection (url, device token, account id).
+// Returns null when the vault is not configured — callers treat that as "DB
+// intents not available" and no-op.
+function getConn(): VaultConn | null {
+  const v = getVaultConfig()
+  if (!v || !v.vaultUrl || !v.vaultToken || !v.accountId) return null
+  return { vaultUrl: v.vaultUrl, vaultToken: v.vaultToken, accountId: v.accountId }
+}
+
+// Single HTTP entry point. Uses the same device-token bearer the sync transport
+// uses (Authorization: Bearer <token>). On native (Capacitor) it goes straight
+// through the native HTTP stack, CORS-free; in the browser/PWA it uses fetch
+// directly against the vault server (which serves CORS, unlike WebDAV).
+async function vaultFetch(
+  conn: VaultConn,
+  method: string,
+  path: string,
+  opts: { query?: Record<string, string>; body?: unknown } = {},
+): Promise<VaultResponse> {
+  const base = conn.vaultUrl.replace(/\/+$/, '')
+  let url = base + path
+  if (opts.query) {
+    const qs = new URLSearchParams(opts.query).toString()
+    if (qs) url += `?${qs}`
+  }
+  const headers: Record<string, string> = { Authorization: `Bearer ${conn.vaultToken}` }
+  const body = opts.body !== undefined ? JSON.stringify(opts.body) : null
+  if (body !== null) headers['Content-Type'] = 'application/json'
+
+  if (isNativePlatform) {
+    const r = await nativeHttpFetch(method, url, headers, body)
+    return { status: r.status, ok: r.ok, text: async () => r.body }
+  }
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(new DOMException('Request timed out', 'AbortError')), REQUEST_TIMEOUT_MS)
+  return fetch(url, {
+    method,
+    headers,
+    ...(body !== null ? { body } : {}),
+    signal: controller.signal,
+  }).finally(() => clearTimeout(timer))
+}
+
+export interface BatchResult {
+  written: number
+  maxSeq: number
+}
+
+// POST a batch of insert-only intent rows. The accountId is a top-level field
+// of the batch body, NOT part of any row — sending is structurally incapable of
+// advancing a receive cursor. Re-sending a row whose eventId already exists is a
+// server-side no-op, so a failed/retried send is always safe.
+export async function postIntentsBatch(events: OutboundIntentRow[]): Promise<BatchResult | null> {
+  const conn = getConn()
+  if (!conn) return null
+  const res = await vaultFetch(conn, 'POST', '/intents/batch', {
+    body: { accountId: conn.accountId, events },
+  })
+  if (!res.ok) throw new Error(`intents batch failed: ${res.status}`)
+  return JSON.parse(await res.text()) as BatchResult
+}
+
+export interface ListPage {
+  rows: IntentEventRow[]
+  hasMore: boolean
+}
+
+// GET one page of intents with seq > since (ascending). Each raw row is run
+// through the codec's parseIntentRow, which validates the camelCase/base64 wire
+// shape and decodes the envelope back to a structured object.
+export async function listIntentsPage(since: number, limit = DEFAULT_LIST_LIMIT): Promise<ListPage | null> {
+  const conn = getConn()
+  if (!conn) return null
+  const res = await vaultFetch(conn, 'GET', '/intents/list', {
+    query: { accountId: conn.accountId, since: String(since), limit: String(limit) },
+  })
+  if (!res.ok) throw new Error(`intents list failed: ${res.status}`)
+  const data = JSON.parse(await res.text()) as { rows: unknown[]; hasMore: boolean }
+  return {
+    rows: data.rows.map((r) => parseIntentRow(r)),
+    hasMore: data.hasMore === true,
+  }
+}
+
+export interface ReceiveDeps {
+  // Reads the app-owned receive cursor (null = from the beginning / full backlog).
+  getCursor: () => number | null
+  // Persists the advanced receive cursor. Only ever called from the receive loop.
+  setCursor: (seq: number) => void
+  // Fetches one page from `since`. Injected so tests can drive the pagination
+  // loop without a server; the poller passes listIntentsPage.
+  listPage: (since: number) => Promise<ListPage | null>
+  // Handles one decoded row (route the envelope to the app's intent handling).
+  processRow: (row: IntentEventRow) => Promise<void>
+}
+
+// RECEIVE with PAGINATION. Reading .rows once would silently truncate any
+// backlog over one page (default 500). So we LOOP: read .rows, process them,
+// advance the cursor to the last row's seq, and if hasMore is true immediately
+// list again from the new cursor — until hasMore is false.
+//
+// Returns the number of rows processed. The cursor advances ONLY here, from
+// intents actually received and processed; nothing in the send path can move it.
+export async function receiveAllIntents(deps: ReceiveDeps): Promise<number> {
+  let cursor = deps.getCursor() ?? 0
+  let processed = 0
+
+  for (;;) {
+    const page = await deps.listPage(cursor)
+    if (!page) break
+
+    for (const row of page.rows) {
+      await deps.processRow(row)
+      // Advance the receive cursor to this row's seq. THE CURSOR MAY LEGITIMATELY
+      // ADVANCE PAST A SEQ WHOSE INTENT EXPIRED before this device listed it: the
+      // server returns only non-expired rows, so an expired intent is simply
+      // never delivered and its seq is skipped. THIS IS CORRECT AND INTENDED
+      // (TTL means a stale intent is meant to be missed) — it is NOT the sync
+      // cursor-skip bug and must not be "fixed" by re-listing from a lower seq.
+      cursor = row.seq
+      deps.setCursor(cursor)
+      processed++
+    }
+
+    if (!page.hasMore) break
+    // hasMore — there is more backlog beyond this page. List again immediately
+    // from the just-advanced cursor rather than waiting for the next poll tick.
+  }
+
+  return processed
+}
+
+// SEND one CREATE intent over the DB transport. Mirrors emitCreateIntent's
+// WebDAV path but encodes the envelope into a vault row via the codec and POSTs
+// the batch wrapper. Returns true on success.
+//
+// NOTE: this never reads or writes the receive cursor. The batch body carries
+// accountId at the top level and the row carries no seq, so sending cannot
+// advance what this device has received.
+export async function sendCreateIntent(chore: ChoreWithLastCompletion): Promise<boolean> {
+  const conn = getConn()
+  if (!conn) return false
+
+  try {
+    const encryptionEnabled = getIntentsConfig().encryptionEnabled
+    const envelope = await buildCreateEnvelope(chore, encryptionEnabled)
+    // buildIntentRow lifts envelope.event_id to the row's top-level eventId (the
+    // server idempotency key) and computes ttlMs from the envelope's emitted_at,
+    // so re-sending the same chore produces a byte-identical, idempotent row.
+    const row = buildIntentRow(envelope, { ttlMs: getDbIntentsConfig().ttlMs })
+
+    const result = await postIntentsBatch([row])
+    if (!result) return false
+
+    addActivityEntry({ type: 'sent', message: `Sent "${chore.name}" to dayGLANCE` })
+    return true
+  } catch (err) {
+    if (err instanceof IntentsKeyMissingError) {
+      addActivityEntry({ type: 'error', message: 'intents encryption setup incomplete — open Settings to complete setup' })
+      return false
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    addActivityEntry({ type: 'error', message: `Failed to send "${chore.name}" to dayGLANCE`, detail: message })
+    return false
+  }
+}

--- a/src/intents/emitter.ts
+++ b/src/intents/emitter.ts
@@ -1,41 +1,24 @@
-import { ACTIONS, SOURCE_APPS, buildEnvelope, buildEncryptedEnvelope, filenameFor, deriveEnvelopeKey } from '@glance-apps/intents'
+import { filenameFor } from '@glance-apps/intents'
 import type { ChoreWithLastCompletion } from '@/types'
 import { getIntentsConfig, isIntentsConfigured, addActivityEntry } from './config'
+import { isDbIntentsEnabled } from './dbConfig'
+import { sendCreateIntent } from './dbTransport'
 import { buildAuthHeader, ensureFolder, putFile } from './webdav'
-import { loadIntentsRootKey } from './intentsKeyStore'
-import dayjs from 'dayjs'
+import { buildCreateEnvelope, IntentsKeyMissingError } from './buildCreateEnvelope'
 
 export async function emitCreateIntent(chore: ChoreWithLastCompletion): Promise<boolean> {
+  // TRANSPORT SELECTION. When the per-user GLANCEvault DB intents transport is
+  // enabled, send there. Otherwise fall through to the WebDAV transport, which
+  // remains the default and is unchanged below. An app runs one or the other.
+  if (isDbIntentsEnabled()) return sendCreateIntent(chore)
+
   const config = getIntentsConfig()
   if (!isIntentsConfigured(config)) return false
 
   const authHeader = buildAuthHeader(config.webdavUsername, config.webdavPassword)
 
   try {
-    const assignedUserIds = chore.assigned_user_sync_ids ?? []
-    const payload = {
-      title: chore.name,
-      due: dayjs().format('YYYY-MM-DD'),
-      all_day: true,
-      source_app: SOURCE_APPS.LASTGLANCE,
-      source_entity_id: chore.sync_id,
-      ...(assignedUserIds.length > 0 && { assigned_user_ids: assignedUserIds }),
-    }
-
-    let envelope: Awaited<ReturnType<typeof buildEncryptedEnvelope>> | ReturnType<typeof buildEnvelope>
-    if (config.encryptionEnabled) {
-      const rootKey = await loadIntentsRootKey()
-      if (!rootKey) {
-        addActivityEntry({ type: 'error', message: 'intents encryption setup incomplete — open Settings to complete setup' })
-        return false
-      }
-      envelope = await buildEncryptedEnvelope(
-        { action: ACTIONS.CREATE, payload, emittedBy: SOURCE_APPS.LASTGLANCE },
-        (salt) => deriveEnvelopeKey(rootKey, salt)
-      )
-    } else {
-      envelope = buildEnvelope({ action: ACTIONS.CREATE, payload, emittedBy: SOURCE_APPS.LASTGLANCE })
-    }
+    const envelope = await buildCreateEnvelope(chore, config.encryptionEnabled)
 
     const filename = `${envelope.event_id}.json`
     const content = JSON.stringify(envelope)
@@ -46,6 +29,10 @@ export async function emitCreateIntent(chore: ChoreWithLastCompletion): Promise<
     addActivityEntry({ type: 'sent', message: `Sent "${chore.name}" to dayGLANCE` })
     return true
   } catch (err) {
+    if (err instanceof IntentsKeyMissingError) {
+      addActivityEntry({ type: 'error', message: 'intents encryption setup incomplete — open Settings to complete setup' })
+      return false
+    }
     const message = err instanceof Error ? err.message : String(err)
     addActivityEntry({ type: 'error', message: `Failed to send "${chore.name}" to dayGLANCE`, detail: message })
     return false


### PR DESCRIPTION
## Summary

Adds a **per-user opt-in GLANCEvault DB transport for INTENTS**, alongside the existing WebDAV intents transport. WebDAV intents remain the **default and fully intact** — an app runs one transport or the other. Built on `@glance-apps/intents@1.4.0`'s `src/vault/` codec (`buildIntentRow` / `parseIntentRow` / `parseSince` / `formatSince`), which handles only envelope↔row encoding and cursor formatting; **the app owns delivery** (HTTP, device-token auth, the receive cursor, pagination, transport selection), mirroring how the WebDAV intents transport is app-owned.

## What's included

**Transport** (`src/intents/dbTransport.ts`, `dbConfig.ts`)
- **SEND** — builds a row via `buildIntentRow`, assembles the batch wrapper `{ accountId, events: [...] }`, and `POST`s to `/intents/batch` with the same device-token bearer the GLANCEvault sync transport uses. Insert-only, so a re-sent `eventId` is a server no-op (retries are safe).
- **RECEIVE with pagination** — loops `GET /intents/list` on the `hasMore` flag, processing `.rows`, advancing the cursor to each consumed row's `seq`, and re-listing until `hasMore` is false. A backlog over one page (500) is drained completely rather than truncated. Rows are decoded via `parseIntentRow` and routed (by `encrypted` flag) through `parseEnvelope`/`parseEncryptedEnvelope` into the **same** `processNotifyEnvelope` handler WebDAV feeds.
- **Receive-cursor discipline** — the cursor lives in its own app-owned `localStorage` key and advances **only** from received-and-processed rows; the send path never touches it. The advance site documents that advancing past an expired intent's `seq` is correct/intended (TTL), **not** the sync cursor-skip bug.

**Polling** (`src/hooks/useDbIntentsPoller.ts`) — drives the receive poll on the same cadence as the WebDAV intents poller (startup, focus, interval). No push path added.

**Transport selection** — `isDbIntentsEnabled()` gate, independent of the WebDAV intents config and of the vault sync toggle. The emitter routes to the DB transport only when enabled, else the unchanged WebDAV path.

**Settings UI** (`IntegrationSettingsModal`) — a "GLANCEvault intents (beta)" section with an enable toggle, placed alongside the WebDAV intents config. No URL/token/account fields: the transport **inherits** its connection from the GLANCEvault sync config (`getVaultConfig`), so the UI shows connection status instead of duplicating entry. On save it writes `lg_db_intents_config` in the exact shape `getDbIntentsConfig()` reads (spreads the existing config, overrides only `enabled`), and reloads on an enable change so the poller remounts — mirroring the vault sync toggle.

## Dependency

- Pins `@glance-apps/intents` to **exactly `1.4.0`** (the vault-codec release).
- `@glance-apps/sync` is **untouched** (`^1.5.2`).

## Tests

`src/intents/dbTransport.test.ts` proves: (a) the pagination loop drains a >500-row backlog completely (incl. a deliberate expiry gap), (b) sending never advances the receive cursor, (c) a re-sent `eventId` is idempotent (server no-op). Full suite: **62/62 passing**; `tsc -b` clean; production build clean.

## Scope / non-regression

- Does **not** modify `@glance-apps/intents` or `@glance-apps/sync`.
- Does **not** change the WebDAV intents or vault sync behavior — the DB intents toggle writes only `lg_db_intents_config`.
- No merge/conflict logic (intents are insert-only); intents salt is **not** migrated to server state (separate follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyinAqGvPz2BfwmxhD1RrQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyinAqGvPz2BfwmxhD1RrQ)_