### PR TITLE
Android: Soon/overdue list widget (Glance)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,17 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/single_chore_widget_info" />
         </receiver>
+
+        <receiver
+            android:name=".glance.SoonListWidgetReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/soon_list_widget_info" />
+        </receiver>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
@@ -12,6 +12,7 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
 import com.lastglance.app.glance.SingleChoreWidgetReceiver;
+import com.lastglance.app.glance.SoonListWidgetReceiver;
 
 // Receives the denormalized snapshot from the web app and persists it for the
 // home-screen widgets to render, and hands back completions logged from widgets.
@@ -29,7 +30,8 @@ public class WidgetBridgePlugin extends Plugin {
         Context context = getContext();
         SharedDataStore.writeSnapshot(context, json);
         HeatmapWidgetProvider.refreshAll(context);
-        refreshGlanceWidget(context);
+        refreshGlanceWidget(context, SingleChoreWidgetReceiver.class);
+        refreshGlanceWidget(context, SoonListWidgetReceiver.class);
         call.resolve();
     }
 
@@ -43,12 +45,12 @@ public class WidgetBridgePlugin extends Plugin {
         call.resolve(ret);
     }
 
-    // Nudge the Glance widget to recompose from the freshly written snapshot.
-    private static void refreshGlanceWidget(Context context) {
-        ComponentName component = new ComponentName(context, SingleChoreWidgetReceiver.class);
+    // Nudge a Glance widget to recompose from the freshly written snapshot.
+    private static void refreshGlanceWidget(Context context, Class<?> receiver) {
+        ComponentName component = new ComponentName(context, receiver);
         int[] ids = AppWidgetManager.getInstance(context).getAppWidgetIds(component);
         if (ids == null || ids.length == 0) return;
-        Intent intent = new Intent(context, SingleChoreWidgetReceiver.class);
+        Intent intent = new Intent(context, receiver);
         intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
         intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
         context.sendBroadcast(intent);

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -19,6 +19,7 @@ import androidx.glance.appwidget.action.ActionCallback
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.updateAll
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Column
@@ -49,9 +50,9 @@ import java.util.UUID
 // snapshot and queues the completion for the app to replay into the DB on next
 // foreground (see SharedDataStore + drainWidgetCompletions on the web side).
 
-private val SYNC_ID_KEY = ActionParameters.Key<String>("choreSyncId")
+internal val SYNC_ID_KEY = ActionParameters.Key<String>("choreSyncId")
 
-private data class ChoreData(
+internal data class ChoreData(
     val syncId: String,
     val name: String,
     val elapsed: String,
@@ -59,7 +60,7 @@ private data class ChoreData(
     val iconResId: Int, // ic_lucide_* drawable, or 0 when the chore has no icon
 )
 
-private object ChoreSnapshot {
+internal object ChoreSnapshot {
     // The chore with the highest elapsed/target ratio (most overdue, or closest
     // to due). Null when nothing has a cadence + a completion yet.
     fun pickMostOverdue(context: Context): ChoreData? {
@@ -88,6 +89,35 @@ private object ChoreSnapshot {
             }
         } catch (e: Exception) {
             null
+        }
+    }
+
+    // Chores aged into the amber/red zone (state soon or overdue), most-overdue
+    // first, capped at `limit`. Powers the Soon list widget.
+    fun pickSoonList(context: Context, limit: Int): List<ChoreData> {
+        val raw = SharedDataStore.readSnapshot(context) ?: return emptyList()
+        return try {
+            val chores = JSONObject(raw).optJSONArray("chores") ?: return emptyList()
+            val rows = ArrayList<Pair<Double, ChoreData>>()
+            for (i in 0 until chores.length()) {
+                val ch = chores.getJSONObject(i)
+                val state = ch.optString("state")
+                if (state != "soon" && state != "overdue") continue
+                val ratio = if (ch.isNull("ratio")) 0.0 else ch.optDouble("ratio", 0.0)
+                rows.add(
+                    ratio to ChoreData(
+                        syncId = ch.optString("syncId"),
+                        name = ch.optString("name"),
+                        elapsed = elapsedLabel(ch),
+                        colorInt = parseColor(ch.optString("color", "#22c55e")),
+                        iconResId = resolveIcon(context, ch.optString("icon", null)),
+                    ),
+                )
+            }
+            rows.sortByDescending { it.first }
+            rows.take(limit).map { it.second }
+        } catch (e: Exception) {
+            emptyList()
         }
     }
 
@@ -189,7 +219,9 @@ class CompleteChoreCallback : ActionCallback {
     override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
         val syncId = parameters[SYNC_ID_KEY] ?: return
         CompletionStore.complete(context, syncId)
-        SingleChoreWidget().update(context, glanceId)
+        // Refresh every widget kind so the tile and the list both reflect it.
+        SingleChoreWidget().updateAll(context)
+        SoonListWidget().updateAll(context)
     }
 }
 

--- a/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
@@ -1,0 +1,148 @@
+package com.lastglance.app.glance
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.ColorFilter
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.lazy.LazyColumn
+import androidx.glance.appwidget.lazy.items
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lastglance.app.R
+
+// Phase 2: the "Soon" list widget — the chores aged into the amber/red zone,
+// most-overdue first, each with one-tap Done. Shares the snapshot read, the
+// completion callback, and the row styling with the single-chore tile.
+private const val MAX_ROWS = 25
+
+class SoonListWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val rows = ChoreSnapshot.pickSoonList(context, MAX_ROWS)
+        provideContent {
+            GlanceTheme {
+                Content(context, rows)
+            }
+        }
+    }
+
+    @Composable
+    private fun Content(context: Context, rows: List<ChoreData>) {
+        Column(
+            modifier = GlanceModifier
+                .fillMaxSize()
+                .background(GlanceTheme.colors.surface)
+                .cornerRadius(16.dp)
+                .padding(12.dp),
+        ) {
+            Text(
+                context.getString(R.string.soon_list_widget_title),
+                style = TextStyle(
+                    color = GlanceTheme.colors.onSurfaceVariant,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 12.sp,
+                ),
+                modifier = GlanceModifier.padding(bottom = 8.dp),
+            )
+            if (rows.isEmpty()) {
+                Text(
+                    context.getString(R.string.widget_all_caught_up),
+                    style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 14.sp),
+                )
+            } else {
+                LazyColumn {
+                    items(rows) { chore -> ChoreListRow(context, chore) }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ChoreListRow(context: Context, chore: ChoreData) {
+        Row(
+            modifier = GlanceModifier.fillMaxWidth().padding(vertical = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(
+                modifier = GlanceModifier
+                    .width(5.dp)
+                    .height(26.dp)
+                    .cornerRadius(2.dp)
+                    .background(ColorProvider(Color(chore.colorInt))),
+            )
+            Spacer(modifier = GlanceModifier.width(8.dp))
+            if (chore.iconResId != 0) {
+                Image(
+                    provider = ImageProvider(chore.iconResId),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(ColorProvider(Color(chore.colorInt))),
+                    modifier = GlanceModifier.size(18.dp),
+                )
+                Spacer(modifier = GlanceModifier.width(8.dp))
+            }
+            Column(modifier = GlanceModifier.defaultWeight()) {
+                Text(
+                    chore.name,
+                    maxLines = 1,
+                    style = TextStyle(
+                        color = GlanceTheme.colors.onSurface,
+                        fontWeight = FontWeight.Medium,
+                        fontSize = 14.sp,
+                    ),
+                )
+                Text(
+                    chore.elapsed,
+                    style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 11.sp),
+                )
+            }
+            Spacer(modifier = GlanceModifier.width(8.dp))
+            Text(
+                context.getString(R.string.widget_done),
+                style = TextStyle(
+                    color = ColorProvider(Color.White),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 12.sp,
+                ),
+                modifier = GlanceModifier
+                    .background(ColorProvider(Color(0xFF22C55E)))
+                    .cornerRadius(8.dp)
+                    .padding(horizontal = 10.dp, vertical = 5.dp)
+                    .clickable(
+                        actionRunCallback<CompleteChoreCallback>(
+                            actionParametersOf(SYNC_ID_KEY to chore.syncId),
+                        ),
+                    ),
+            )
+        }
+    }
+}
+
+class SoonListWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SoonListWidget()
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="custom_url_scheme">com.lastglance.app</string>
     <string name="heatmap_widget_description">Your recent completion activity at a glance.</string>
     <string name="single_chore_widget_description">The chore most in need of attention, with one-tap done.</string>
+    <string name="soon_list_widget_description">Chores that need attention soon, with one-tap done.</string>
+    <string name="soon_list_widget_title">Soon</string>
     <string name="widget_done">Done</string>
     <string name="widget_all_caught_up">All caught up</string>
 </resources>

--- a/android/app/src/main/res/xml/soon_list_widget_info.xml
+++ b/android/app/src/main/res/xml/soon_list_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="150dp"
+    android:targetCellWidth="3"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="0"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewImage="@mipmap/ic_launcher"
+    android:description="@string/soon_list_widget_description" />

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -264,27 +264,29 @@ time (test on Doze via `adb shell dumpsys deviceidle force-idle`).
 
 ### Phase 2 — Action widgets + optimistic tap-to-complete — 🚧 IN PROGRESS
 
-**Decision (resolved):** widgets use **Jetpack Glance** (Kotlin + Compose). This
-adds a toolchain to the Java project: Kotlin 2.2.0 + the Compose compiler plugin
-+ `androidx.glance:glance-appwidget`/`glance-material3` 1.1.1 (`buildFeatures.compose`,
-`jvmTarget 21`). **Not compilable in the dev environment** — the first on-device
-build is where any version mismatch surfaces and may need a round of adjustment.
+**Decision (resolved):** widgets use **Jetpack Glance** (Kotlin + Compose), toolchain
+Kotlin 2.2.0 + Compose plugin + Glance 1.1.1 (`buildFeatures.compose`, `jvmTarget 21`).
+**Toolchain compiles on-device** (verified). `GlanceTheme` lives in `androidx.glance`.
 
-**Built so far (Phase 2a):**
-- **Tap-to-complete spine** (tech-agnostic, verified): native completion queue in
-  `SharedDataStore`; `WidgetBridge.drainPendingCompletions`; web drain
-  `src/native/pendingCompletions.ts` + `usePendingCompletions` replays each via
-  `logCompletion(choreId, { syncId })` — idempotent on the native-minted sync_id.
-- **Single-chore Glance tile** (`glance/SingleChoreWidget.kt`): shows the
-  most-overdue chore (no config Activity needed yet) with a recency color bar and
-  one-tap **Done**. Done → optimistic snapshot update (instant, offline) + queue;
-  the app drains on next foreground. The bridge nudges the Glance widget to
-  recompose on every snapshot push.
+**Built & device-tested:**
+- **Tap-to-complete spine**: native completion queue in `SharedDataStore`;
+  `WidgetBridge.drainPendingCompletions`; web drain `pendingCompletions.ts` +
+  `usePendingCompletions` replays each via `logCompletion(choreId, { syncId,
+  completedByUserSyncId })` — idempotent on the native-minted sync_id.
+- **Single-chore Glance tile** (`glance/SingleChoreWidget.kt`): most-overdue chore,
+  recency color bar **+ the chore's Lucide icon** (full set shipped as vector
+  drawables via `scripts/gen-lucide-drawables.mjs`, tinted to the recency color),
+  one-tap **Done** (optimistic snapshot update + queue).
 
-**Still to do:** the Soon/overdue **list** widget; a configuration Activity for a
-user-picked single-chore tile; the deep-link router so widget body-taps open the
-specific chore (today they just open the app). Possible later: migrate the Phase 0
-heatmap from RemoteViews to Glance for uniformity.
+**Built, awaiting device test:**
+- **Soon/overdue list widget** (`glance/SoonListWidget.kt`): Glance `LazyColumn` of
+  soon+overdue chores (most-overdue first, cap 25), shared row styling + Done
+  action with the tile. A completion refreshes both widgets (`updateAll`).
+
+**Still to do:** the **deep-link router** so a widget body-tap opens the specific
+chore (today taps only open the app / complete via Done); a configuration Activity
+for a user-picked single-chore tile. Possible later: migrate the Phase 0 heatmap
+from RemoteViews to Glance for uniformity.
 
 **Original goal:** the marquee widgets, with completion that *feels instant* and is
 *safe*.


### PR DESCRIPTION
Next Phase 2 step: the marquee **Soon/overdue list widget**.

## What's here

A Glance `LazyColumn` listing soon + overdue chores (most-overdue first, capped at 25). Each row shares the single-chore tile's styling — **recency color bar, the chore's Lucide icon (tinted to the recency color), name, "Xd ago", and one-tap Done**. Empty state shows "All caught up".

- `glance/SoonListWidget.kt` — the widget + receiver + row composable.
- Reuses the existing spine: `ChoreData`, `ChoreSnapshot` (new `pickSoonList`), and `CompleteChoreCallback`. The callback now refreshes **both** widgets via `updateAll`, and `WidgetBridgePlugin` nudges both Glance widgets on each snapshot push.
- `res/xml/soon_list_widget_info.xml`, manifest receiver, strings.

So a Done tap → optimistic snapshot update + queued completion (same idempotent drain as the tile), and both widgets stay in sync.

## Testing

- ✅ Web build unaffected; **112/112** tests pass; XML valid.
- ⚠️ **Native unverified here** (no Android SDK). Watch on the device build: the Glance `LazyColumn` / `items(List)` API and the `updateAll` import.

## Still to come in Phase 2 (separate PRs)

- Deep-link router so a row **body**-tap opens that specific chore (today taps complete via Done / open the app).
- A configuration Activity for a user-picked single-chore tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_