### PR TITLE
feat(intents): surface outbound delivery status (queued → delivered, waiting-for-key)

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -27,7 +27,12 @@
     "clear": "Löschen",
     "noActivity": "Noch keine Aktivität.",
     "collapseDetails": "Details einklappen",
-    "expandDetails": "Details ausklappen"
+    "expandDetails": "Details ausklappen",
+    "delivery": {
+      "queued": "In Warteschlange",
+      "held": "Warten auf Schlüssel",
+      "delivered": "Zugestellt"
+    }
   },
   "backup": {
     "title": "Sicherung & Wiederherstellung",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -27,7 +27,12 @@
     "clear": "Clear",
     "noActivity": "No activity yet.",
     "collapseDetails": "Collapse details",
-    "expandDetails": "Expand details"
+    "expandDetails": "Expand details",
+    "delivery": {
+      "queued": "Queued",
+      "held": "Waiting for key",
+      "delivered": "Delivered"
+    }
   },
   "backup": {
     "title": "Backup & Restore",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -27,7 +27,12 @@
     "clear": "Borrar",
     "noActivity": "Sin actividad por ahora.",
     "collapseDetails": "Contraer detalles",
-    "expandDetails": "Expandir detalles"
+    "expandDetails": "Expandir detalles",
+    "delivery": {
+      "queued": "En cola",
+      "held": "Esperando la clave",
+      "delivered": "Entregado"
+    }
   },
   "backup": {
     "title": "Copia de seguridad y restauración",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -27,7 +27,12 @@
     "clear": "Effacer",
     "noActivity": "Aucune activité pour l'instant.",
     "collapseDetails": "Réduire les détails",
-    "expandDetails": "Afficher les détails"
+    "expandDetails": "Afficher les détails",
+    "delivery": {
+      "queued": "En file d'attente",
+      "held": "En attente de la clé",
+      "delivered": "Remis"
+    }
   },
   "backup": {
     "title": "Sauvegarde & Restauration",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -27,7 +27,12 @@
     "clear": "Cancella",
     "noActivity": "Nessuna attività per ora.",
     "collapseDetails": "Comprimi dettagli",
-    "expandDetails": "Espandi dettagli"
+    "expandDetails": "Espandi dettagli",
+    "delivery": {
+      "queued": "In coda",
+      "held": "In attesa della chiave",
+      "delivered": "Consegnato"
+    }
   },
   "backup": {
     "title": "Backup e ripristino",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -27,7 +27,12 @@
     "clear": "Limpar",
     "noActivity": "Sem atividade por enquanto.",
     "collapseDetails": "Recolher detalhes",
-    "expandDetails": "Expandir detalhes"
+    "expandDetails": "Expandir detalhes",
+    "delivery": {
+      "queued": "Na fila",
+      "held": "A aguardar chave",
+      "delivered": "Entregue"
+    }
   },
   "backup": {
     "title": "Cópia de segurança e restauro",

--- a/src/components/ActivityLogModal/ActivityLogModal.tsx
+++ b/src/components/ActivityLogModal/ActivityLogModal.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X, RefreshCw, ChevronRight, ChevronDown } from 'lucide-react'
-import { type ActivityEntry, getActivityLog, clearActivityLog } from '@/intents/config'
+import { type ActivityEntry, type IntentDelivery, getActivityLog, clearActivityLog, INTENTS_ACTIVITY_EVENT } from '@/intents/config'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from 'react-i18next'
 
@@ -18,12 +18,31 @@ function badgeClass(type: ActivityEntry['type']): string {
   }
 }
 
+// Visual styling for the outbound delivery chip. Deliberately NOT the red error
+// palette — a "waiting for key" hold is a normal, recoverable state, not a
+// failure, so it must never render through the error path.
+function deliveryChipClass(delivery: IntentDelivery): string {
+  switch (delivery) {
+    case 'queued':    return 'bg-slate-100 dark:bg-slate-700/40  text-slate-500 dark:text-slate-400'
+    case 'held':      return 'bg-amber-100 dark:bg-amber-900/30  text-amber-600 dark:text-amber-400'
+    case 'delivered': return 'bg-green-100 dark:bg-green-900/30  text-green-600 dark:text-green-400'
+  }
+}
+
 export function ActivityLogModal({ onClose }: Props) {
   const { t } = useTranslation()
   const [log, setLog] = useState<ActivityEntry[]>(() => getActivityLog())
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
   useEscapeKey(onClose)
+
+  // Live-refresh while open: a background flush that advances a chip
+  // (queued -> waiting for key -> delivered) fires INTENTS_ACTIVITY_EVENT.
+  useEffect(() => {
+    const onChange = () => setLog(getActivityLog())
+    window.addEventListener(INTENTS_ACTIVITY_EVENT, onChange)
+    return () => window.removeEventListener(INTENTS_ACTIVITY_EVENT, onChange)
+  }, [])
 
   function refresh() { setLog(getActivityLog()) }
   function clear() { clearActivityLog(); setLog([]); setExpandedIds(new Set()) }
@@ -94,6 +113,11 @@ export function ActivityLogModal({ onClose }: Props) {
                       </span>
                       <div className="min-w-0 break-words flex-1">
                         <span className="text-slate-600 dark:text-slate-300">{entry.message}</span>
+                        {entry.direction === 'out' && entry.delivery && (
+                          <span className={`ml-2 align-middle inline-block px-1 py-0.5 rounded text-[10px] font-medium ${deliveryChipClass(entry.delivery)}`}>
+                            {t(`activityLog.delivery.${entry.delivery}`)}
+                          </span>
+                        )}
                       </div>
                       {entry.detail && (
                         <button

--- a/src/intents/activityDelivery.test.ts
+++ b/src/intents/activityDelivery.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  type ActivityEntry,
+  applyOutboundDelivery,
+  reconcileDeliveryFromFlush,
+  addActivityEntry,
+  getActivityLog,
+} from './config'
+
+// Minimal in-memory localStorage so the reconcile (which reads/writes the
+// persisted Activity Log) works in the node test environment. window is absent
+// in node, so the change-notification dispatch inside config.ts no-ops safely.
+beforeEach(() => {
+  const store = new Map<string, string>()
+  ;(globalThis as { localStorage?: Storage }).localStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, String(v)) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => { store.clear() },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size },
+  } as Storage
+  ;(globalThis as { crypto?: Crypto }).crypto ??= { randomUUID: () => `id-${Math.random()}` } as Crypto
+})
+
+function outEntry(eventId: string, delivery?: ActivityEntry['delivery']): ActivityEntry {
+  return { id: `a-${eventId}`, timestamp: '2026-06-25T00:00:00.000Z', type: 'sent', message: 'Queued', direction: 'out', eventId, delivery }
+}
+
+describe('applyOutboundDelivery (forward-only)', () => {
+  it('advances queued -> held -> delivered and reports a change each step', () => {
+    const log = [outEntry('e1', 'queued')]
+    expect(applyOutboundDelivery(log, 'e1', 'held')).toBe(true)
+    expect(log[0].delivery).toBe('held')
+    expect(applyOutboundDelivery(log, 'e1', 'delivered')).toBe(true)
+    expect(log[0].delivery).toBe('delivered')
+  })
+
+  it('can jump queued -> delivered directly (key was ready on first flush)', () => {
+    const log = [outEntry('e1', 'queued')]
+    expect(applyOutboundDelivery(log, 'e1', 'delivered')).toBe(true)
+    expect(log[0].delivery).toBe('delivered')
+  })
+
+  it('never downgrades and is a no-op (returns false) when not strictly ahead', () => {
+    const log = [outEntry('e1', 'delivered')]
+    expect(applyOutboundDelivery(log, 'e1', 'held')).toBe(false)
+    expect(applyOutboundDelivery(log, 'e1', 'queued')).toBe(false)
+    expect(applyOutboundDelivery(log, 'e1', 'delivered')).toBe(false) // unchanged
+    expect(log[0].delivery).toBe('delivered')
+  })
+
+  it('treats a missing delivery as queued for the rank comparison', () => {
+    const log = [outEntry('e1', undefined)]
+    expect(applyOutboundDelivery(log, 'e1', 'held')).toBe(true)
+    expect(log[0].delivery).toBe('held')
+  })
+
+  it('matches only OUTBOUND entries with the given eventId', () => {
+    const inbound: ActivityEntry = { id: 'b', timestamp: 't', type: 'received', message: 'in', direction: 'in', eventId: 'e1', delivery: 'queued' }
+    const otherId = outEntry('e2', 'queued')
+    const log = [inbound, otherId]
+    expect(applyOutboundDelivery(log, 'e1', 'delivered')).toBe(false) // inbound ignored
+    expect(applyOutboundDelivery(log, 'e2', 'delivered')).toBe(true)
+    expect(inbound.delivery).toBe('queued') // untouched
+    expect(otherId.delivery).toBe('delivered')
+  })
+})
+
+describe('reconcileDeliveryFromFlush', () => {
+  it('folds delivered + held ids back into the persisted log', () => {
+    addActivityEntry({ type: 'sent', direction: 'out', eventId: 'e1', delivery: 'queued', message: 'Queued "A"' })
+    addActivityEntry({ type: 'sent', direction: 'out', eventId: 'e2', delivery: 'queued', message: 'Queued "B"' })
+
+    reconcileDeliveryFromFlush({ deliveredIds: ['e1'], heldNoKeyIds: ['e2'] })
+
+    const log = getActivityLog()
+    expect(log.find(e => e.eventId === 'e1')?.delivery).toBe('delivered')
+    expect(log.find(e => e.eventId === 'e2')?.delivery).toBe('held')
+  })
+
+  it('lands on delivered when an id is in both lists (delivered outranks held)', () => {
+    addActivityEntry({ type: 'sent', direction: 'out', eventId: 'e1', delivery: 'queued', message: 'Queued "A"' })
+
+    reconcileDeliveryFromFlush({ deliveredIds: ['e1'], heldNoKeyIds: ['e1'] })
+
+    expect(getActivityLog().find(e => e.eventId === 'e1')?.delivery).toBe('delivered')
+  })
+
+  it('does not downgrade an already-delivered entry on a later held report', () => {
+    addActivityEntry({ type: 'sent', direction: 'out', eventId: 'e1', delivery: 'queued', message: 'Queued "A"' })
+    reconcileDeliveryFromFlush({ deliveredIds: ['e1'], heldNoKeyIds: [] })
+    // A subsequent pass that (spuriously) reports it held must not move it back.
+    reconcileDeliveryFromFlush({ deliveredIds: [], heldNoKeyIds: ['e1'] })
+    expect(getActivityLog().find(e => e.eventId === 'e1')?.delivery).toBe('delivered')
+  })
+
+  it('is a safe no-op when nothing matches or nothing changes', () => {
+    addActivityEntry({ type: 'sent', direction: 'out', eventId: 'e1', delivery: 'delivered', message: 'Queued "A"' })
+    const before = JSON.stringify(getActivityLog())
+    reconcileDeliveryFromFlush({ deliveredIds: ['nope'], heldNoKeyIds: ['e1'] }) // e1 already delivered, 'nope' absent
+    expect(JSON.stringify(getActivityLog())).toBe(before)
+  })
+})

--- a/src/intents/config.ts
+++ b/src/intents/config.ts
@@ -8,12 +8,30 @@ export interface IntentsConfig {
   encryptionEnabled: boolean
 }
 
+// Delivery lifecycle of an OUTBOUND intent, surfaced as a chip on its Activity
+// Log entry. Forward-only: queued -> held -> delivered, never backwards.
+//   queued    — enqueued durably; a transmit has not yet succeeded.
+//   held      — a transmit attempt is holding (today: the vault intents key is
+//               not cached on this device yet), so nothing has gone out.
+//   delivered — the row reached the GLANCEvault relay (the POST returned 2xx).
+//               This is NOT a peer-receipt: GLANCEvault is a zero-knowledge,
+//               insert-only relay with no end-to-end acknowledgement, so "the
+//               peer app ingested it" is explicitly NOT claimed here.
+export type IntentDelivery = 'queued' | 'held' | 'delivered'
+
 export interface ActivityEntry {
   id: string
   timestamp: string
   type: 'sent' | 'received' | 'warning' | 'error'
   message: string
   detail?: string
+  // OUTBOUND-only observability fields. `direction: 'out'` marks an entry the
+  // delivery reconcile may update; `eventId` is the intent's stable id (the
+  // outbox key) used to match a flush outcome back to its entry; `delivery` is
+  // the lifecycle state above.
+  direction?: 'out' | 'in'
+  eventId?: string
+  delivery?: IntentDelivery
 }
 
 export const DEFAULT_CONFIG: IntentsConfig = {
@@ -30,6 +48,19 @@ const CONFIG_KEY = 'lg_intents_config'
 const ACTIVITY_KEY = 'lg_intents_activity'
 const CURSOR_KEY = 'lg_intents_cursor'
 const MAX_ACTIVITY = 50
+
+// Fired whenever the Activity Log changes (a new entry, or a delivery-state
+// reconcile) so an open Activity Log view can refresh live. Guarded for the node
+// test environment, where window is absent.
+export const INTENTS_ACTIVITY_EVENT = 'lg:intents-activity'
+function notifyActivityChanged(): void {
+  if (typeof window !== 'undefined') window.dispatchEvent(new CustomEvent(INTENTS_ACTIVITY_EVENT))
+}
+
+// Forward-only delivery rank: a transition only "sticks" if it is strictly ahead
+// of the current state, so a late or out-of-order flush can never downgrade a
+// chip (e.g. delivered -> held) or rewrite an unchanged one.
+const DELIVERY_RANK: Record<IntentDelivery, number> = { queued: 0, held: 1, delivered: 2 }
 
 export function getIntentsConfig(): IntentsConfig {
   try {
@@ -68,10 +99,45 @@ export function addActivityEntry(entry: Omit<ActivityEntry, 'id' | 'timestamp'>)
   }
   const updated = [newEntry, ...log].slice(0, MAX_ACTIVITY)
   localStorage.setItem(ACTIVITY_KEY, JSON.stringify(updated))
+  notifyActivityChanged()
 }
 
 export function clearActivityLog(): void {
   localStorage.removeItem(ACTIVITY_KEY)
+  notifyActivityChanged()
+}
+
+// Forward-only delivery-state transition over an in-memory log. Updates the
+// OUTBOUND ('out') entry matching `eventId` to `next` ONLY when `next` is ahead
+// of its current state; returns true iff it changed something. Pure over the
+// passed array (no I/O), so it is unit-testable and reused by the reconcile
+// wrapper below. A no-op when unchanged keeps repeated flushes from rewriting or
+// spamming the log.
+export function applyOutboundDelivery(log: ActivityEntry[], eventId: string, next: IntentDelivery): boolean {
+  let changed = false
+  for (const entry of log) {
+    if (entry.direction !== 'out' || entry.eventId !== eventId) continue
+    const current = entry.delivery ?? 'queued'
+    if (DELIVERY_RANK[next] > DELIVERY_RANK[current]) {
+      entry.delivery = next
+      changed = true
+    }
+  }
+  return changed
+}
+
+// Folds one flush pass's outcome back into the persisted Activity Log. Held ids
+// are applied before delivered ids so that, when an id is in both lists, the
+// forward-only rule lands it on `delivered` (the higher rank). Writes (and
+// notifies) at most once, and only if something actually changed.
+export function reconcileDeliveryFromFlush(result: { deliveredIds: string[]; heldNoKeyIds: string[] }): void {
+  const log = getActivityLog()
+  let changed = false
+  for (const id of result.heldNoKeyIds) changed = applyOutboundDelivery(log, id, 'held') || changed
+  for (const id of result.deliveredIds) changed = applyOutboundDelivery(log, id, 'delivered') || changed
+  if (!changed) return
+  localStorage.setItem(ACTIVITY_KEY, JSON.stringify(log))
+  notifyActivityChanged()
 }
 
 export function getPollingCursor(): string | null {

--- a/src/intents/deliverers.test.ts
+++ b/src/intents/deliverers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import { webcrypto } from 'node:crypto'
 import { deriveIntentsRootKey } from '@glance-apps/intents'
 import { createVaultDeliverer, createWebdavDeliverer } from './deliverers'
+import { INTENTS_KEY_NOT_READY } from './outbox'
 import type { OutboxIntent } from './outbox'
 import type { IntentsConfig } from './config'
 
@@ -76,8 +77,9 @@ describe('vault deliverer (always encrypted)', () => {
     expect(env.payload).toBeUndefined() // the title etc. is NOT in cleartext
   })
 
-  // (b) no cached key -> 'transient-fail', nothing built or sent.
-  it('returns transient and sends nothing when no key is cached', async () => {
+  // (b) no cached key -> tagged transient hold, nothing built or sent. The reason
+  // tag is what lets flush/the Activity Log show "waiting for key".
+  it('returns a key-not-ready transient and sends nothing when no key is cached', async () => {
     const send = captureSend({ ok: true, status: 200 })
     const deliver = createVaultDeliverer({
       loadRootKey: async () => null,
@@ -86,7 +88,7 @@ describe('vault deliverer (always encrypted)', () => {
     })
 
     const result = await deliver(makeIntent())
-    expect(result).toBe('transient-fail')
+    expect(result).toEqual({ status: 'transient-fail', reason: INTENTS_KEY_NOT_READY })
     expect(send.sent).toHaveLength(0) // built nothing, sent nothing
   })
 

--- a/src/intents/deliverers.ts
+++ b/src/intents/deliverers.ts
@@ -22,6 +22,7 @@ import {
   deriveEnvelopeKey,
 } from '@glance-apps/intents'
 import type { CreatePayload, IntentEnvelope, OutboundIntentRow } from '@glance-apps/intents'
+import { INTENTS_KEY_NOT_READY } from './outbox'
 import type { Deliverer, DeliveryResult, OutboxIntent } from './outbox'
 import { getConn, vaultFetch, type VaultConn } from './dbTransport'
 import { getDbIntentsConfig } from './dbConfig'
@@ -96,7 +97,9 @@ export function createVaultDeliverer(deps: VaultDelivererDeps): Deliverer {
     const rootKey = await deps.loadRootKey()
     if (!rootKey) {
       // Key not set up yet (2b populates it): hold the intent, build/send NOTHING.
-      return 'transient-fail'
+      // Tag the hold so flush/the Activity Log can show "waiting for key" instead
+      // of an indistinguishable silent stall — the row is still held + retried.
+      return { status: 'transient-fail', reason: INTENTS_KEY_NOT_READY }
     }
 
     const envelope: IntentEnvelope = await buildEncryptedEnvelope(

--- a/src/intents/emitter.test.ts
+++ b/src/intents/emitter.test.ts
@@ -50,7 +50,7 @@ async function emitAndAwaitFlush(
   ob: ReturnType<typeof createOutbox>,
   deliverers: Record<string, Deliverer>,
 ): Promise<void> {
-  let flushPromise: Promise<void> = Promise.resolve()
+  let flushPromise: Promise<unknown> = Promise.resolve()
   await emitCreateIntent(chore, {
     targets: () => Object.keys(deliverers) as TransportName[],
     enqueue: (i, t) => ob.enqueue(i, t),

--- a/src/intents/emitter.ts
+++ b/src/intents/emitter.ts
@@ -47,7 +47,10 @@ export function enabledIntentTargets(): TransportName[] {
 export interface EmitDeps {
   targets: () => TransportName[]
   enqueue: (intent: OutboxIntent, targets: TransportName[]) => Promise<void>
-  flush: () => Promise<void>
+  // The emit path fires-and-forgets the flush and ignores its outcome (the
+  // Activity-Log reconcile happens inside flushIntents), so the result type is
+  // intentionally unconstrained here.
+  flush: () => Promise<unknown>
 }
 
 const defaultEmitDeps: EmitDeps = {
@@ -78,7 +81,16 @@ export async function emitCreateIntent(
   const intent = buildCreateIntent(chore)
   // Durable before returning: a resolved enqueue means "queued, will be delivered".
   await deps.enqueue(intent, targets)
-  addActivityEntry({ type: 'sent', message: `Queued "${chore.name}" for dayGLANCE` })
+  // Carry the event_id + direction + delivery state so a later flush can match
+  // this entry and advance its chip queued -> waiting for key -> delivered. The
+  // type stays 'sent' (the existing blue badge); delivery is a separate axis.
+  addActivityEntry({
+    type: 'sent',
+    direction: 'out',
+    eventId: intent.event_id,
+    delivery: 'queued',
+    message: `Queued "${chore.name}" for dayGLANCE`,
+  })
 
   // Trigger delivery now; the outbox's in-flight lock guards overlapping flushes.
   deps.flush().catch(() => { /* failures surface via the deliverers/outbox */ })

--- a/src/intents/flushIntents.ts
+++ b/src/intents/flushIntents.ts
@@ -1,12 +1,18 @@
-import { outbox } from './outbox'
+import { outbox, type FlushResult } from './outbox'
 import { webdavDeliverer, vaultDeliverer } from './deliverers'
+import { reconcileDeliveryFromFlush } from './config'
 
 // Single outbound flush entry point: drains the durable outbox using the real
 // per-transport deliverers (webdav + vault; no iCloud). The outbox's in-flight
 // lock makes overlapping calls safe, so every trigger can call this freely.
 //
 // This is the ONLY place the deliverers are wired to the outbox, keeping the
-// "emit -> enqueue -> flush(deliverers)" path in one spot.
-export function flushIntents(): Promise<void> {
-  return outbox.flush({ webdav: webdavDeliverer, vault: vaultDeliverer })
+// "emit -> enqueue -> flush(deliverers)" path in one spot. It is therefore also
+// the one place that folds each pass's outcome back into the Activity Log, so
+// BOTH the emit-time flush and the background drain (both call this) update the
+// "queued -> waiting for key -> delivered" chips without any extra wiring.
+export async function flushIntents(): Promise<FlushResult> {
+  const result = await outbox.flush({ webdav: webdavDeliverer, vault: vaultDeliverer })
+  reconcileDeliveryFromFlush(result)
+  return result
 }

--- a/src/intents/outbox.test.ts
+++ b/src/intents/outbox.test.ts
@@ -4,6 +4,7 @@ import {
   createOutbox,
   createIndexedDbOutboxStore,
   MAX_OUTBOX_ATTEMPTS,
+  INTENTS_KEY_NOT_READY,
   type OutboxIntent,
   type Deliverer,
   type DeliveryResult,
@@ -247,5 +248,70 @@ describe('intents outbox', () => {
     await first
     expect(vault.calls).toBe(1)
     expect(await ob.pendingCount()).toBe(0)
+  })
+})
+
+describe('flush result reporting (for Activity-Log reconcile)', () => {
+  it('reports deliveredIds for targets that reached delivered this pass, and nothing held', async () => {
+    const ob = freshOutbox()
+    const vault = scriptedDeliverer('delivered')
+    await ob.enqueue(makeIntent('evt-d1'), ['vault'])
+
+    const result = await ob.flush({ vault })
+    expect(result.deliveredIds).toEqual(['evt-d1'])
+    expect(result.heldNoKeyIds).toEqual([])
+  })
+
+  it('reports an id once even when multiple targets deliver in the same pass', async () => {
+    const ob = freshOutbox()
+    const webdav = scriptedDeliverer('delivered')
+    const vault = scriptedDeliverer('delivered')
+    await ob.enqueue(makeIntent('evt-d2'), ['webdav', 'vault'])
+
+    const result = await ob.flush({ webdav, vault })
+    expect(result.deliveredIds).toEqual(['evt-d2']) // de-duplicated, not twice
+    expect(result.heldNoKeyIds).toEqual([])
+  })
+
+  it('reports heldNoKeyIds ONLY for the tagged key-not-ready transient, not a bare one', async () => {
+    const ob = freshOutbox()
+    const keyless = scriptedDeliverer({ status: 'transient-fail', reason: INTENTS_KEY_NOT_READY })
+    const bareTransient = scriptedDeliverer('transient-fail')
+    await ob.enqueue(makeIntent('evt-held'), ['vault'])
+    await ob.enqueue(makeIntent('evt-bare'), ['webdav'])
+
+    const result = await ob.flush({ vault: keyless, webdav: bareTransient })
+    expect(result.heldNoKeyIds).toEqual(['evt-held'])
+    expect(result.deliveredIds).toEqual([])
+    // Both are still held + retried regardless of the tag.
+    expect(await ob.pendingCount()).toBe(2)
+  })
+
+  it('an id can appear in BOTH lists when one target delivers and another holds for its key', async () => {
+    const ob = freshOutbox()
+    const webdav = scriptedDeliverer('delivered')
+    const vault = scriptedDeliverer({ status: 'transient-fail', reason: INTENTS_KEY_NOT_READY })
+    await ob.enqueue(makeIntent('evt-mix'), ['webdav', 'vault'])
+
+    const result = await ob.flush({ webdav, vault })
+    expect(result.deliveredIds).toEqual(['evt-mix'])
+    expect(result.heldNoKeyIds).toEqual(['evt-mix'])
+  })
+
+  it('returns empty lists when a concurrent flush short-circuits', async () => {
+    const ob = freshOutbox()
+    const vault = deferredDeliverer()
+    await ob.enqueue(makeIntent('evt-cc'), ['vault'])
+
+    const first = ob.flush({ vault })
+    await vault.called
+    // This call observes the in-flight flush and bails with empty lists.
+    const concurrent = await ob.flush({ vault })
+    expect(concurrent.deliveredIds).toEqual([])
+    expect(concurrent.heldNoKeyIds).toEqual([])
+
+    vault.resolve('delivered')
+    const firstResult = await first
+    expect(firstResult.deliveredIds).toEqual(['evt-cc'])
   })
 })

--- a/src/intents/outbox.ts
+++ b/src/intents/outbox.ts
@@ -69,9 +69,42 @@ export interface OutboxEntry {
 //                     yet" (e.g. sync not unlocked): the outbox just keeps the
 //                     target pending and retries once the deliverer can proceed.
 //   permanent-fail  — will never succeed; give up on this target now.
-export type DeliveryResult = 'delivered' | 'transient-fail' | 'permanent-fail'
+export type DeliveryStatus = 'delivered' | 'transient-fail' | 'permanent-fail'
+
+// A deliverer may return a bare status OR a tagged outcome carrying a `reason`.
+// The reason is purely for OBSERVABILITY — it does not change the give-up math
+// (a tagged transient counts toward the bound exactly like a bare one). Today the
+// only reason is INTENTS_KEY_NOT_READY, which lets flush() surface a "waiting for
+// key" hold instead of a silent stall. Bare strings remain valid so deliverers
+// that have nothing to add keep returning them.
+export interface DeliveryOutcome {
+  status: DeliveryStatus
+  reason?: string
+}
+export type DeliveryResult = DeliveryStatus | DeliveryOutcome
 export type Deliverer = (intent: OutboxIntent) => Promise<DeliveryResult>
 export type Deliverers = { [transport: string]: Deliverer | undefined }
+
+// Shared reason tag for "held because the GLANCEvault intents key isn't cached on
+// this device yet". Referenced by BOTH the vault deliverer (which emits it) and
+// flush (which reports it), so the magic string lives in exactly one place.
+export const INTENTS_KEY_NOT_READY = 'intents_key_not_ready'
+
+// Normalizes a deliverer's return to the object shape so flush can read .status
+// and .reason uniformly regardless of which form the deliverer used.
+function asOutcome(result: DeliveryResult): DeliveryOutcome {
+  return typeof result === 'string' ? { status: result } : result
+}
+
+// What a single flush pass reports back for Activity-Log reconciliation. Both are
+// event_id lists (de-duplicated): the entries that had a target reach DELIVERED
+// this pass, and the entries whose vault target HELD because the intents key was
+// absent. An id can legitimately appear in both (e.g. webdav delivered while
+// vault waits for its key) — the forward-only reconcile resolves the precedence.
+export interface FlushResult {
+  deliveredIds: string[]
+  heldNoKeyIds: string[]
+}
 
 // Generous bound, much higher than the receive drain's MAX_INTENT_RETRIES (5):
 // losing OUTBOUND data is worse than retrying, so we lean hard toward retry.
@@ -161,7 +194,9 @@ export interface Outbox {
   // Attempt every still-pending target of every entry once, applying the result
   // model below. Overlapping flushes are guarded — a flush already in flight
   // makes a concurrent call a no-op, so a target is never delivered twice.
-  flush(deliverers: Deliverers): Promise<void>
+  // Returns the per-pass outcome ids for Activity-Log reconciliation (empty
+  // lists when a concurrent flush short-circuits this call).
+  flush(deliverers: Deliverers): Promise<FlushResult>
   // Number of entries still holding undelivered work (diagnostics/tests).
   pendingCount(): Promise<number>
   list(): Promise<OutboxEntry[]>
@@ -211,8 +246,13 @@ export function createOutbox(store: OutboxStore): Outbox {
     await store.put(entry)
   }
 
-  async function flush(deliverers: Deliverers): Promise<void> {
-    if (flushing) return
+  async function flush(deliverers: Deliverers): Promise<FlushResult> {
+    // De-duplicated per-pass id sets for Activity-Log reconciliation.
+    const deliveredIds = new Set<string>()
+    const heldNoKeyIds = new Set<string>()
+    const result: FlushResult = { deliveredIds: [], heldNoKeyIds: [] }
+
+    if (flushing) return result
     flushing = true
     try {
       const entries = await store.getAll()
@@ -228,27 +268,31 @@ export function createOutbox(store: OutboxStore): Outbox {
           // enabled): leave the target pending, untouched, for a later flush.
           if (!deliver) continue
 
-          let result: DeliveryResult
+          let outcome: DeliveryOutcome
           try {
-            result = await deliver(entry.intent)
+            outcome = asOutcome(await deliver(entry.intent))
           } catch {
             // A deliverer that throws instead of classifying is treated as a
             // transient failure: the outbox must never lose an intent because a
             // deliverer misbehaved.
-            result = 'transient-fail'
+            outcome = { status: 'transient-fail' }
           }
 
-          if (result === 'delivered') {
+          if (outcome.status === 'delivered') {
             entry.targets[target] = 'delivered'
             changed = true
-          } else if (result === 'permanent-fail') {
+            deliveredIds.add(entry.id)
+          } else if (outcome.status === 'permanent-fail') {
             // Decisive failure: give up on this target now, bypassing the bound.
             entry.targets[target] = 'given-up'
             changed = true
             logGiveUp(entry, target, 'permanent failure reported by deliverer')
           } else {
             // transient-fail: count it toward the bound and retry next flush,
-            // unless we have now hit the bound.
+            // unless we have now hit the bound. Surface the key-not-ready hold so
+            // the Activity Log can show "waiting for key" rather than stalling
+            // silently — this does NOT change the give-up math.
+            if (outcome.reason === INTENTS_KEY_NOT_READY) heldNoKeyIds.add(entry.id)
             const n = (entry.attempts[target] ?? 0) + 1
             entry.attempts[target] = n
             changed = true
@@ -272,6 +316,10 @@ export function createOutbox(store: OutboxStore): Outbox {
     } finally {
       flushing = false
     }
+
+    result.deliveredIds = [...deliveredIds]
+    result.heldNoKeyIds = [...heldNoKeyIds]
+    return result
   }
 
   async function pendingCount(): Promise<number> {


### PR DESCRIPTION
## Problem

The outbound intent Activity Log wrote `Queued "<task>" for dayGLANCE` (SENT badge) **once at enqueue time and never updated it**. If the vault POST later silently held — e.g. the GLANCEvault *intents* encryption key isn't cached on this device yet, so the vault deliverer sends nothing and returns a transient result — the log still read "sent." A stuck-in-outbox intent was indistinguishable from a delivered one, and undiagnosable.

This mirrors dayGLANCE's PR #1051 on the **sender** side.

## (a) queued → delivered

`outbox.flush()` now returns a `FlushResult` carrying the `event_id`s that had a target reach **delivered** this pass (de-duplicated), keeping the existing per-target/give-up behavior intact. `flushIntents` — the single place deliverers are wired to the outbox, hit by **both** the emit-time flush and the background drain — folds that outcome back into the matching Activity Log entry, so the chip advances without any extra wiring at the call sites.

**Semantic caveat (important):** *delivered* means the row **reached the GLANCEvault relay** (the POST returned 2xx). It does **NOT** mean the peer app ingested it — GLANCEvault is a zero-knowledge, insert-only relay with no end-to-end receipt. No label claims peer-receipt; that would reintroduce the same misleading-"sent" trap one level up. This is documented on the `IntentDelivery` type.

## (b) waiting-for-key

When the vault deliverer holds because the intents key is absent, it now returns `{ status: 'transient-fail', reason: INTENTS_KEY_NOT_READY }` instead of a bare transient. `flush` collects those ids (`heldNoKeyIds`) and the Activity Log shows a **"waiting for key"** state instead of a silent stall. The reason tag is purely observational — it does **not** change the give-up math (a tagged transient still counts toward the bound and is still held + retried). `INTENTS_KEY_NOT_READY` is a shared constant referenced by both the deliverer and flush (no duplicated magic string).

## Supporting changes

- `ActivityEntry` gains `direction` / `eventId` / `delivery`; the enqueue entry sets `direction:'out'`, `eventId`, `delivery:'queued'`. The `type` stays `'sent'` (existing blue badge) — delivery is a separate axis.
- `applyOutboundDelivery` — forward-only updater (`queued → held → delivered`, never downgrades, no-op when unchanged so repeated flushes don't rewrite or spam the log), matching **only** OUTBOUND (`'out'`) entries. `reconcileDeliveryFromFlush` folds a flush result into the persisted log (held applied before delivered, so an id in both lands on `delivered`) and fires a change event.
- UI: a small delivery chip (`queued` / `waiting for key` / `delivered`) rendered off the delivery state and **kept out of the red error path** — a held intent is a normal recoverable state, not a failure. The Activity Log live-refreshes on the change event. i18n labels added for all six locales.

## Testing

- Deliverer no-key assertion updated to the tagged object.
- New coverage: flush reporting (delivered/held ids, de-dup, both-lists, concurrent short-circuit), forward-only transitions, and reconcile.
- Full suite: **113 passed** (16 files). `tsc -b` clean. Production `vite build` succeeds.

## Note on branching

This is an independent feature; it is intentionally **not** stacked on the self-heal PR (#140). It branches from `main` for an isolated diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGjKE1bqebd7WY1v7sKAc2)_