### PR TITLE
Android Phase 2a: Glance single-chore widget + tap-to-complete (+ notification fixes)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 // Derive versionName/versionCode from package.json so the native build tracks
 // the web app version (e.g. 1.8.4 -> versionCode 10804) instead of drifting.
@@ -29,6 +31,13 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "com.lastglance.app"
     compileSdk = rootProject.ext.compileSdkVersion
+    // Jetpack Glance widgets are Kotlin + Compose.
+    buildFeatures {
+        compose true
+    }
+    kotlinOptions {
+        jvmTarget = '21'
+    }
     defaultConfig {
         applicationId "com.lastglance.app"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -83,6 +92,9 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation project(':capacitor-android')
+    // Jetpack Glance home-screen widgets (Compose-based).
+    implementation "androidx.glance:glance-appwidget:$glanceVersion"
+    implementation "androidx.glance:glance-material3:$glanceVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,17 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/heatmap_widget_info" />
         </receiver>
+
+        <receiver
+            android:name=".glance.SingleChoreWidgetReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/single_chore_widget_info" />
+        </receiver>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
+++ b/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
@@ -3,6 +3,9 @@ package com.lastglance.app;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 // Single SharedPreferences store shared between the Capacitor bridge (writer)
 // and the home-screen widgets (readers). Kept tiny on purpose: the web app is
 // the source of truth, this is just the hand-off surface.
@@ -10,6 +13,9 @@ public final class SharedDataStore {
 
     private static final String PREFS = "lastglance_shared";
     private static final String KEY_SNAPSHOT = "snapshot";
+    // Completions logged from a widget tap, awaiting drain into the DB by the
+    // web app on next foreground (a widget can't write IndexedDB itself).
+    private static final String KEY_PENDING = "pending_completions";
 
     private SharedDataStore() {}
 
@@ -23,5 +29,29 @@ public final class SharedDataStore {
 
     public static String readSnapshot(Context context) {
         return prefs(context).getString(KEY_SNAPSHOT, null);
+    }
+
+    // Append a completion to the durable queue. The web app mints nothing here;
+    // the caller supplies the sync_id so the later DB replay is idempotent.
+    public static void appendPendingCompletion(Context context, String choreSyncId, String syncId, String completedAt) {
+        try {
+            JSONArray arr = new JSONArray(prefs(context).getString(KEY_PENDING, "[]"));
+            JSONObject o = new JSONObject();
+            o.put("choreSyncId", choreSyncId);
+            o.put("syncId", syncId);
+            o.put("completedAt", completedAt);
+            arr.put(o);
+            prefs(context).edit().putString(KEY_PENDING, arr.toString()).apply();
+        } catch (Exception e) {
+            // Best-effort; a dropped queue entry just means that tap isn't
+            // persisted to the DB (the optimistic snapshot still updated).
+        }
+    }
+
+    // Return the queued completions as a JSON array string and clear the queue.
+    public static String readAndClearPendingCompletions(Context context) {
+        String raw = prefs(context).getString(KEY_PENDING, "[]");
+        prefs(context).edit().remove(KEY_PENDING).apply();
+        return raw;
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
@@ -1,12 +1,21 @@
 package com.lastglance.app;
 
+import android.appwidget.AppWidgetManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+
+import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import com.lastglance.app.glance.SingleChoreWidgetReceiver;
+
 // Receives the denormalized snapshot from the web app and persists it for the
-// home-screen widgets to render. Registered in MainActivity.
+// home-screen widgets to render, and hands back completions logged from widgets.
+// Registered in MainActivity.
 @CapacitorPlugin(name = "WidgetBridge")
 public class WidgetBridgePlugin extends Plugin {
 
@@ -17,8 +26,31 @@ public class WidgetBridgePlugin extends Plugin {
             call.reject("missing json");
             return;
         }
-        SharedDataStore.writeSnapshot(getContext(), json);
-        HeatmapWidgetProvider.refreshAll(getContext());
+        Context context = getContext();
+        SharedDataStore.writeSnapshot(context, json);
+        HeatmapWidgetProvider.refreshAll(context);
+        refreshGlanceWidget(context);
         call.resolve();
+    }
+
+    // Hand the queued widget completions to the web app (which replays them into
+    // the DB) and clear the queue.
+    @PluginMethod
+    public void drainPendingCompletions(PluginCall call) {
+        String json = SharedDataStore.readAndClearPendingCompletions(getContext());
+        JSObject ret = new JSObject();
+        ret.put("completions", json);
+        call.resolve(ret);
+    }
+
+    // Nudge the Glance widget to recompose from the freshly written snapshot.
+    private static void refreshGlanceWidget(Context context) {
+        ComponentName component = new ComponentName(context, SingleChoreWidgetReceiver.class);
+        int[] ids = AppWidgetManager.getInstance(context).getAppWidgetIds(component);
+        if (ids == null || ids.length == 0) return;
+        Intent intent = new Intent(context, SingleChoreWidgetReceiver.class);
+        intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
+        context.sendBroadcast(intent);
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -1,0 +1,256 @@
+package com.lastglance.app.glance
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.ActionCallback
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.material3.GlanceTheme
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lastglance.app.R
+import com.lastglance.app.SharedDataStore
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+
+// Phase 2: an interactive Glance widget showing the chore most in need of
+// attention, with one-tap "Done". The widget renders from the SharedPreferences
+// snapshot the web app pushes (never the DB). A tap optimistically updates that
+// snapshot and queues the completion for the app to replay into the DB on next
+// foreground (see SharedDataStore + drainWidgetCompletions on the web side).
+
+private val SYNC_ID_KEY = ActionParameters.Key<String>("choreSyncId")
+
+private data class ChoreData(
+    val syncId: String,
+    val name: String,
+    val elapsed: String,
+    val colorInt: Int,
+)
+
+private object ChoreSnapshot {
+    // The chore with the highest elapsed/target ratio (most overdue, or closest
+    // to due). Null when nothing has a cadence + a completion yet.
+    fun pickMostOverdue(context: Context): ChoreData? {
+        val raw = SharedDataStore.readSnapshot(context) ?: return null
+        return try {
+            val chores = JSONObject(raw).optJSONArray("chores") ?: return null
+            var best: JSONObject? = null
+            var bestRatio = -1.0
+            for (i in 0 until chores.length()) {
+                val ch = chores.getJSONObject(i)
+                if (ch.isNull("ratio")) continue
+                val r = ch.optDouble("ratio", -1.0)
+                if (r > bestRatio) {
+                    bestRatio = r
+                    best = ch
+                }
+            }
+            best?.let {
+                ChoreData(
+                    syncId = it.optString("syncId"),
+                    name = it.optString("name"),
+                    elapsed = elapsedLabel(it),
+                    colorInt = parseColor(it.optString("color", "#22c55e")),
+                )
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun elapsedLabel(chore: JSONObject): String {
+        if (chore.isNull("elapsedDays")) return "never"
+        val d = chore.optDouble("elapsedDays", 0.0)
+        if (d < 1) return "today"
+        val days = Math.round(d)
+        return "${days}d ago"
+    }
+
+    private fun parseColor(hex: String): Int {
+        return try {
+            android.graphics.Color.parseColor(hex)
+        } catch (e: Exception) {
+            android.graphics.Color.parseColor("#22c55e")
+        }
+    }
+}
+
+object CompletionStore {
+    // Record a widget completion: queue it (idempotent sync_id minted here) and
+    // optimistically fold it into the snapshot so the widget reflects it
+    // instantly, before the app ever runs.
+    fun complete(context: Context, choreSyncId: String) {
+        val syncId = UUID.randomUUID().toString()
+        val completedAt = isoNowUtc()
+        SharedDataStore.appendPendingCompletion(context, choreSyncId, syncId, completedAt)
+
+        val raw = SharedDataStore.readSnapshot(context) ?: return
+        try {
+            val root = JSONObject(raw)
+            val chores = root.optJSONArray("chores")
+            if (chores != null) {
+                for (i in 0 until chores.length()) {
+                    val ch = chores.getJSONObject(i)
+                    if (ch.optString("syncId") == choreSyncId) {
+                        ch.put("lastCompletedAt", completedAt)
+                        ch.put("elapsedDays", 0)
+                        ch.put("ratio", 0)
+                        ch.put("color", "#22c55e")
+                        ch.put("state", "fresh")
+                        break
+                    }
+                }
+                var overdue = 0
+                var soon = 0
+                for (i in 0 until chores.length()) {
+                    when (chores.getJSONObject(i).optString("state")) {
+                        "overdue" -> overdue++
+                        "soon" -> soon++
+                    }
+                }
+                val counts = root.optJSONObject("counts") ?: JSONObject()
+                counts.put("overdue", overdue)
+                counts.put("soon", soon)
+                root.put("counts", counts)
+            }
+            val heatmap = root.optJSONObject("heatmap") ?: JSONObject()
+            val today = localDay()
+            heatmap.put(today, heatmap.optInt(today, 0) + 1)
+            root.put("heatmap", heatmap)
+
+            SharedDataStore.writeSnapshot(context, root.toString())
+        } catch (e: Exception) {
+            // Best-effort; the completion is already queued for the DB replay.
+        }
+    }
+
+    private fun isoNowUtc(): String {
+        val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        fmt.timeZone = TimeZone.getTimeZone("UTC")
+        return fmt.format(Date())
+    }
+
+    // Local-day key, matching the web snapshot's dayjs().format('YYYY-MM-DD').
+    private fun localDay(): String = SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date())
+}
+
+class CompleteChoreCallback : ActionCallback {
+    override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
+        val syncId = parameters[SYNC_ID_KEY] ?: return
+        CompletionStore.complete(context, syncId)
+        SingleChoreWidget().update(context, glanceId)
+    }
+}
+
+class SingleChoreWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val chore = ChoreSnapshot.pickMostOverdue(context)
+        provideContent {
+            GlanceTheme {
+                Content(context, chore)
+            }
+        }
+    }
+
+    @Composable
+    private fun Content(context: Context, chore: ChoreData?) {
+        Row(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(GlanceTheme.colors.surface)
+                .cornerRadius(16.dp)
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (chore == null) {
+                Column(modifier = GlanceModifier.defaultWeight()) {
+                    Text(
+                        context.getString(R.string.app_name),
+                        style = TextStyle(
+                            color = GlanceTheme.colors.onSurface,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 15.sp,
+                        ),
+                    )
+                    Text(
+                        context.getString(R.string.widget_all_caught_up),
+                        style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp),
+                    )
+                }
+            } else {
+                Spacer(
+                    modifier = GlanceModifier
+                        .width(6.dp)
+                        .height(36.dp)
+                        .cornerRadius(3.dp)
+                        .background(ColorProvider(Color(chore.colorInt))),
+                )
+                Spacer(modifier = GlanceModifier.width(10.dp))
+                Column(modifier = GlanceModifier.defaultWeight()) {
+                    Text(
+                        chore.name,
+                        maxLines = 1,
+                        style = TextStyle(
+                            color = GlanceTheme.colors.onSurface,
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 15.sp,
+                        ),
+                    )
+                    Text(
+                        chore.elapsed,
+                        style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp),
+                    )
+                }
+                Spacer(modifier = GlanceModifier.width(8.dp))
+                Text(
+                    context.getString(R.string.widget_done),
+                    style = TextStyle(
+                        color = ColorProvider(Color.White),
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 13.sp,
+                    ),
+                    modifier = GlanceModifier
+                        .background(ColorProvider(Color(0xFF22C55E)))
+                        .cornerRadius(8.dp)
+                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                        .clickable(
+                            actionRunCallback<CompleteChoreCallback>(
+                                actionParametersOf(SYNC_ID_KEY to chore.syncId),
+                            ),
+                        ),
+                )
+            }
+        }
+    }
+}
+
+class SingleChoreWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SingleChoreWidget()
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,4 +5,7 @@
     <string name="package_name">com.lastglance.app</string>
     <string name="custom_url_scheme">com.lastglance.app</string>
     <string name="heatmap_widget_description">Your recent completion activity at a glance.</string>
+    <string name="single_chore_widget_description">The chore most in need of attention, with one-tap done.</string>
+    <string name="widget_done">Done</string>
+    <string name="widget_all_caught_up">All caught up</string>
 </resources>

--- a/android/app/src/main/res/xml/single_chore_widget_info.xml
+++ b/android/app/src/main/res/xml/single_chore_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:resizeMode="horizontal"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewImage="@mipmap/ic_launcher"
+    android:description="@string/single_chore_widget_description" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,9 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.4'
+        // Kotlin + Compose compiler, for the Jetpack Glance home-screen widgets.
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.0'
+        classpath 'org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -13,4 +13,5 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
+    glanceVersion = '1.1.1'
 }

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -14,9 +14,10 @@ Where lastGLANCE differs from dayGLANCE, it is called out explicitly.
 >   (Path A), **+ notification actions** (Mark done; Send to dayGLANCE when intents
 >   are configured) **+ branded contribution-grid notification icon**. Device-tested
 >   through step 6 (closed-app + Doze delivery) and the cold-start tap fix.
-> - **Phase 2 is now starting** (action widgets + optimistic tap-to-complete).
-> - **Gating decision before Phase 2 native UI:** RemoteViews (as built in Phase 0)
->   vs Glance for the interactive widgets.
+> - **Phase 2 in progress** (action widgets + optimistic tap-to-complete). Widget
+>   tech **decided: Jetpack Glance**. Phase 2a built: tap-to-complete spine +
+>   single-chore Glance tile. **Glance toolchain is unverified locally — first
+>   on-device build may need version adjustment.**
 > - **Settled:** Path A (B backup); "clearly same family"; no battery-opt prompt;
 >   defer the WorkManager re-arm backstop until testing proves OEM killers clear alarms.
 > - **Carry-over to Phase 2:** silent "Mark done" (the official plugin opens the app
@@ -261,9 +262,31 @@ dayGLANCE's war story warns about).
 **Exit criteria:** kill the app, advance a chore past its cadence, alarm fires on
 time (test on Doze via `adb shell dumpsys deviceidle force-idle`).
 
-### Phase 2 — Action widgets + optimistic tap-to-complete
+### Phase 2 — Action widgets + optimistic tap-to-complete — 🚧 IN PROGRESS
 
-**Goal:** the marquee widgets, with completion that *feels instant* and is
+**Decision (resolved):** widgets use **Jetpack Glance** (Kotlin + Compose). This
+adds a toolchain to the Java project: Kotlin 2.2.0 + the Compose compiler plugin
++ `androidx.glance:glance-appwidget`/`glance-material3` 1.1.1 (`buildFeatures.compose`,
+`jvmTarget 21`). **Not compilable in the dev environment** — the first on-device
+build is where any version mismatch surfaces and may need a round of adjustment.
+
+**Built so far (Phase 2a):**
+- **Tap-to-complete spine** (tech-agnostic, verified): native completion queue in
+  `SharedDataStore`; `WidgetBridge.drainPendingCompletions`; web drain
+  `src/native/pendingCompletions.ts` + `usePendingCompletions` replays each via
+  `logCompletion(choreId, { syncId })` — idempotent on the native-minted sync_id.
+- **Single-chore Glance tile** (`glance/SingleChoreWidget.kt`): shows the
+  most-overdue chore (no config Activity needed yet) with a recency color bar and
+  one-tap **Done**. Done → optimistic snapshot update (instant, offline) + queue;
+  the app drains on next foreground. The bridge nudges the Glance widget to
+  recompose on every snapshot push.
+
+**Still to do:** the Soon/overdue **list** widget; a configuration Activity for a
+user-picked single-chore tile; the deep-link router so widget body-taps open the
+specific chore (today they just open the app). Possible later: migrate the Phase 0
+heatmap from RemoteViews to Glance for uniformity.
+
+**Original goal:** the marquee widgets, with completion that *feels instant* and is
 *safe*.
 
 - **Overdue/"Soon" list widget** (Glance `LazyColumn` from `snapshot.chores`

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -11,15 +11,17 @@ Where lastGLANCE differs from dayGLANCE, it is called out explicitly.
 > - **Phase 0 + Phase 1 built** on branch `claude/wonderful-mccarthy-abm730`
 >   (PR #126). Web build + 58 tests green; **Android not yet compiled/device-tested.**
 > - **Phase 1** = exact-alarm overdue notifications via `@capacitor/local-notifications`
->   (Path A). Plugin handles reboot re-registration; we added `SCHEDULE_EXACT_ALARM`
->   + a lazy one-time exact-alarm prompt.
-> - **Next action is yours:** on-device smoke test of both (widget refresh; kill the
->   app, advance a chore past cadence, confirm the notification fires — test Doze via
->   `adb shell dumpsys deviceidle force-idle`).
-> - **Still open:** RemoteViews (as built) vs Glance for widgets (Phase 0). Next code
->   phase is **Phase 2** (action widgets + optimistic tap-to-complete).
+>   (Path A), **+ notification actions** (Mark done; Send to dayGLANCE when intents
+>   are configured) **+ branded contribution-grid notification icon**. Device-tested
+>   through step 6 (closed-app + Doze delivery) and the cold-start tap fix.
+> - **Phase 2 is now starting** (action widgets + optimistic tap-to-complete).
+> - **Gating decision before Phase 2 native UI:** RemoteViews (as built in Phase 0)
+>   vs Glance for the interactive widgets.
 > - **Settled:** Path A (B backup); "clearly same family"; no battery-opt prompt;
 >   defer the WorkManager re-arm backstop until testing proves OEM killers clear alarms.
+> - **Carry-over to Phase 2:** silent "Mark done" (the official plugin opens the app
+>   for every notification action; truly background completion needs native work —
+>   the same optimistic-native + queue path Phase 2 builds for widgets).
 
 ---
 
@@ -219,6 +221,20 @@ schedule. Files: `src/native/reminders.ts`, `src/hooks/useReminders.ts`,
 `src/utils/seasonal.ts` (extracted), plus guards in `useNotifications.ts`.
 Known v1 gaps to revisit: a reminder whose trigger falls outside the seasonal
 window still schedules; already-overdue chores get no closed-app nudge.
+
+Follow-ups landed after #126 (PRs #146/#148):
+- **Permission gate fix** — the "Notify when overdue" toggle now checks the native
+  Local Notifications permission, not the WebView Notification API (which is
+  unavailable in the Capacitor WebView). Copy simplified to "enable in settings".
+- **Cold-start tap routing** — notification taps survive a killed-app launch via a
+  durable pending-open request (`src/native/pendingOpenChore.ts`) the Ribbon
+  retries as its data loads, replacing a one-shot event that raced the DB load.
+- **Notification actions** — "Mark done" (logs completion, reschedules) and "Send
+  to dayGLANCE" (shown only when intents are configured, via a second action type).
+  Caveat: the official plugin opens the app for every action; silent Mark done is a
+  Phase 2 carry-over.
+- **Branded notification icon** — monochrome contribution-grid (`ic_stat_notify`) +
+  brand-green accent, replacing the default info glyph.
 
 **Goal:** replace the WebView-timer notifications that silently don't fire when
 closed (`useNotifications.ts:106` is the exact "fire from JS loop" anti-pattern

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { useUsers } from '@/multiuser/useUsers'
 import { useNotifications } from '@/hooks/useNotifications'
 import { useWidgetSnapshot } from '@/hooks/useWidgetSnapshot'
 import { useReminders } from '@/hooks/useReminders'
+import { usePendingCompletions } from '@/hooks/usePendingCompletions'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { useDbIntentsPoller } from '@/hooks/useDbIntentsPoller'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
@@ -124,6 +125,7 @@ function AppInner() {
   useNotifications()
   useWidgetSnapshot()
   useReminders()
+  usePendingCompletions()
   const { refreshConfig } = useIntents()
   const usersCtx = useUsers()
   const reloadUsers = usersCtx.reload

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -101,7 +101,7 @@ export function useNotifications() {
                 body,
                 type: 'warning',
                 onAction: async () => {
-                  await logCompletion(choreId)
+                  await logCompletion(choreId, { completedByUserSyncId: getMeUserSyncId() })
                   window.dispatchEvent(new CustomEvent('lg:chore-logged'))
                 },
                 onDetails: () => {

--- a/src/hooks/usePendingCompletions.ts
+++ b/src/hooks/usePendingCompletions.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { Capacitor } from '@capacitor/core'
+import { drainWidgetCompletions } from '@/native/pendingCompletions'
+
+// Drains widget-originated completions into the DB on mount and whenever the app
+// returns to the foreground (when a widget tap may have queued one while we were
+// away). No-op off Android.
+export function usePendingCompletions(): void {
+  useEffect(() => {
+    if (Capacitor.getPlatform() !== 'android') return
+
+    drainWidgetCompletions()
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') drainWidgetCompletions()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => document.removeEventListener('visibilitychange', onVisibility)
+  }, [])
+}

--- a/src/native/pendingCompletions.ts
+++ b/src/native/pendingCompletions.ts
@@ -1,0 +1,31 @@
+import { drainPendingCompletions } from './widgetBridge'
+import { db } from '@/db/client'
+import { logCompletion } from '@/db/queries'
+
+// Drain widget-originated completions into the DB. A widget tap can't write to
+// IndexedDB (it runs in the native process), so the native side optimistically
+// updates its snapshot and queues the completion; the web app replays the queue
+// here on next foreground.
+//
+// Each entry carries the sync_id the native side minted at tap time, so
+// replaying via logCompletion is idempotent — no double-count if the queue is
+// drained twice, or if the event already arrived from another device via sync.
+export async function drainWidgetCompletions(): Promise<void> {
+  const pending = await drainPendingCompletions()
+  if (pending.length === 0) return
+
+  let logged = false
+  for (const p of pending) {
+    try {
+      const already = await db.completionEvents.where('sync_id').equals(p.syncId).count()
+      if (already > 0) continue
+      const chore = await db.chores.where('sync_id').equals(p.choreSyncId).first()
+      if (chore?.id == null) continue
+      await logCompletion(chore.id, { completedAt: p.completedAt, syncId: p.syncId })
+      logged = true
+    } catch {
+      // Skip a malformed/unresolvable entry rather than failing the whole drain.
+    }
+  }
+  if (logged) window.dispatchEvent(new CustomEvent('lg:chore-logged'))
+}

--- a/src/native/pendingCompletions.ts
+++ b/src/native/pendingCompletions.ts
@@ -1,6 +1,7 @@
 import { drainPendingCompletions } from './widgetBridge'
 import { db } from '@/db/client'
 import { logCompletion } from '@/db/queries'
+import { getMeUserSyncId } from '@/multiuser/settings'
 
 // Drain widget-originated completions into the DB. A widget tap can't write to
 // IndexedDB (it runs in the native process), so the native side optimistically
@@ -21,7 +22,11 @@ export async function drainWidgetCompletions(): Promise<void> {
       if (already > 0) continue
       const chore = await db.chores.where('sync_id').equals(p.choreSyncId).first()
       if (chore?.id == null) continue
-      await logCompletion(chore.id, { completedAt: p.completedAt, syncId: p.syncId })
+      await logCompletion(chore.id, {
+        completedAt: p.completedAt,
+        syncId: p.syncId,
+        completedByUserSyncId: getMeUserSyncId(),
+      })
       logged = true
     } catch {
       // Skip a malformed/unresolvable entry rather than failing the whole drain.

--- a/src/native/reminders.ts
+++ b/src/native/reminders.ts
@@ -6,6 +6,7 @@ import { db } from '@/db/client'
 import { setPendingOpenChore } from './pendingOpenChore'
 import { emitCreateIntent } from '@/intents/emitter'
 import { getIntentsConfig, isIntentsConfigured } from '@/intents/config'
+import { isDbIntentsEnabled } from '@/intents/dbConfig'
 import { ownedByMe } from '@/utils/choreFilter'
 import { isInSeasonalWindow } from '@/utils/seasonal'
 import { getMeUserSyncId } from '@/multiuser/settings'
@@ -160,7 +161,10 @@ export async function syncReminders(): Promise<void> {
     await ensureChannel()
     await ensureActionTypes()
 
-    const dgEnabled = isIntentsConfigured(getIntentsConfig())
+    // "Configured" means EITHER transport is enabled — WebDAV intents or the
+    // GLANCEvault DB transport — mirroring IntentsContext.isConfigured. Checking
+    // WebDAV alone hid the action on vault-only setups.
+    const dgEnabled = isIntentsConfigured(getIntentsConfig()) || isDbIntentsEnabled()
     const desired = await buildReminders(dgEnabled)
     if (desired.length > 0) await maybePromptExactAlarm()
 
@@ -214,7 +218,8 @@ export async function syncReminders(): Promise<void> {
 async function markChoreDone(choreSyncId: string): Promise<void> {
   const chore = await db.chores.where('sync_id').equals(choreSyncId).first()
   if (chore?.id == null) return
-  await logCompletion(chore.id)
+  // Attribute to the current "Me" user, matching in-app completion (ChoreRow).
+  await logCompletion(chore.id, { completedByUserSyncId: getMeUserSyncId() })
   // Refreshes the list/heatmap, repushes the widget snapshot, and re-runs
   // syncReminders — which reschedules this chore's next overdue alarm.
   window.dispatchEvent(new CustomEvent('lg:chore-logged'))

--- a/src/native/widgetBridge.ts
+++ b/src/native/widgetBridge.ts
@@ -7,6 +7,9 @@ import { Capacitor, registerPlugin } from '@capacitor/core'
 export interface WidgetBridgePlugin {
   // Persist the snapshot JSON and refresh any placed widgets.
   updateSnapshot(options: { json: string }): Promise<void>
+  // Return and clear the queue of completions logged from widgets (JSON array
+  // string). The web app drains this into the DB on foreground.
+  drainPendingCompletions(): Promise<{ completions: string }>
 }
 
 const WidgetBridge = registerPlugin<WidgetBridgePlugin>('WidgetBridge')
@@ -18,5 +21,22 @@ export async function pushWidgetSnapshot(json: string): Promise<void> {
   } catch {
     // Plugin unavailable or transient failure — widgets are a cosmetic extra,
     // so swallow rather than disrupt the app.
+  }
+}
+
+export interface PendingCompletion {
+  choreSyncId: string
+  syncId: string
+  completedAt: string
+}
+
+export async function drainPendingCompletions(): Promise<PendingCompletion[]> {
+  if (Capacitor.getPlatform() !== 'android') return []
+  try {
+    const res = await WidgetBridge.drainPendingCompletions()
+    const arr = JSON.parse(res?.completions ?? '[]')
+    return Array.isArray(arr) ? arr : []
+  } catch {
+    return []
   }
 }


### PR DESCRIPTION
Kicks off Phase 2 of the native Android work. Widget tech decided: **Jetpack Glance**.

## Phase 2a — single-chore widget + tap-to-complete spine

**Tap-to-complete spine** (tech-agnostic; web build verified):
- `SharedDataStore` durable pending-completions queue → `WidgetBridge.drainPendingCompletions` → `src/native/pendingCompletions.ts` + `usePendingCompletions` drain on foreground, replaying each via `logCompletion(choreId, { syncId, completedByUserSyncId })`. Idempotent on the native-minted `sync_id` (no double-count across drains or a sync round-trip).

**Single-chore Glance tile** (`glance/SingleChoreWidget.kt`):
- Shows the most-overdue chore (no config Activity yet), recency color bar, one-tap **Done**.
- Done → optimistic snapshot update (instant, offline) + queue; the bridge nudges the Glance widget to recompose on every snapshot push.

**Toolchain:** adds Kotlin 2.2.0 + the Compose compiler plugin + Glance 1.1.1 (`buildFeatures.compose`, `jvmTarget 21`) to the Java project.

## Notification fixes (from on-device testing)

- **"Send to dayGLANCE" now appears for GLANCEvault DB-transport setups**, not just WebDAV. The reminder gating checked `isIntentsConfigured()` only; the app shows the option when *either* transport is enabled (`IntentsContext.isConfigured`), so it now includes `isDbIntentsEnabled()`.
- **Completing user is now recorded.** Mark-done from a notification, the in-app toast, and a widget tap now set `completed_by_user_sync_id` via `getMeUserSyncId()`, matching in-app completion (previously logged a null user).

## Testing

- ✅ Web build green; **112/112** tests pass. XML well-formed.
- ⚠️ **The Glance / Kotlin / Gradle toolchain is NOT compilable in CI/this environment** (no Android SDK). The first on-device build is where any version/API mismatch will surface — most likely the Kotlin↔AGP↔Gradle alignment or a Glance API name. Widget code kept minimal so a failure points at the toolchain, not logic.

## Follow-ups (noted in the plan doc)

Soon/overdue **list** widget; a configuration Activity for a user-picked tile; the deep-link router so a widget body-tap opens the specific chore; possibly migrating the Phase 0 heatmap to Glance for uniformity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_