### PR TITLE
android: forward APP_VERSION_CODE through build-android.sh (follow-up to #135)

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -11,6 +11,14 @@ set -e
 #                                 -> outputs/lastglance.apk, outputs/lastglance.aab
 #   ./build-android.sh --clean    full gradle clean + wipe dist/ first
 # Flags combine, e.g. ./build-android.sh --clean --release
+#
+# One-off versionCode override (for pre-release / internal-test uploads), via the
+# APP_VERSION_CODE env var. Play requires each upload to have a higher versionCode
+# than any previous upload, so to push an internal build without consuming the
+# next release's number, pass a code in the band between the current and next
+# release (e.g. 10901 between 1.9.0's 10900 and 1.10.0's 11000):
+#   APP_VERSION_CODE=10901 ./build-android.sh --release
+# Unset, the versionCode derives from package.json as usual.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ANDROID_DIR="$SCRIPT_DIR/android"
@@ -70,9 +78,15 @@ if $RELEASE; then
 
   # Build the release APK (for sideloading/testing) and the AAB (App Bundle)
   # that the Play Store requires for uploads, in a single Gradle invocation.
-  echo "==> Building release APK + AAB..."
+  # APP_VERSION_CODE, when set, overrides the package.json-derived versionCode
+  # (see build.gradle); otherwise the gradle property is simply not passed.
+  if [ -n "$APP_VERSION_CODE" ]; then
+    echo "==> Building release APK + AAB (versionCode override: $APP_VERSION_CODE)..."
+  else
+    echo "==> Building release APK + AAB..."
+  fi
   cd "$ANDROID_DIR"
-  ./gradlew assembleRelease bundleRelease
+  ./gradlew assembleRelease bundleRelease ${APP_VERSION_CODE:+-PappVersionCode="$APP_VERSION_CODE"}
 
   cp "app/build/outputs/apk/release/lastglance.apk" "$OUT_DIR/lastglance.apk"
   echo "    APK (release) → outputs/lastglance.apk"


### PR DESCRIPTION
## Summary

Follow-up to #135. That PR added the `-PappVersionCode` override to `android/app/build.gradle`, but the release build actually runs through `build-android.sh`, which bakes in the `./gradlew assembleRelease bundleRelease` call — so there was no way to pass the property. This forwards it.

## Change

`build-android.sh` now forwards an optional `APP_VERSION_CODE` env var to the release Gradle invocation:

```bash
./gradlew assembleRelease bundleRelease ${APP_VERSION_CODE:+-PappVersionCode="$APP_VERSION_CODE"}
```

- **Set:** the versionCode override is applied to the build.
- **Unset:** nothing is passed; the versionCode derives from `package.json` exactly as before (no change to normal release builds).

## Usage

For an internal-test upload, pick a code in the band between the current and next release (e.g. 10901, between 1.9.0's 10900 and 1.10.0's 11000):

```bash
APP_VERSION_CODE=10901 ./build-android.sh --release
```

→ produces `outputs/lastglance.aab` with versionCode 10901, leaving the derived release numbering untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017C8rAer47fR2PPW7S1WcX7)_