### PR TITLE
fix(intents): decrypt GLANCEvault receive with the vault key, not the WebDAV key

### DIFF
--- a/src/hooks/useDbIntentsPoller.ts
+++ b/src/hooks/useDbIntentsPoller.ts
@@ -12,7 +12,7 @@ import {
   clearReceiveFailure,
 } from '@/intents/dbConfig'
 import { listIntentsPage, receiveAllIntents, MAX_INTENT_RETRIES } from '@/intents/dbTransport'
-import { loadIntentsRootKey } from '@/intents/intentsKeyStore'
+import { loadVaultIntentsRootKey } from '@/intents/vaultIntentsKeyStore'
 import { routeIncomingVaultRow } from '@/intents/routeIncoming'
 import { processNotifyEnvelope } from '@/intents/processNotifyEnvelope'
 
@@ -33,8 +33,14 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
       // Route by the row's `encrypted` flag. A NON-encrypted row on the vault is
       // a zero-knowledge contract violation: routeIncomingVaultRow rejects it
       // (logs loudly, advances past it) and never routes plaintext into the app.
+      //
+      // Decrypt with the VAULT intents key — the SAME slot the vault deliverer
+      // encrypts with (loadVaultIntentsRootKey), NOT the WebDAV intents key. The
+      // two transports derive different keys from different salts, so using the
+      // WebDAV slot here fails: absent in a vault-only setup ("encryption not set
+      // up"), or a key mismatch when both are configured.
       await routeIncomingVaultRow(row, {
-        loadRootKey: loadIntentsRootKey,
+        loadRootKey: loadVaultIntentsRootKey,
         handleEnvelope: processEnvelope,
         addActivityEntry,
       })


### PR DESCRIPTION
## Symptom

With GLANCEvault intents enabled, **sending** a chore to dayGLANCE works, but when dayGLANCE sends the completion back, lastGLANCE logs:

> encrypted intent xxxxxxxxxx received but intents encryption not set up on this device

## Cause

A key-slot mismatch between send and receive:

- **Send** (vault deliverer) encrypts with `loadVaultIntentsRootKey()` — the **vault** key slot, populated by the enable flow.
- **Receive** (`useDbIntentsPoller`) decrypted with `loadIntentsRootKey()` — the **WebDAV** key slot.

The two transports derive different keys from different salts (WebDAV salt file vs. the vault `/salt/:accountId`). In a GLANCEvault-only setup the WebDAV slot is empty → "not set up". With both transports configured it would fail as a key mismatch instead. Sending worked precisely because it used the (set-up) vault key — confirming the key exists; receive was just reaching into the wrong slot.

This was a gap from the staged rollout: stage 2a kept the receive decrypt key as the WebDAV slot (deferred), and the later stages switched the *send* path to the vault key but never updated the *receive* decrypt key.

## Fix

Point the vault receive path at `loadVaultIntentsRootKey` so decrypt uses the same slot the deliverer encrypts with. One-line wiring change in `useDbIntentsPoller.ts`.

## Note on already-errored intents

The completion intents that already errored had the receive cursor advanced past them (a missing-key skip is treated as consumed), so they won't auto-replay after this fix — only *new* completions will decrypt. They're likely still on the server within TTL; recovery options are to re-complete in dayGLANCE (emits a fresh completion) or reset the vault receive cursor to re-pull the backlog (completion logging is idempotent). Whether a missing-key skip *should* advance the cursor is a separate design question worth a follow-up.

## Verification
Full suite 96/96; `tsc -b && vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017C8rAer47fR2PPW7S1WcX7)_