### PR TITLE
Android Phase 1: exact-alarm overdue notifications

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-status-bar')
 
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,4 +43,7 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Exact alarms for Doze-proof overdue reminders (Android 12+). The plugin
+         already declares POST_NOTIFICATIONS and RECEIVE_BOOT_COMPLETED. -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 </manifest>

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,5 +2,8 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-local-notifications'
+project(':capacitor-local-notifications').projectDir = new File('../node_modules/@capacitor/local-notifications/android')
+
 include ':capacitor-status-bar'
 project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -7,16 +7,19 @@ This plan was informed by a teardown of how the sibling app **dayGLANCE**
 solved timely closed-app notifications (its process is referenced throughout).
 Where lastGLANCE differs from dayGLANCE, it is called out explicitly.
 
-> **▶ RESUME HERE (last updated end of session 2026-06-20)**
-> - **Phase 0 built** (snapshot bridge + heatmap widget) → **PR #126**, branch
->   `claude/wonderful-mccarthy-abm730`. Web build + 58 tests green.
-> - **Next action is yours:** smoke-test the widget on a device
->   (`npm run cap:android`) — Android side is **not yet compiled**.
-> - **Open decision before Phase 1:** RemoteViews (as built) vs Glance for widgets
->   (see Phase 0). Then proceed to **Phase 1** (exact-alarm notifications, Path A).
-> - **Settled:** Path A chosen (B backup); visual target = "clearly same family";
->   no battery-opt prompt; defer the WorkManager re-arm backstop until testing
->   proves OEM killers clear our alarms.
+> **▶ RESUME HERE (last updated 2026-06-26)**
+> - **Phase 0 + Phase 1 built** on branch `claude/wonderful-mccarthy-abm730`
+>   (PR #126). Web build + 58 tests green; **Android not yet compiled/device-tested.**
+> - **Phase 1** = exact-alarm overdue notifications via `@capacitor/local-notifications`
+>   (Path A). Plugin handles reboot re-registration; we added `SCHEDULE_EXACT_ALARM`
+>   + a lazy one-time exact-alarm prompt.
+> - **Next action is yours:** on-device smoke test of both (widget refresh; kill the
+>   app, advance a chore past cadence, confirm the notification fires — test Doze via
+>   `adb shell dumpsys deviceidle force-idle`).
+> - **Still open:** RemoteViews (as built) vs Glance for widgets (Phase 0). Next code
+>   phase is **Phase 2** (action widgets + optimistic tap-to-complete).
+> - **Settled:** Path A (B backup); "clearly same family"; no battery-opt prompt;
+>   defer the WorkManager re-arm backstop until testing proves OEM killers clear alarms.
 
 ---
 
@@ -202,7 +205,20 @@ queue** in `SharedPreferences`; JS drains via `getPendingActions()` on
 **Exit criteria:** heatmap on the home screen reflects completions within one app
 foreground cycle; survives reboot (re-renders from persisted snapshot).
 
-### Phase 1 — Exact-alarm overdue notifications (Path A)
+### Phase 1 — Exact-alarm overdue notifications (Path A) — ✅ BUILT (PR #126)
+
+As-built notes: the plugin (`@capacitor/local-notifications@8.2.0`) already ships
+`POST_NOTIFICATIONS`, `RECEIVE_BOOT_COMPLETED`, and a boot-restore receiver, so
+**reboot re-registration is free** — we only added `SCHEDULE_EXACT_ALARM`.
+`allowWhileIdle: true` maps to `setExactAndAllowWhileIdle` when the exact-alarm
+permission is granted, so Path A meets the Doze bar and **Path B was not needed**.
+Reminders are single-shot at the future overdue instant (`last + cadence`);
+already-overdue chores are left to the in-app toast (we don't schedule a past
+`at`). The exact-alarm prompt fires lazily/once, only when there's a reminder to
+schedule. Files: `src/native/reminders.ts`, `src/hooks/useReminders.ts`,
+`src/utils/seasonal.ts` (extracted), plus guards in `useNotifications.ts`.
+Known v1 gaps to revisit: a reminder whose trigger falls outside the seasonal
+window still schedules; already-overdue chores get no closed-app nudge.
 
 **Goal:** replace the WebView-timer notifications that silently don't fire when
 closed (`useNotifications.ts:106` is the exact "fire from JS loop" anti-pattern

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",
         "@capacitor/ios": "^8.4.0",
+        "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/status-bar": "^8.0.2",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.5.2",
@@ -2166,6 +2167,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.2.0.tgz",
+      "integrity": "sha512-fvLY0w2w4MiX+DD4+Wv4DOwOLdzKZsMDwAcRv/Juudd+QbKbn69s6cM3xVqPwAiDqfnqsY4/S8xtQD6M73wY2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/status-bar": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@capacitor/android": "^8.4.0",
     "@capacitor/core": "^8.4.0",
     "@capacitor/ios": "^8.4.0",
+    "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/status-bar": "^8.0.2",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.5.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { UsersContext } from '@/multiuser/UsersContext'
 import { useUsers } from '@/multiuser/useUsers'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useWidgetSnapshot } from '@/hooks/useWidgetSnapshot'
+import { useReminders } from '@/hooks/useReminders'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { useDbIntentsPoller } from '@/hooks/useDbIntentsPoller'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
@@ -122,6 +123,7 @@ function AppInner() {
   const { showToast } = useToast()
   useNotifications()
   useWidgetSnapshot()
+  useReminders()
   const { refreshConfig } = useIntents()
   const usersCtx = useUsers()
   const reloadUsers = usersCtx.reload

--- a/src/components/CategorySection/CategorySection.tsx
+++ b/src/components/CategorySection/CategorySection.tsx
@@ -11,6 +11,7 @@ import { deleteCategory, deleteChore, updateCategory, updateChore, reorderChores
 import { ICON_REGISTRY } from '@/icons/registry'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { getFillRatio, getCadenceColor } from '@/utils/cadence'
+import { isInSeasonalWindow } from '@/utils/seasonal'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -23,15 +24,6 @@ interface Props {
   onCategoryDragHandlePointerDown?: (e: React.PointerEvent) => void
   isCategoryDragging?: boolean
   wrapChores?: boolean
-}
-
-function isInSeasonalWindow(chore: ChoreWithLastCompletion): boolean {
-  if (!chore.seasonal_start || !chore.seasonal_end) return true
-  const now = new Date()
-  const today = `${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
-  const { seasonal_start: s, seasonal_end: e } = chore
-  // If start <= end it's a same-year window; otherwise it wraps the new year
-  return s <= e ? today >= s && today <= e : today >= s || today <= e
 }
 
 /**
@@ -186,7 +178,7 @@ function ChoreList({
     setDraggingId(choreId)
   }
 
-  const visibleChores = editMode ? localChores : localChores.filter(isInSeasonalWindow)
+  const visibleChores = editMode ? localChores : localChores.filter(c => isInSeasonalWindow(c))
 
   return (
     <>
@@ -302,7 +294,7 @@ function SubcategorySection({
   // When collapsed, surface a dot if any (in-season) chore is overdue, so it
   // isn't hidden. Colour matches the most-overdue chore (amber → red).
   const overdueRatio = collapsed
-    ? maxOverdueRatio(editMode ? data.chores : data.chores.filter(isInSeasonalWindow))
+    ? maxOverdueRatio(editMode ? data.chores : data.chores.filter(c => isInSeasonalWindow(c)))
     : null
 
   return (

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { getCategories, getChoresForCategory, logCompletion } from '@/db/queries'
+import { Capacitor } from '@capacitor/core'
 import { useToast, type ToastOptions } from '@/components/Toast/Toast'
 import { useIntents } from '@/intents/IntentsContext'
 import { emitCreateIntent } from '@/intents/emitter'
@@ -94,7 +95,10 @@ export function useNotifications() {
                 toastOpts.onSendToDayGlance = async () => emitCreateIntent(chore)
               }
               showToastRef.current(toastOpts)
-            } else {
+            } else if (Capacitor.getPlatform() !== 'android') {
+              // On Android, native exact-alarm reminders (useReminders) own
+              // closed/backgrounded delivery — skip the web notification so it
+              // isn't duplicated. Other platforms keep the in-WebView path.
               await fireBrowserNotification(chore.name, body)
             }
 

--- a/src/hooks/useReminders.ts
+++ b/src/hooks/useReminders.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { Capacitor } from '@capacitor/core'
+import { LocalNotifications } from '@capacitor/local-notifications'
+import type { PluginListenerHandle } from '@capacitor/core'
+import { syncReminders, handleNotificationTap } from '@/native/reminders'
+
+// Keeps the native exact-alarm reminder set in sync with the chores, on the same
+// signals as the widget snapshot, and routes notification taps to the chore.
+// No-op off Android (syncReminders guards the platform internally).
+export function useReminders(): void {
+  useEffect(() => {
+    if (Capacitor.getPlatform() !== 'android') return
+
+    syncReminders()
+
+    const onChange = () => { syncReminders() }
+    window.addEventListener('lg:chore-logged', onChange)
+    window.addEventListener('lg:sync-applied', onChange)
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') syncReminders()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    let tapHandle: PluginListenerHandle | undefined
+    LocalNotifications.addListener('localNotificationActionPerformed', action => {
+      handleNotificationTap(action.notification.extra)
+    }).then(handle => { tapHandle = handle })
+
+    return () => {
+      window.removeEventListener('lg:chore-logged', onChange)
+      window.removeEventListener('lg:sync-applied', onChange)
+      document.removeEventListener('visibilitychange', onVisibility)
+      tapHandle?.remove()
+    }
+  }, [])
+}

--- a/src/native/reminders.ts
+++ b/src/native/reminders.ts
@@ -1,0 +1,182 @@
+import { Capacitor } from '@capacitor/core'
+import { LocalNotifications } from '@capacitor/local-notifications'
+import type { PendingLocalNotificationSchema } from '@capacitor/local-notifications'
+import { getCategories, getChoresForCategory } from '@/db/queries'
+import { db } from '@/db/client'
+import { ownedByMe } from '@/utils/choreFilter'
+import { isInSeasonalWindow } from '@/utils/seasonal'
+import { getMeUserSyncId } from '@/multiuser/settings'
+import dayjs from 'dayjs'
+
+// Phase 1: closed-app overdue notifications. The web app pre-computes each
+// chore's next-overdue instant (last completion + cadence) and registers it as
+// an exact Android alarm via @capacitor/local-notifications, so notifications
+// fire when the app is closed — replacing the in-WebView timer that only ran
+// while the app was alive. Native owns closed-app delivery; the in-app toast in
+// useNotifications.ts still covers the foreground case.
+//
+// No-op anywhere but Android (the only platform wired so far).
+
+const CHANNEL_ID = 'overdue'
+const EXACT_PROMPTED_KEY = 'lg_exact_alarm_prompted'
+
+interface ReminderDescriptor {
+  id: number // stable numeric id derived from choreSyncId
+  choreSyncId: string
+  title: string
+  body: string
+  triggerAtMillis: number
+}
+
+// Deterministic positive 31-bit id from a chore's sync_id (UUID). Notification
+// ids must be Java ints; mapping a chore to a stable id means re-scheduling
+// replaces its alarm in place rather than stacking a duplicate.
+export function reminderIdFor(syncId: string): number {
+  let h = 0
+  for (let i = 0; i < syncId.length; i++) {
+    h = (Math.imul(31, h) + syncId.charCodeAt(i)) | 0
+  }
+  return (h & 0x7fffffff) || 1
+}
+
+let channelReady = false
+async function ensureChannel(): Promise<void> {
+  if (channelReady) return
+  try {
+    await LocalNotifications.createChannel({
+      id: CHANNEL_ID,
+      name: 'Overdue chores',
+      description: 'Reminds you when a chore passes its cadence.',
+      importance: 4, // HIGH — heads-up
+      visibility: 1, // public
+    })
+    channelReady = true
+  } catch {
+    // Channel creation is best-effort; scheduling still works on the default.
+  }
+}
+
+// On Android 12+ exact alarms require the user to grant "Alarms & reminders".
+// Without it the plugin silently falls back to inexact (Doze-batched) delivery —
+// the classic "late when closed" failure. Prompt once, lazily, and only when we
+// actually have something to schedule, so users who never opt a chore into
+// reminders are never sent to Settings.
+async function maybePromptExactAlarm(): Promise<void> {
+  if (localStorage.getItem(EXACT_PROMPTED_KEY)) return
+  try {
+    const status = await LocalNotifications.checkExactNotificationSetting()
+    // Mark prompted up front so we never re-open Settings on subsequent syncs.
+    localStorage.setItem(EXACT_PROMPTED_KEY, '1')
+    if (status.exact_alarm !== 'granted') {
+      await LocalNotifications.changeExactNotificationSetting()
+    }
+  } catch {
+    // Method unavailable (older plugin/OS) — allowWhileIdle still gives
+    // best-effort delivery.
+  }
+}
+
+async function buildReminders(): Promise<ReminderDescriptor[]> {
+  const meId = getMeUserSyncId()
+  const categories = await getCategories()
+  const lists = await Promise.all(categories.map(c => getChoresForCategory(c.id)))
+  const now = Date.now()
+  const out: ReminderDescriptor[] = []
+
+  for (const list of lists) {
+    for (const ch of list) {
+      // Eligibility — mirrors the in-app overdue check (see plan §2).
+      if (!ch.notify_when_overdue) continue
+      if (ch.target_cadence_days == null) continue
+      if (ch.last_completed_at == null) continue
+      if (!isInSeasonalWindow(ch)) continue
+      if (meId && !ownedByMe(ch.assigned_user_sync_ids ?? [], meId)) continue
+
+      const triggerAtMillis = dayjs(ch.last_completed_at)
+        .add(ch.target_cadence_days, 'day')
+        .valueOf()
+      // Already overdue → the in-app toast surfaces it; we only pre-schedule
+      // future crossings (a past `at` would fire immediately on every sync).
+      if (triggerAtMillis <= now) continue
+
+      const days = ch.target_cadence_days
+      out.push({
+        id: reminderIdFor(ch.sync_id),
+        choreSyncId: ch.sync_id,
+        title: ch.name,
+        body: `It's been ${days} ${days === 1 ? 'day' : 'days'}`,
+        triggerAtMillis,
+      })
+    }
+  }
+  return out
+}
+
+// Diff-replace the scheduled alarm set: cancel only what's removed or changed,
+// schedule only what's new or changed. Avoids a blanket cancel-all that could
+// drop an alarm in the window before it's re-registered.
+export async function syncReminders(): Promise<void> {
+  if (Capacitor.getPlatform() !== 'android') return
+  try {
+    let perm = await LocalNotifications.checkPermissions()
+    if (perm.display !== 'granted') {
+      perm = await LocalNotifications.requestPermissions()
+      if (perm.display !== 'granted') return
+    }
+    await ensureChannel()
+
+    const desired = await buildReminders()
+    if (desired.length > 0) await maybePromptExactAlarm()
+
+    const desiredById = new Map(desired.map(r => [r.id, r]))
+    const pending: PendingLocalNotificationSchema[] =
+      (await LocalNotifications.getPending()).notifications
+    const pendingById = new Map(pending.map(p => [p.id, p]))
+
+    const changed = (p: PendingLocalNotificationSchema, d: ReminderDescriptor) => {
+      const extra = (p.extra ?? {}) as { triggerAtMillis?: number }
+      return extra.triggerAtMillis !== d.triggerAtMillis || p.body !== d.body
+    }
+
+    const toCancel = pending.filter(p => {
+      const d = desiredById.get(p.id)
+      return !d || changed(p, d)
+    })
+    if (toCancel.length > 0) {
+      await LocalNotifications.cancel({ notifications: toCancel.map(p => ({ id: p.id })) })
+    }
+
+    const cancelledIds = new Set(toCancel.map(p => p.id))
+    const toSchedule = desired.filter(d => !pendingById.has(d.id) || cancelledIds.has(d.id))
+    if (toSchedule.length > 0) {
+      await LocalNotifications.schedule({
+        notifications: toSchedule.map(d => ({
+          id: d.id,
+          title: d.title,
+          body: d.body,
+          channelId: CHANNEL_ID,
+          schedule: { at: new Date(d.triggerAtMillis), allowWhileIdle: true },
+          extra: {
+            choreSyncId: d.choreSyncId,
+            deepLink: `lastglance://chore/${d.choreSyncId}`,
+            triggerAtMillis: d.triggerAtMillis,
+          },
+        })),
+      })
+    }
+  } catch {
+    // Best-effort: reminders must never disrupt the app.
+  }
+}
+
+// Notification tap → focus the chore. Resolves the carried sync_id to a local
+// row id and reuses the existing lg:open-chore contract (Ribbon opens its log
+// modal). The tap launches the WebView, so the app is alive when this runs.
+export async function handleNotificationTap(extra: unknown): Promise<void> {
+  const choreSyncId = (extra as { choreSyncId?: string } | null)?.choreSyncId
+  if (!choreSyncId) return
+  const chore = await db.chores.where('sync_id').equals(choreSyncId).first()
+  if (chore?.id != null) {
+    window.dispatchEvent(new CustomEvent('lg:open-chore', { detail: { choreId: chore.id } }))
+  }
+}

--- a/src/utils/seasonal.ts
+++ b/src/utils/seasonal.ts
@@ -1,0 +1,15 @@
+import type { Chore } from '@/types'
+
+// True when a chore is within its active seasonal window (or has no window set).
+// `seasonal_start`/`seasonal_end` are "MM-DD" strings; a window whose start is
+// after its end wraps across the new year (e.g. 11-01 → 02-28).
+export function isInSeasonalWindow(
+  chore: Pick<Chore, 'seasonal_start' | 'seasonal_end'>,
+  now: Date = new Date(),
+): boolean {
+  if (!chore.seasonal_start || !chore.seasonal_end) return true
+  const today = `${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+  const s = chore.seasonal_start
+  const e = chore.seasonal_end
+  return s <= e ? today >= s && today <= e : today >= s || today <= e
+}


### PR DESCRIPTION
Continues the native Android work (Phase 0 / heatmap widget shipped in #126). Rebased onto current `main`, so this diff is **only Phase 1**.

## Summary

Replaces the in-WebView notification timer — which only ran while the app was alive — with **exact Android alarms that fire when the app is closed**, via `@capacitor/local-notifications` (Path A from the plan). The web app pre-computes each chore's next-overdue instant (`last completion + cadence`) and registers it as an alarm.

## What's here

- **`src/native/reminders.ts`** — eligible set (notify-when-overdue + has cadence + has a completion + in-season + owned-by-me), **diff-replace** scheduling keyed on a stable id derived from `sync_id` (re-scheduling replaces rather than stacks), a **lazy one-time** exact-alarm permission prompt, and `tap → lg:open-chore` (reuses the existing Ribbon contract).
- **`src/hooks/useReminders.ts`** — re-syncs on mount / `lg:chore-logged` / `lg:sync-applied` / foreground; routes notification taps.
- **`src/utils/seasonal.ts`** — extracted `isInSeasonalWindow` (previously private in `CategorySection`) and switched the component to it; no more duplicated wrap-around logic.
- **`src/hooks/useNotifications.ts`** — on Android, skip the closed-app web notification so native alarms aren't duplicated; the in-app toast stays.
- **Manifest** — add `SCHEDULE_EXACT_ALARM`. The plugin already declares `POST_NOTIFICATIONS`, `RECEIVE_BOOT_COMPLETED`, and ships a boot-restore receiver, so **reboot re-registration is free**. `cap sync` wired the plugin into Gradle.

## Why Path A (not Path B)

`allowWhileIdle: true` maps to `setExactAndAllowWhileIdle` once the exact-alarm permission is granted, clearing the Doze bar — so the custom-Kotlin fallback wasn't needed.

## Testing

- ✅ Web build green; **112/112** tests pass (rebased onto current main).
- ⚠️ **Android not compiled in this environment** (no SDK). Needs an on-device check per the plan's exit criteria: kill the app, advance a chore past its cadence, confirm the notification fires — and test Doze via `adb shell dumpsys deviceidle force-idle`.

## Known v1 gaps (deliberate, noted in the plan doc)

1. A reminder whose trigger falls *outside* the seasonal window still schedules (season is only checked at schedule time).
2. Already-overdue chores get no closed-app nudge — they're left to the in-app toast (we don't schedule a past time, matching dayGLANCE's "drop past" rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_