### PR TITLE
Android: deep-link router (widget body-taps open the chore)

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -1,5 +1,7 @@
 package com.lastglance.app;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 
 import com.getcapacitor.BridgeActivity;
@@ -10,5 +12,28 @@ public class MainActivity extends BridgeActivity {
         // Register app-local plugins before the bridge starts.
         registerPlugin(WidgetBridgePlugin.class);
         super.onCreate(savedInstanceState);
+        captureWidgetDeepLink(getIntent());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        captureWidgetDeepLink(intent);
+    }
+
+    // Widget body-taps launch this activity with a lastglance:// URI. Stash the
+    // target so the web app can route it on foreground (see consumeDeepLink /
+    // routeWidgetDeepLink). The web app owns navigation; we just hand off.
+    private void captureWidgetDeepLink(Intent intent) {
+        if (intent == null) return;
+        Uri data = intent.getData();
+        if (data == null || !"lastglance".equals(data.getScheme())) return;
+        String host = data.getHost();
+        if ("chore".equals(host)) {
+            String syncId = data.getLastPathSegment();
+            if (syncId != null) SharedDataStore.writePendingDeepLink(this, "chore:" + syncId);
+        } else if ("filter".equals(host)) {
+            SharedDataStore.writePendingDeepLink(this, "filter:soon");
+        }
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
+++ b/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
@@ -16,6 +16,9 @@ public final class SharedDataStore {
     // Completions logged from a widget tap, awaiting drain into the DB by the
     // web app on next foreground (a widget can't write IndexedDB itself).
     private static final String KEY_PENDING = "pending_completions";
+    // A widget body-tap target ("chore:<syncId>" or "filter:soon") captured by
+    // MainActivity, consumed by the web app on foreground.
+    private static final String KEY_DEEPLINK = "pending_deeplink";
 
     private SharedDataStore() {}
 
@@ -53,5 +56,15 @@ public final class SharedDataStore {
         String raw = prefs(context).getString(KEY_PENDING, "[]");
         prefs(context).edit().remove(KEY_PENDING).apply();
         return raw;
+    }
+
+    public static void writePendingDeepLink(Context context, String value) {
+        prefs(context).edit().putString(KEY_DEEPLINK, value).apply();
+    }
+
+    public static String readAndClearPendingDeepLink(Context context) {
+        String value = prefs(context).getString(KEY_DEEPLINK, null);
+        if (value != null) prefs(context).edit().remove(KEY_DEEPLINK).apply();
+        return value;
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
@@ -45,6 +45,15 @@ public class WidgetBridgePlugin extends Plugin {
         call.resolve(ret);
     }
 
+    // Hand the pending widget body-tap target to the web app, and clear it.
+    @PluginMethod
+    public void consumeDeepLink(PluginCall call) {
+        String value = SharedDataStore.readAndClearPendingDeepLink(getContext());
+        JSObject ret = new JSObject();
+        ret.put("deepLink", value);
+        call.resolve(ret);
+    }
+
     // Nudge a Glance widget to recompose from the freshly written snapshot.
     private static void refreshGlanceWidget(Context context, Class<?> receiver) {
         ComponentName component = new ComponentName(context, receiver);

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -1,6 +1,8 @@
 package com.lastglance.app.glance
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -12,6 +14,7 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.action.ActionParameters
 import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
@@ -35,6 +38,7 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
+import com.lastglance.app.MainActivity
 import com.lastglance.app.R
 import com.lastglance.app.SharedDataStore
 import org.json.JSONObject
@@ -51,6 +55,21 @@ import java.util.UUID
 // foreground (see SharedDataStore + drainWidgetCompletions on the web side).
 
 internal val SYNC_ID_KEY = ActionParameters.Key<String>("choreSyncId")
+
+// Explicit intents that launch the app to a specific chore / the Soon view. The
+// unique data URI also keeps each widget element's PendingIntent distinct
+// (filterEquals ignores extras), so rows don't collide onto one target.
+internal fun openChoreIntent(context: Context, syncId: String): Intent =
+    Intent(context, MainActivity::class.java)
+        .setAction(Intent.ACTION_VIEW)
+        .setData(Uri.parse("lastglance://chore/$syncId"))
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+
+internal fun openSoonIntent(context: Context): Intent =
+    Intent(context, MainActivity::class.java)
+        .setAction(Intent.ACTION_VIEW)
+        .setData(Uri.parse("lastglance://filter/soon"))
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
 
 internal data class ChoreData(
     val syncId: String,
@@ -242,7 +261,13 @@ class SingleChoreWidget : GlanceAppWidget() {
                 .fillMaxSize()
                 .background(GlanceTheme.colors.surface)
                 .cornerRadius(16.dp)
-                .padding(12.dp),
+                .padding(12.dp)
+                .clickable(
+                    actionStartActivity(
+                        if (chore != null) openChoreIntent(context, chore.syncId)
+                        else openSoonIntent(context),
+                    ),
+                ),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (chore == null) {

--- a/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
@@ -12,6 +12,7 @@ import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
@@ -86,7 +87,10 @@ class SoonListWidget : GlanceAppWidget() {
     @Composable
     private fun ChoreListRow(context: Context, chore: ChoreData) {
         Row(
-            modifier = GlanceModifier.fillMaxWidth().padding(vertical = 5.dp),
+            modifier = GlanceModifier
+                .fillMaxWidth()
+                .padding(vertical = 5.dp)
+                .clickable(actionStartActivity(openChoreIntent(context, chore.syncId))),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Spacer(

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -283,10 +283,18 @@ Kotlin 2.2.0 + Compose plugin + Glance 1.1.1 (`buildFeatures.compose`, `jvmTarge
   soon+overdue chores (most-overdue first, cap 25), shared row styling + Done
   action with the tile. A completion refreshes both widgets (`updateAll`).
 
-**Still to do:** the **deep-link router** so a widget body-tap opens the specific
-chore (today taps only open the app / complete via Done); a configuration Activity
-for a user-picked single-chore tile. Possible later: migrate the Phase 0 heatmap
-from RemoteViews to Glance for uniformity.
+**Built, awaiting device test:**
+- **Deep-link router**: widget body-taps launch `MainActivity` with a
+  `lastglance://chore/<syncId>` or `lastglance://filter/soon` URI; `MainActivity`
+  stashes the target in `SharedDataStore`; the web app consumes it on foreground
+  (`consumeDeepLink` → `routeWidgetDeepLink` → reuses the pending-open mechanism
+  for a chore, or sets the attention filter for "soon"). The unique data URI also
+  keeps each row's `PendingIntent` distinct (filterEquals ignores extras). Wires
+  the single-chore tile body, every Soon-list row, and the heatmap "soon" tap.
+
+**Still to do:** a configuration Activity for a user-picked single-chore tile.
+Possible later: migrate the Phase 0 heatmap from RemoteViews to Glance for
+uniformity.
 
 **Original goal:** the marquee widgets, with completion that *feels instant* and is
 *safe*.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { useNotifications } from '@/hooks/useNotifications'
 import { useWidgetSnapshot } from '@/hooks/useWidgetSnapshot'
 import { useReminders } from '@/hooks/useReminders'
 import { usePendingCompletions } from '@/hooks/usePendingCompletions'
+import { usePendingDeepLink } from '@/hooks/usePendingDeepLink'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { useDbIntentsPoller } from '@/hooks/useDbIntentsPoller'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
@@ -126,6 +127,7 @@ function AppInner() {
   useWidgetSnapshot()
   useReminders()
   usePendingCompletions()
+  usePendingDeepLink()
   const { refreshConfig } = useIntents()
   const usersCtx = useUsers()
   const reloadUsers = usersCtx.reload
@@ -375,6 +377,14 @@ function AppInner() {
     window.addEventListener('lg:sync-applied', loadHeatmap)
     return () => window.removeEventListener('lg:sync-applied', loadHeatmap)
   }, [loadHeatmap])
+
+  // A widget "Soon" tap (heatmap, or the empty single-chore tile) switches on the
+  // attention filter once the app is foregrounded.
+  useEffect(() => {
+    function onFilterSoon() { setAttentionOnly(true) }
+    window.addEventListener('lg:widget-filter-soon', onFilterSoon)
+    return () => window.removeEventListener('lg:widget-filter-soon', onFilterSoon)
+  }, [setAttentionOnly])
 
   function toggleTheme() {
     setIsDark(d => !d)

--- a/src/hooks/usePendingDeepLink.ts
+++ b/src/hooks/usePendingDeepLink.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+import { Capacitor } from '@capacitor/core'
+import { routeWidgetDeepLink } from '@/native/pendingDeepLink'
+
+// Consume a widget body-tap deep link on mount and on each return to foreground.
+// No-op off Android.
+export function usePendingDeepLink(): void {
+  useEffect(() => {
+    if (Capacitor.getPlatform() !== 'android') return
+
+    routeWidgetDeepLink()
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') routeWidgetDeepLink()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => document.removeEventListener('visibilitychange', onVisibility)
+  }, [])
+}

--- a/src/native/pendingDeepLink.ts
+++ b/src/native/pendingDeepLink.ts
@@ -1,0 +1,17 @@
+import { consumeDeepLink } from './widgetBridge'
+import { setPendingOpenChore } from './pendingOpenChore'
+
+// Route a widget body-tap target captured natively (see MainActivity). A chore
+// tap reuses the durable pending-open mechanism (the Ribbon consumes it once its
+// data has loaded, so cold-start ordering doesn't matter); a "soon" tap asks the
+// app to switch on the attention filter.
+export async function routeWidgetDeepLink(): Promise<void> {
+  const link = await consumeDeepLink()
+  if (!link) return
+  if (link.startsWith('chore:')) {
+    setPendingOpenChore(link.slice('chore:'.length))
+    window.dispatchEvent(new Event('lg:open-chore-pending'))
+  } else if (link === 'filter:soon') {
+    window.dispatchEvent(new Event('lg:widget-filter-soon'))
+  }
+}

--- a/src/native/widgetBridge.ts
+++ b/src/native/widgetBridge.ts
@@ -10,6 +10,8 @@ export interface WidgetBridgePlugin {
   // Return and clear the queue of completions logged from widgets (JSON array
   // string). The web app drains this into the DB on foreground.
   drainPendingCompletions(): Promise<{ completions: string }>
+  // Return and clear the pending widget body-tap target, or null.
+  consumeDeepLink(): Promise<{ deepLink: string | null }>
 }
 
 const WidgetBridge = registerPlugin<WidgetBridgePlugin>('WidgetBridge')
@@ -38,5 +40,15 @@ export async function drainPendingCompletions(): Promise<PendingCompletion[]> {
     return Array.isArray(arr) ? arr : []
   } catch {
     return []
+  }
+}
+
+export async function consumeDeepLink(): Promise<string | null> {
+  if (Capacitor.getPlatform() !== 'android') return null
+  try {
+    const res = await WidgetBridge.consumeDeepLink()
+    return res?.deepLink ?? null
+  } catch {
+    return null
   }
 }


### PR DESCRIPTION
Next Phase 2 step: tapping a widget's **body** (not just Done) now opens the specific chore, instead of just launching the app.

## How it works

1. Widget body-taps `actionStartActivity` to `MainActivity` with a `lastglance://chore/<syncId>` (or `lastglance://filter/soon`) URI.
2. `MainActivity` captures the launch/`onNewIntent` URI and stashes the target in `SharedDataStore`.
3. The web app consumes it on foreground: `WidgetBridge.consumeDeepLink` → `src/native/pendingDeepLink.ts` → `usePendingDeepLink`. A chore reuses the **durable pending-open mechanism** (the Ribbon opens its log modal once data loads — so cold-start ordering doesn't matter); `soon` switches on the attention filter.

Wired for the single-chore tile body, **every Soon-list row**, and the heatmap "soon" tap (which previously only opened the app).

## Detail worth noting

Each chore's intent carries a unique data URI, which keeps each row's `PendingIntent` distinct — Android's `filterEquals` ignores extras, so without distinct data all rows would collide onto one target.

## Testing

- ✅ Web build green; **112/112** tests pass.
- ⚠️ **Native unverified here** (no Android SDK). Watch the Glance `actionStartActivity(Intent)` path and the `MainActivity.onNewIntent` capture on the device build.

## Still to come in Phase 2

A configuration Activity for a user-picked single-chore tile (the last item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_