### PR TITLE
fix(android): use Intent-based actionStartActivity (appwidget.action)

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -14,8 +14,8 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.action.ActionParameters
 import androidx.glance.action.actionParametersOf
-import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
+import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.action.ActionCallback

--- a/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
@@ -12,8 +12,8 @@ import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.action.actionParametersOf
-import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
+import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.action.actionRunCallback


### PR DESCRIPTION
androidx.glance.action.actionStartActivity only takes a ComponentName; the Intent overload is in androidx.glance.appwidget.action. Fixes the compileReleaseKotlin argument-type-mismatch in both Glance widgets.


Claude-Session: https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA