### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.9.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.10.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release bump to **v1.10.0**.

Updates the web app version in `package.json` (1.9.0 to 1.10.0) and the version badge in `README.md`. Android `versionName`/`versionCode` (11000) and the iOS marketing version derive from `package.json` automatically, so no other files need changing.

### Release notes (for the GitHub release)

**Reliable cross-app delivery: chores sent to dayGLANCE now survive failures and restarts.**

v1.9.0 introduced sending chores to dayGLANCE over GLANCEvault as a beta. Delivery was fire-and-forget, so a failed request, a missing key, or an app restart mid-send could drop an intent silently. v1.10.0 rebuilds that path on a durable, encrypted outbox and fixes several vault-side issues.

**New**
- Durable intent delivery via a persistent on-device outbox; intents are held and retried until they land, and the "sent today" marker is only written after an intent is safely queued.
- Always-encrypted vault sends: the encryption key is derived and cached on enable, every outgoing intent is encrypted at send time, and non-encrypted vault rows are rejected.

**Improved**
- Send-to-dayGLANCE buttons now appear for GLANCEvault-only setups (any enabled transport counts as configured).
- Clearer WebDAV intents toggle label in Integration settings.

**Fixed**
- Incoming vault intents decrypt with the vault key rather than the WebDAV key.
- Intents arriving before their key is ready are held and retried instead of skipped.

**Under the hood**
- Pinned `@glance-apps/sync` to exactly `1.5.2`.
- Internal versionCode override for pre-release Android uploads.
- Regression tests across the outbox, deliverers, and vault receive path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RueKwRAPGzENurG8Ct9JSR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RueKwRAPGzENurG8Ct9JSR)_