### PR TITLE
ci: enforce lint/test/build and clear the ESLint warning backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "test": "vitest run",
     "cap:sync": "npm run build && cap sync",
     "build:android": "npm run build && cap sync android",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -281,6 +281,9 @@ function AppInner() {
     runDbSync()
 
     return () => { registerDbEngine(null) }
+    // Mount-once engine init; runSharedUserSync is a stable callback invoked
+    // imperatively elsewhere and intentionally not a dependency here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runDbSync])
 
   // Shared user roster sync — fire-and-forget, non-fatal

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -23,6 +23,8 @@ interface ToastContextValue {
 
 const ToastContext = createContext<ToastContextValue | null>(null)
 
+// Provider + hook live together by design; the fast-refresh hint doesn't apply.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useToast() {
   const ctx = useContext(ToastContext)
   if (!ctx) throw new Error('useToast must be used inside ToastProvider')

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -157,7 +157,7 @@ class LastGlanceDB extends Dexie {
         const toDelete: number[] = []
         for (const group of bySyncId.values()) {
           if (group.length <= 1) continue
-          group.sort((a: any, b: any) => (b.updated_at ?? '').localeCompare(a.updated_at ?? ''))
+          group.sort((a: { updated_at?: string }, b: { updated_at?: string }) => (b.updated_at ?? '').localeCompare(a.updated_at ?? ''))
           for (const u of group.slice(1)) toDelete.push(u.id as number)
         }
         if (toDelete.length) await tx.table('users').bulkDelete(toDelete)

--- a/src/intents/IntentsContext.tsx
+++ b/src/intents/IntentsContext.tsx
@@ -30,6 +30,8 @@ export function IntentsProvider({ children }: { children: React.ReactNode }) {
   )
 }
 
+// Provider + hook live together by design; the fast-refresh hint doesn't apply.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useIntents(): IntentsContextValue {
   const ctx = useContext(IntentsContext)
   if (!ctx) throw new Error('useIntents must be used inside IntentsProvider')

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -9,6 +9,7 @@ import {
 } from '@glance-apps/sync'
 import type { SyncEngine, SyncStatus, SyncErrorCode, BackupFrequency } from '@glance-apps/sync'
 import { db } from '@/db/client'
+import type { Category, Chore, CompletionEvent, User } from '@/types'
 import { buildAuthHeader, ensureFolder } from '@/intents/webdav'
 import { isNativePlatform, nativeHttpFetch } from './nativeHttp'
 import type { SyncPayload, SyncSettings } from './types'
@@ -232,7 +233,9 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
     const userBySyncId   = new Map(existingUsers.map(u => [u.sync_id,  u]))
 
     // ── CATEGORIES pass 1: upsert by sync_id ──
-    const catsToAdd: any[] = []
+    // `id` is Dexie's auto-increment key, assigned on insert, so the accumulators
+    // hold the entity minus `id`; the bulkAdd casts back (Dexie fills it in).
+    const catsToAdd: Omit<Category, 'id'>[] = []
     const catsToUpdate: Array<[number, object]> = []
     for (const cat of (data.categories ?? [])) {
       if (tombstoneIds.has(cat.id)) continue
@@ -253,7 +256,7 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
       }
     }
     await Promise.all(catsToUpdate.map(([id, fields]) => db.categories.update(id, fields)))
-    await db.categories.bulkAdd(catsToAdd)
+    await db.categories.bulkAdd(catsToAdd as Category[])
 
     // ── CATEGORIES pass 2: resolve parent_sync_id → parent_category_id ──
     // Re-fetch after inserts so new categories are in the map
@@ -283,7 +286,7 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
     // Re-fetch categories (tombstones may have been deleted) for category_id resolution
     const allCatsForChores = await db.categories.toArray()
     const catMapForChores = new Map(allCatsForChores.map(c => [c.sync_id, c]))
-    const choresToAdd: any[] = []
+    const choresToAdd: Omit<Chore, 'id'>[] = []
     const choresToUpdate: Array<[number, object]> = []
     for (const chore of (data.chores ?? [])) {
       if (tombstoneIds.has(chore.id)) continue
@@ -324,7 +327,7 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
       }
     }
     await Promise.all(choresToUpdate.map(([id, fields]) => db.chores.update(id, fields)))
-    await db.chores.bulkAdd(choresToAdd)
+    await db.chores.bulkAdd(choresToAdd as Chore[])
 
     // ── Delete tombstoned chores ──
     const choreTombstoneIds = [...tombstoneIds]
@@ -336,7 +339,7 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
     // Re-fetch chores after upsert for chore_id resolution
     const allChoresForEvents = await db.chores.toArray()
     const choreMapForEvents = new Map(allChoresForEvents.map(c => [c.sync_id, c]))
-    const eventsToAdd: any[] = []
+    const eventsToAdd: Omit<CompletionEvent, 'id'>[] = []
     for (const evt of (data.completionEvents ?? [])) {
       if (tombstoneIds.has(evt.id)) continue
       if (eventBySyncId.has(evt.id)) continue  // immutable; already present
@@ -348,7 +351,7 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
         completed_by_user_sync_id: evt.completedByUserSyncId ?? null,
       })
     }
-    await db.completionEvents.bulkAdd(eventsToAdd)
+    await db.completionEvents.bulkAdd(eventsToAdd as CompletionEvent[])
 
     // ── Delete tombstoned completion events ──
     const evtTombstoneIds = [...tombstoneIds]
@@ -357,7 +360,7 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
     await db.completionEvents.bulkDelete(evtTombstoneIds)
 
     // ── USERS: upsert by sync_id ──
-    const usersToAdd: any[] = []
+    const usersToAdd: Omit<User, 'id'>[] = []
     const usersToUpdate: Array<[number, object]> = []
     for (const user of (data.users ?? [])) {
       if (tombstoneIds.has(user.id)) continue
@@ -369,7 +372,7 @@ export const applyPayload = async (rawData: unknown, { allowEmpty }: { allowEmpt
       }
     }
     await Promise.all(usersToUpdate.map(([id, fields]) => db.users.update(id, fields)))
-    await db.users.bulkAdd(usersToAdd)
+    await db.users.bulkAdd(usersToAdd as User[])
 
     // ── Delete tombstoned users ──
     const userTombstoneIds = [...tombstoneIds]


### PR DESCRIPTION
Follow-up to the ESLint adoption (#143, now merged): get to a genuinely clean lint and make CI enforce it going forward. Branched off the updated `main`.

## (2) Clear the warning backlog → 0 warnings

- **The six `any`s are typed away.** The four Dexie accumulator arrays in `engine.ts` (`catsToAdd` / `choresToAdd` / `eventsToAdd` / `usersToAdd`) now use `Omit<Entity, 'id'>[]` — so the pushed objects get **full field-checking against the real schema**, minus the auto-increment `id` Dexie assigns — and cast back to the entity type only at the single `bulkAdd`. The v9 migration's user-dedup sort comparator gets a precise `{ updated_at?: string }` param type instead of `any`. (Net bonus: this is stronger typing than before, not just a silenced lint.)
- **The three remaining warnings get documented, targeted disables**, each legitimate:
  - two `react-refresh/only-export-components` — `Toast.tsx` and `IntentsContext.tsx` intentionally co-locate a provider and its hook (a dev-only fast-refresh hint, not a correctness issue);
  - one `react-hooks/exhaustive-deps` — the App mount-init effect intentionally omits a stable callback invoked imperatively elsewhere.
- **`npm run lint` is now `eslint . --max-warnings 0`**, so any *new* warning — not just errors — fails the lint and keeps the bar at zero.

## (1) CI gating

- Adds `.github/workflows/ci.yml` running **lint → test → build** on every PR and on pushes to `main`. Previously the only workflows were GHCR publish and a site-rebuild trigger, so nothing enforced lint/tests/build.

## Verification

`npm run lint` (strict, `--max-warnings 0`) exits 0 · `tsc -b` clean · **112 tests pass** · production `vite build` succeeds.

## Note

`--max-warnings 0` is deliberately strict: a stray `any` or a new `exhaustive-deps` warning will now fail CI until it's typed or has a documented disable. If you'd rather warnings stay non-blocking (errors fail, warnings allowed), drop the `--max-warnings 0` from the `lint` script and the rest still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGjKE1bqebd7WY1v7sKAc2)_