### PR TITLE
Pin @glance-apps/sync to exact version 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/ios": "^8.4.0",
         "@capacitor/status-bar": "^8.0.2",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "^1.5.2",
+        "@glance-apps/sync": "1.5.2",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/ios": "^8.4.0",
     "@capacitor/status-bar": "^8.0.2",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "^1.5.2",
+    "@glance-apps/sync": "1.5.2",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",


### PR DESCRIPTION
## Summary

Pins `@glance-apps/sync` to the exact version `1.5.2`, removing the caret (`^`) range. This aligns it with the exact-version pinning style already used by `@glance-apps/intents` (`1.4.0`), so both `@glance-apps` dependencies are uniform.

## Changes

- `package.json`: `@glance-apps/sync` changed from `^1.5.2` → `1.5.2`
- `package-lock.json`: updated the root package's dependency range to match

The resolved version in the lockfile was already `1.5.2`, so no install changes are needed — this only tightens the declared range for consistent, reproducible installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017C8rAer47fR2PPW7S1WcX7)_