### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.10.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.11.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps the version from 1.10.0 to 1.11.0.

Since 1.10.0, the merged work added new backward-compatible features (outbound intent delivery-status observability, localized cloud-sync error messages) plus fixes and tooling, so semver points to a minor bump.

Changes:
- `package.json` version: 1.10.0 to 1.11.0
- `package-lock.json` regenerated to match (version-only change, no dependency churn)
- README version badge: 1.10.0 to 1.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGjKE1bqebd7WY1v7sKAc2)_