### PR TITLE
fix(intents): self-heal missing vault key + actionable drop message

### DIFF
--- a/src/hooks/useDbIntentsPoller.ts
+++ b/src/hooks/useDbIntentsPoller.ts
@@ -12,8 +12,10 @@ import {
   clearReceiveFailure,
 } from '@/intents/dbConfig'
 import { listIntentsPage, receiveAllIntents, MAX_INTENT_RETRIES } from '@/intents/dbTransport'
+import { getSyncPassphrase } from '@glance-apps/sync'
 import { loadVaultIntentsRootKey } from '@/intents/vaultIntentsKeyStore'
-import { routeIncomingVaultRow } from '@/intents/routeIncoming'
+import { routeIncomingVaultRow, KeyNotAvailableError } from '@/intents/routeIncoming'
+import { ensureVaultIntentsKey, setupVaultIntentsEncryption } from '@/intents/setupVaultIntentsEncryption'
 import { processNotifyEnvelope } from '@/intents/processNotifyEnvelope'
 
 // Drives the GLANCEvault DB intents receive poll on the SAME cadence the WebDAV
@@ -57,8 +59,34 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
       })
     }
 
+    // Best-effort, SILENT self-heal of the vault intents key. The "enabled" flag
+    // lives in localStorage while the derived key lives in IndexedDB, so the two
+    // can desync — IndexedDB eviction (e.g. Safari/ITP after ~7 days), cleared
+    // site data, a PWA reinstall, or first run on a device set up elsewhere all
+    // leave us enabled-but-keyless. When that happens EVERY received intent fails
+    // to decrypt and is eventually dropped. If the sync passphrase is in memory we
+    // re-derive + re-cache the key here so incoming intents decrypt without the
+    // user having to re-save Integration settings. We never PROMPT from the poll
+    // (promptForPassphrase -> null): a missing passphrase simply leaves the key
+    // absent until the next poll (or a manual re-save) finds it. ensureVaultIntentsKey
+    // short-circuits to a single cached-key read once a key is present, so calling
+    // it every poll is cheap and only derives at most once.
+    async function selfHealVaultKey() {
+      try {
+        await ensureVaultIntentsKey({
+          loadCachedKey: loadVaultIntentsRootKey,
+          getPassphrase: getSyncPassphrase,
+          promptForPassphrase: async () => null,
+          derive: setupVaultIntentsEncryption,
+        })
+      } catch {
+        // Self-heal is opportunistic; never let it block the receive drain.
+      }
+    }
+
     async function poll() {
       if (!isDbIntentsEnabled()) return
+      await selfHealVaultKey()
       try {
         await receiveAllIntents({
           getCursor: getReceiveCursor,
@@ -68,10 +96,16 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
           recordFailure: recordReceiveFailure,
           clearFailure: clearReceiveFailure,
           onGiveUp: (row, err, failures) => {
+            // When the failure is a missing key (not a genuinely bad row), the
+            // generic decrypt-error detail is a dead end. Surface the one action
+            // that actually fixes it so the user isn't left guessing.
+            const keyMissing = err instanceof KeyNotAvailableError
             addActivityEntry({
               type: 'error',
               message: `Dropping intent ${row.eventId} after ${failures} failed attempts (limit ${MAX_INTENT_RETRIES})`,
-              detail: err instanceof Error ? err.message : String(err),
+              detail: keyMissing
+                ? 'This device has no GLANCEvault intents encryption key cached. Open Integration settings → GLANCEvault intents (beta) and Save to re-derive it (you may be asked for your sync passphrase).'
+                : err instanceof Error ? err.message : String(err),
             })
           },
         })


### PR DESCRIPTION
## Problem

A user reported intents being dropped with `encrypted intent … received but intents encryption is not set up on this device yet`, despite having encryption configured.

Root cause: the GLANCEvault intents **"enabled" flag lives in localStorage** while the **derived encryption key lives in IndexedDB**, so the two can desync — Safari/ITP eviction (~7 days idle), cleared site data, a PWA reinstall, or first run on a device that was set up elsewhere all leave the app *enabled-but-keyless*. When that happens, every received intent fails to decrypt with `KeyNotAvailableError` and is dropped after `MAX_INTENT_RETRIES`, and the resulting message gives the user no way to recover.

Note this is a different key slot from the WebDAV intents encryption key — setting up WebDAV intents encryption does not populate the vault slot.

## Changes (`src/hooks/useDbIntentsPoller.ts`)

- **Silent, best-effort self-heal in the receive poll.** When vault intents is enabled but no key is cached *and* the sync passphrase is in memory, re-derive + re-cache the key via `ensureVaultIntentsKey`. It never prompts from the poll (a missing passphrase just leaves the key absent until the next poll or a manual re-save). It short-circuits to one cached-key read once a key is present, so it derives at most once and is cheap thereafter.
- **Actionable drop message.** When a drop is specifically caused by a missing key (`KeyNotAvailableError`), the activity-log detail now points the user at Integration settings → GLANCEvault intents (beta) to re-derive, instead of surfacing a dead-end decrypt error. Other decrypt failures keep their original detail.

## Scope / not included

This does **not** change the 5-retry poison bound — intents whose key isn't restored in time are still permanently dropped (a follow-up could exempt key-not-available from that bound so messages are held until the key returns). Already-dropped intents remain lost and need re-sending from the source.

## Testing

- `tsc -b` clean
- Full vitest suite: 99 passed (15 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGjKE1bqebd7WY1v7sKAc2)_