### PR TITLE
fix(android): GlanceTheme import path

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -25,7 +25,7 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.width
-import androidx.glance.material3.GlanceTheme
+import androidx.glance.GlanceTheme
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle


### PR DESCRIPTION
GlanceTheme is in androidx.glance, not androidx.glance.material3 (that artifact only provides the ColorProviders builder). Fixes the compileReleaseKotlin unresolved-reference errors. Toolchain itself (Kotlin 2.2.0 + Glance 1.1.1) compiles fine.


Claude-Session: https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA