### PR TITLE
fix(intents): hold + retry vault receive on key-not-available (don't skip)

### DIFF
--- a/src/intents/routeIncoming.test.ts
+++ b/src/intents/routeIncoming.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vite
 import { webcrypto } from 'node:crypto'
 import { buildEncryptedEnvelope, buildEnvelope, deriveIntentsRootKey, ACTIONS } from '@glance-apps/intents'
 import type { Envelope, IntentEventRow } from '@glance-apps/intents'
-import { routeIncomingVaultRow } from './routeIncoming'
+import { routeIncomingVaultRow, KeyNotAvailableError } from './routeIncoming'
+import { receiveAllIntents, MAX_INTENT_RETRIES, type ListPage } from './dbTransport'
 
 beforeAll(() => {
   if (!(globalThis as { crypto?: Crypto }).crypto) {
@@ -21,18 +22,26 @@ const createArgs = {
   eventId: 'evt-1',
 } as const
 
+function keyFrom(pass: string, fill: number): Promise<CryptoKey> {
+  return deriveIntentsRootKey(pass, new Uint8Array(16).fill(fill))
+}
 async function rootKey(): Promise<CryptoKey> {
-  return deriveIntentsRootKey('test-passphrase', new Uint8Array(16).fill(7))
+  return keyFrom('test-passphrase', 7)
 }
 
+async function deriveEnvelopeKeyFor(key: CryptoKey, salt: Uint8Array<ArrayBuffer>): Promise<CryptoKey> {
+  const { deriveEnvelopeKey } = await import('@glance-apps/intents')
+  return deriveEnvelopeKey(key, salt)
+}
+async function encryptedRow(key: CryptoKey, eventId = 'evt-1', seq = 1): Promise<IntentEventRow> {
+  const env = await buildEncryptedEnvelope({ ...createArgs, eventId }, (salt) => deriveEnvelopeKeyFor(key, salt))
+  return { eventId, envelope: env, seq, expiresAt: '', serverMtime: '' } as unknown as IntentEventRow
+}
 function rowFrom(envelope: unknown): IntentEventRow {
-  // parseIntentRow normally produces this; we only need the fields the router reads.
   return { eventId: 'evt-1', envelope, seq: 1, expiresAt: '', serverMtime: '' } as unknown as IntentEventRow
 }
 
-describe('vault receive routing — plaintext rejection', () => {
-  // (d) a NON-encrypted row on the vault is rejected: permanent-bad, logged
-  // loudly, NOT routed, parseEnvelope never reached.
+describe('vault receive routing — plaintext rejection & decrypt outcomes', () => {
   it('rejects a plaintext row without routing it', async () => {
     const plaintext = buildEnvelope(createArgs) // a normal, NON-encrypted envelope
     const handleEnvelope = vi.fn(async () => {})
@@ -51,13 +60,10 @@ describe('vault receive routing — plaintext rejection', () => {
     expect(activity.some((a) => a.type === 'error' && a.message.includes('evt-1'))).toBe(true)
   })
 
-  // (d cont.) an ENCRYPTED row is processed normally.
   it('decrypts and routes an encrypted row', async () => {
     const key = await rootKey()
-    const encrypted = await buildEncryptedEnvelope(createArgs, (salt) => deriveEnvelopeKeyFor(key, salt))
-
     const routed: Envelope[] = []
-    const outcome = await routeIncomingVaultRow(rowFrom(encrypted), {
+    const outcome = await routeIncomingVaultRow(await encryptedRow(key), {
       loadRootKey: async () => key,
       handleEnvelope: async (env) => { routed.push(env) },
       addActivityEntry: () => {},
@@ -69,25 +75,126 @@ describe('vault receive routing — plaintext rejection', () => {
     expect(errorSpy).not.toHaveBeenCalled()
   })
 
-  it('skips (does not reject) an encrypted row when no key is available', async () => {
+  // KEY NOT AVAILABLE -> TRANSIENT: throws (so the drain holds + retries) rather
+  // than returning a terminal outcome.
+  it('throws KeyNotAvailableError (transient) when no key is cached', async () => {
     const key = await rootKey()
-    const encrypted = await buildEncryptedEnvelope(createArgs, (salt) => deriveEnvelopeKeyFor(key, salt))
     const handleEnvelope = vi.fn(async () => {})
 
-    const outcome = await routeIncomingVaultRow(rowFrom(encrypted), {
-      loadRootKey: async () => null,
+    await expect(
+      routeIncomingVaultRow(await encryptedRow(key), {
+        loadRootKey: async () => null, // key not set up yet
+        handleEnvelope,
+        addActivityEntry: () => {},
+      }),
+    ).rejects.toBeInstanceOf(KeyNotAvailableError)
+    expect(handleEnvelope).not.toHaveBeenCalled()
+  })
+
+  // (b) DECRYPT FAILED WITH KEY PRESENT -> PERMANENT: returns 'skipped' (advance)
+  // and logs; does NOT throw.
+  it('returns skipped (permanent) when a key is present but the row is undecryptable', async () => {
+    const keyA = await keyFrom('passA', 7)
+    const keyB = await keyFrom('passB', 9) // different key -> wrong-key decrypt
+    const row = await encryptedRow(keyA)
+    const handleEnvelope = vi.fn(async () => {})
+    const activity: Array<{ type: string; message: string }> = []
+
+    const outcome = await routeIncomingVaultRow(row, {
+      loadRootKey: async () => keyB, // key present, but the wrong one
       handleEnvelope,
-      addActivityEntry: () => {},
+      addActivityEntry: (e) => activity.push(e),
     })
 
-    expect(outcome).toBe('skipped')
+    expect(outcome).toBe('skipped') // terminal: advance past the bad row
     expect(handleEnvelope).not.toHaveBeenCalled()
+    expect(activity.some((a) => a.type === 'error' && a.message.includes('evt-1'))).toBe(true)
   })
 })
 
-// Local copy of the deriveEnvelopeKey wiring so the test builds an encrypted
-// envelope with the same root key the router decrypts with.
-async function deriveEnvelopeKeyFor(key: CryptoKey, salt: Uint8Array<ArrayBuffer>): Promise<CryptoKey> {
-  const { deriveEnvelopeKey } = await import('@glance-apps/intents')
-  return deriveEnvelopeKey(key, salt)
+// ── Integration with the receive drain (cursor + bounded retry) ───────────────
+
+function memCounters() {
+  const counts = new Map<number, number>()
+  return {
+    recordFailure: (seq: number) => { const n = (counts.get(seq) ?? 0) + 1; counts.set(seq, n); return n },
+    clearFailure: (seq: number) => { counts.delete(seq) },
+    getCount: (seq: number) => counts.get(seq) ?? 0,
+  }
 }
+
+// Drives receiveAllIntents over a single encrypted row at the given seq, routing
+// through routeIncomingVaultRow with a (possibly absent) key.
+function harness(row: IntentEventRow, getKey: () => CryptoKey | null) {
+  let cursor: number | null = null
+  const counters = memCounters()
+  const handleEnvelope = vi.fn(async () => {})
+  const onGiveUp = vi.fn()
+  const routed: Envelope[] = []
+
+  async function runOnce() {
+    return receiveAllIntents({
+      getCursor: () => cursor,
+      setCursor: (seq) => { cursor = seq },
+      // Return the row only while the cursor sits below it; empty once advanced.
+      listPage: async (since): Promise<ListPage> => ({ rows: since < row.seq ? [row] : [], hasMore: false }),
+      processRow: async (r) => {
+        await routeIncomingVaultRow(r, {
+          loadRootKey: async () => getKey(),
+          handleEnvelope: async (env) => { routed.push(env); await handleEnvelope() },
+          addActivityEntry: () => {},
+        })
+      },
+      recordFailure: counters.recordFailure,
+      clearFailure: counters.clearFailure,
+      onGiveUp,
+    })
+  }
+
+  return { runOnce, getCursor: () => cursor, counters, handleEnvelope, onGiveUp, routed }
+}
+
+describe('vault receive — decrypt/key failures in the bounded-retry model', () => {
+  // (a) key-absent decrypt does NOT advance the cursor; once the key is present
+  // a later poll decrypts and processes it.
+  it('holds (no cursor advance) on key-absent, then processes once keyed', async () => {
+    const key = await rootKey()
+    const row = await encryptedRow(key, 'evt-1', 10)
+    let currentKey: CryptoKey | null = null
+    const h = harness(row, () => currentKey)
+
+    await h.runOnce() // key absent -> transient throw -> hold
+    expect(h.getCursor()).toBeNull() // cursor NOT advanced
+    expect(h.handleEnvelope).not.toHaveBeenCalled()
+    expect(h.counters.getCount(10)).toBe(1) // one recorded failure, will retry
+    expect(h.onGiveUp).not.toHaveBeenCalled()
+
+    currentKey = key // encryption now set up
+    await h.runOnce() // retry from the same cursor -> decrypts + processes
+    expect(h.handleEnvelope).toHaveBeenCalledTimes(1)
+    expect(h.routed[0].event_id).toBe('evt-1')
+    expect(h.getCursor()).toBe(10) // advanced only after success
+    expect(h.counters.getCount(10)).toBe(0) // failure counter cleared
+  })
+
+  // (c) a persistently key-absent row gives up at the bound (advance + onGiveUp),
+  // so it can't wedge the channel forever.
+  it('gives up at MAX_INTENT_RETRIES when the key never arrives', async () => {
+    const key = await rootKey()
+    const row = await encryptedRow(key, 'evt-1', 10)
+    const h = harness(row, () => null) // key never available
+
+    // Each poll records one failure and holds, until the bound is hit.
+    for (let i = 0; i < MAX_INTENT_RETRIES - 1; i++) {
+      await h.runOnce()
+      expect(h.getCursor()).toBeNull() // still held
+      expect(h.onGiveUp).not.toHaveBeenCalled()
+    }
+
+    await h.runOnce() // this poll reaches the bound -> give up
+    expect(h.onGiveUp).toHaveBeenCalledTimes(1)
+    expect(h.onGiveUp.mock.calls[0][0]).toMatchObject({ eventId: 'evt-1' }) // logged with eventId
+    expect(h.getCursor()).toBe(10) // advanced past so the channel can't wedge
+    expect(h.handleEnvelope).not.toHaveBeenCalled()
+  })
+})

--- a/src/intents/routeIncoming.ts
+++ b/src/intents/routeIncoming.ts
@@ -1,4 +1,4 @@
-// Vault intents receive routing (stage 2a).
+// Vault intents receive routing (stage 2a; decrypt-failure retry model added).
 //
 // Extracted from the DB intents poller so the routing decision — including the
 // hard plaintext rejection below — is unit-testable without mounting the hook.
@@ -9,6 +9,18 @@
 // (logs loudly, advances the cursor past it) and NEVER calls parseEnvelope —
 // plaintext is not routed into the app under any circumstance. The WebDAV
 // receive path is unchanged and still accepts its existing envelope policy.
+//
+// RETRY MODEL: this function folds into the receive drain's three-way model. A
+// TRANSIENT failure is signalled by THROWING (the drain holds the cursor and
+// retries this seq, giving up only at MAX_INTENT_RETRIES); a TERMINAL outcome is
+// signalled by RETURNING (the drain advances past the row). The key distinction
+// for decrypt failures is the CAUSE:
+//   - key NOT available (the vault key slot is empty / not set up yet) -> THROW
+//     (transient): hold + retry, so the row is not lost while setup is pending;
+//     once the key exists the held row decrypts and processes. Persistent
+//     absence gives up at the bound so it can't wedge the channel forever.
+//   - decrypt failed WITH a key present (bad ciphertext / wrong shape / key
+//     mismatch) -> RETURN (terminal): advance past the bad row and log.
 
 import {
   parseEncryptedEnvelope,
@@ -20,6 +32,16 @@ import {
 } from '@glance-apps/intents'
 import type { Envelope, IntentEventRow } from '@glance-apps/intents'
 
+// Thrown when no decryption key is cached yet (encryption not set up on this
+// device). The receive drain treats a throw as TRANSIENT, so the row is held and
+// retried via the existing per-seq bounded-retry counter rather than skipped.
+export class KeyNotAvailableError extends Error {
+  constructor(eventId: string) {
+    super(`encrypted intent ${eventId} received but intents encryption is not set up on this device yet`)
+    this.name = 'KeyNotAvailableError'
+  }
+}
+
 type ActivityEntry = { type: 'sent' | 'received' | 'warning' | 'error'; message: string; detail?: string }
 
 export interface RouteIncomingDeps {
@@ -30,9 +52,9 @@ export interface RouteIncomingDeps {
   addActivityEntry: (entry: ActivityEntry) => void
 }
 
-// Outcome is returned for tests/diagnostics. In all non-'processed' cases the
-// caller still advances the cursor past the row (the receive drain treats a
-// normal return as "consumed"); only a thrown error would pause the drain.
+// Returned for tests/diagnostics on a TERMINAL outcome — the caller advances the
+// cursor past the row. (A TRANSIENT failure throws instead of returning, so the
+// drain holds the cursor and retries.)
 export type RouteOutcome = 'processed' | 'rejected' | 'skipped'
 
 export async function routeIncomingVaultRow(
@@ -60,17 +82,21 @@ export async function routeIncomingVaultRow(
 
   const rootKey = await deps.loadRootKey()
   if (!rootKey) {
-    deps.addActivityEntry({
-      type: 'error',
-      message: `encrypted intent ${row.eventId} received but intents encryption not set up on this device`,
-    })
-    return 'skipped'
+    // KEY NOT AVAILABLE — TRANSIENT. Throw so the drain holds the cursor and
+    // retries this seq (bounded by MAX_INTENT_RETRIES) instead of skipping past
+    // it. This is what lets an intent received before encryption setup decrypt
+    // and process once the key is in place, rather than being lost. No
+    // per-attempt activity entry: the drain's onGiveUp logs loudly if the key
+    // never arrives within the bound.
+    throw new KeyNotAvailableError(row.eventId)
   }
 
   let envelope: Envelope
   try {
     envelope = await parseEncryptedEnvelope(data, (salt) => deriveEnvelopeKey(rootKey, salt))
   } catch (err) {
+    // Key WAS present but decryption still failed — a genuinely bad row (wrong
+    // shape / ciphertext / key mismatch). TERMINAL: advance past it and log.
     let message = `Failed to decrypt intent ${row.eventId}`
     if (err instanceof NoKeyError) message = `No encryption key available to decrypt intent ${row.eventId}`
     else if (err instanceof WrongKeyError) message = `decryption failed for intent ${row.eventId} (root key mismatch — try re-running intents encryption setup)`


### PR DESCRIPTION
## Summary

Follow-up to #137. That fix pointed the GLANCEvault receive path at the correct (vault) key slot, so new intents decrypt. But the underlying **cursor behavior on a decrypt/key failure was still wrong**: any decrypt failure returned a terminal outcome, so the drain advanced the cursor past the row and **permanently lost it** — including when the only problem was "the vault key isn't set up yet." That's what lost two completions during testing.

This folds decrypt/key-availability failures into the **same bounded-retry three-way model** the handler-failure path already uses, distinguishing the two causes:

- **Key NOT available** (`loadVaultIntentsRootKey()` returns null) → **transient**: `routeIncomingVaultRow` now **throws `KeyNotAvailableError`**. The receive drain already treats a throw as transient, so it **holds the cursor and retries** this seq via the existing per-seq counter, giving up only at `MAX_INTENT_RETRIES` (loud `onGiveUp` + advance, so a permanently-keyless state can't wedge the channel). Once the key is set up, the held intent decrypts and processes.
- **Decrypt failed WITH a key present** (bad ciphertext / wrong shape / key mismatch) → **permanent**: return `'skipped'` (advance + log), unchanged.

Reuses the existing per-seq counter and `MAX_INTENT_RETRIES` — no second mechanism. The poller's `processRow` already propagates the throw into `receiveAllIntents`, so no poller change was needed.

## Before / after (the cursor-handling change)

```ts
// before — key absent treated as terminal, cursor advances, intent lost:
if (!rootKey) {
  deps.addActivityEntry({ type: 'error', message: `... not set up on this device` })
  return 'skipped'
}

// after — key absent is transient, drain holds + retries:
if (!rootKey) {
  throw new KeyNotAvailableError(row.eventId)
}
```

Full uniform model: key-not-available → transient (hold+retry, **new**); decrypt-with-key → permanent (advance+log); plaintext-on-vault → permanent reject (advance+log); handler threw → transient (hold+retry); handler permanent → advance+log; success → advance+clear.

## Tests
- key-absent **throws** `KeyNotAvailableError` (transient); end-to-end through `receiveAllIntents` it does **not** advance the cursor, then decrypts + processes once the key is present;
- key-present **bad row** is permanent (advance + log, no throw);
- persistently key-absent **gives up at the bound** (`onGiveUp` with eventId + advance) so it can't wedge;
- existing receive tests still pass.

Full suite **99/99**; `tsc -b && vite build` clean.

## Scope
Builds on #137 (does not undo it). Send path, deliverers, outbox, and key setup untouched; no changes to `@glance-apps/intents` or `@glance-apps/sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017C8rAer47fR2PPW7S1WcX7)_