### PR TITLE
android: optional versionCode override for pre-release uploads

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -5,7 +5,18 @@ apply plugin: 'com.android.application'
 def pkg = new groovy.json.JsonSlurper().parse(rootProject.file("../package.json"))
 def appVersionName = pkg.version as String
 def versionParts = appVersionName.tokenize('.')
-def appVersionCode = versionParts[0].toInteger() * 10000 + versionParts[1].toInteger() * 100 + versionParts[2].toInteger()
+def derivedVersionCode = versionParts[0].toInteger() * 10000 + versionParts[1].toInteger() * 100 + versionParts[2].toInteger()
+
+// One-off versionCode override for uploading pre-release builds (e.g. to the
+// Play internal test track) without disturbing the derived release numbering.
+// Play requires each upload to have a strictly higher versionCode than anything
+// previously uploaded to ANY track, so an internal build needs a code above the
+// current release's but below the NEXT release's derived code — pick from that
+// band (e.g. between 1.9.0's 10900 and 1.10.0's 11000, use 10901, 10902, …):
+//   ./gradlew bundleRelease -PappVersionCode=10901
+// Omit the property and the code derives from package.json exactly as before, so
+// real releases keep their clean derived numbering.
+def appVersionCode = (project.findProperty("appVersionCode") ?: derivedVersionCode).toString().toInteger()
 
 // Release signing is configured via android/keystore.properties (gitignored).
 // When absent (e.g. debug-only/CI without secrets) release builds stay unsigned.


### PR DESCRIPTION
## Summary

Adds an optional `-PappVersionCode` override to the Android build so a pre-release build (e.g. for the Play **internal test track**) can be uploaded without disturbing the derived release numbering.

## Why

`android/app/build.gradle` derives `versionCode` from `package.json` (`major*10000 + minor*100 + patch`), so 1.9.0 → 10900 and 1.10.0 → 11000. Play requires every uploaded AAB to have a strictly higher `versionCode` than anything previously uploaded to **any** track. That makes it awkward to push an internal-test build now without consuming the number reserved for the real release.

## Change

```gradle
def appVersionCode = (project.findProperty("appVersionCode") ?: derivedVersionCode).toString().toInteger()
```

- **With the property:** `./gradlew bundleRelease -PappVersionCode=10901` builds with that code.
- **Without it:** the code derives from `package.json` exactly as before — real releases keep their clean derived numbering (no behavior change to the normal build).

## Usage for internal test

Use a code in the band between the current and next release — above 10900, below 11000 — so the actual 1.10.0 release keeps **11000**: `-PappVersionCode=10901` (then 10902, … per upload).

Note: `versionName` still comes from `package.json` (currently `1.9.0`), so the internal build displays 1.9.0 unless `package.json` is bumped. This PR only adds the override mechanism; no version string is bumped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017C8rAer47fR2PPW7S1WcX7)_