### PR TITLE
Clarify WebDAV intents toggle label in Integration settings

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -155,7 +155,8 @@
   "integration": {
     "title": "dayGLANCE-Integration",
     "connectionSection": "Verbindung",
-    "enableIntegration": "Integration aktivieren",
+    "enableIntegration": "WebDAV-Intents aktivieren",
+    "enableIntegrationHint": "Steuert nur den WebDAV-Intents-Transport — GLANCEvault-Intents werden unten festgelegt.",
     "webdavUrl": "WebDAV-URL",
     "webdavUrlPlaceholder": "https://dein-server.com/remote.php/dav/files/user/",
     "webdavUrlHint": "Nextcloud: https://dein-server/remote.php/dav/files/benutzername/",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -155,7 +155,8 @@
   "integration": {
     "title": "dayGLANCE Integration",
     "connectionSection": "Connection",
-    "enableIntegration": "Enable integration",
+    "enableIntegration": "Enable WebDAV intents",
+    "enableIntegrationHint": "Controls the WebDAV intents transport only — GLANCEvault intents are set below.",
     "webdavUrl": "WebDAV URL",
     "webdavUrlPlaceholder": "https://your-server.com/remote.php/dav/files/user/",
     "webdavUrlHint": "Nextcloud: https://your-server/remote.php/dav/files/username/",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -155,7 +155,8 @@
   "integration": {
     "title": "Integración con dayGLANCE",
     "connectionSection": "Conexión",
-    "enableIntegration": "Activar integración",
+    "enableIntegration": "Activar intents por WebDAV",
+    "enableIntegrationHint": "Controla solo el transporte de intents por WebDAV — los intents por GLANCEvault se configuran abajo.",
     "webdavUrl": "URL de WebDAV",
     "webdavUrlPlaceholder": "https://tu-servidor.com/remote.php/dav/files/usuario/",
     "webdavUrlHint": "Nextcloud: https://tu-servidor/remote.php/dav/files/usuario/",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -155,7 +155,8 @@
   "integration": {
     "title": "Intégration dayGLANCE",
     "connectionSection": "Connexion",
-    "enableIntegration": "Activer l'intégration",
+    "enableIntegration": "Activer les intents WebDAV",
+    "enableIntegrationHint": "Contrôle uniquement le transport des intents WebDAV — les intents GLANCEvault se configurent ci-dessous.",
     "webdavUrl": "URL WebDAV",
     "webdavUrlPlaceholder": "https://votre-serveur.com/remote.php/dav/files/user/",
     "webdavUrlHint": "Nextcloud : https://votre-serveur/remote.php/dav/files/utilisateur/",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -155,7 +155,8 @@
   "integration": {
     "title": "Integrazione dayGLANCE",
     "connectionSection": "Connessione",
-    "enableIntegration": "Abilita integrazione",
+    "enableIntegration": "Abilita intent via WebDAV",
+    "enableIntegrationHint": "Controlla solo il trasporto degli intent via WebDAV — gli intent via GLANCEvault si configurano sotto.",
     "webdavUrl": "URL WebDAV",
     "webdavUrlPlaceholder": "https://tuo-server.com/remote.php/dav/files/utente/",
     "webdavUrlHint": "Nextcloud: https://tuo-server/remote.php/dav/files/nomeutente/",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -155,7 +155,8 @@
   "integration": {
     "title": "Integração dayGLANCE",
     "connectionSection": "Ligação",
-    "enableIntegration": "Ativar integração",
+    "enableIntegration": "Ativar intents via WebDAV",
+    "enableIntegrationHint": "Controla apenas o transporte de intents via WebDAV — os intents via GLANCEvault são configurados abaixo.",
     "webdavUrl": "URL WebDAV",
     "webdavUrlPlaceholder": "https://o-seu-servidor.com/remote.php/dav/files/utilizador/",
     "webdavUrlHint": "Nextcloud: https://o-seu-servidor/remote.php/dav/files/utilizador/",

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -176,12 +176,15 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
             </h3>
 
             {/* Enable toggle */}
-            <div className="flex items-center justify-between py-1">
-              <span className="text-sm text-slate-700 dark:text-slate-300">{t('integration.enableIntegration')}</span>
+            <div className="flex items-start justify-between py-1">
+              <div className="min-w-0">
+                <p className="text-sm text-slate-700 dark:text-slate-300">{t('integration.enableIntegration')}</p>
+                <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{t('integration.enableIntegrationHint')}</p>
+              </div>
               <button
                 type="button"
                 onClick={() => set('enabled', !localConfig.enabled)}
-                className={`relative w-10 h-6 rounded-full transition-colors ${localConfig.enabled ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
+                className={`relative shrink-0 mt-0.5 w-10 h-6 rounded-full transition-colors ${localConfig.enabled ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
                 aria-checked={localConfig.enabled}
                 role="switch"
               >


### PR DESCRIPTION
## Summary

Clarifies the top toggle in the dayGLANCE Integration settings so it no longer reads as a master switch for the entire integration.

The toggle previously labeled **"Enable integration"** actually gates **only the WebDAV intents transport** (`config.enabled` → `isIntentsConfigured()`, which drives the WebDAV send fallback and the WebDAV receive poller). GLANCEvault intents are governed independently by the separate "Intents via GLANCEvault" toggle (`isDbIntentsEnabled()`), so turning this off does **not** disable intents entirely. The old label made it look like it might.

## Changes

- Rename the toggle: **"Enable integration" → "Enable WebDAV intents"**, mirroring the "Intents via GLANCEvault" toggle below it so the two transports read as a clear pair.
- Add a hint line under the toggle: *"Controls the WebDAV intents transport only — GLANCEvault intents are set below."*
- Minor layout tweak in `IntegrationSettingsModal.tsx` so the row renders a label + hint.
- Applied the label and hint across all six locales (en, de, es, fr, it, pt).

No behavior change — copy/UX only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017C8rAer47fR2PPW7S1WcX7)_