### PR TITLE
Android: heatmap widget — 26 weeks + footer

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
@@ -18,12 +18,20 @@ import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
+import androidx.compose.ui.unit.sp
 import androidx.glance.background
-import androidx.glance.layout.Box
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
 import androidx.glance.layout.ContentScale
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import com.lastglance.app.R
 import com.lastglance.app.SharedDataStore
 import org.json.JSONObject
 import java.text.SimpleDateFormat
@@ -35,15 +43,16 @@ import java.util.Locale
 // shown via Image; tapping opens the app to the Soon view through the deep-link
 // router. Renders from the snapshot the web app pushes — no DB access.
 
-private const val WEEKS = 18
+private const val WEEKS = 26
 private const val DAYS = 7
 
 class HeatmapWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val bitmap = renderHeatmap(context)
+        val (overdue, soon) = readCounts(context)
         provideContent {
             GlanceTheme {
-                Box(
+                Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
                         .background(GlanceTheme.colors.surface)
@@ -57,10 +66,51 @@ class HeatmapWidget : GlanceAppWidget() {
                         modifier = GlanceModifier.fillMaxWidth(),
                         contentScale = ContentScale.Fit,
                     )
+                    // Fill any leftover height, then a footer: wordmark + a live stat.
+                    Spacer(modifier = GlanceModifier.defaultWeight())
+                    Row(
+                        modifier = GlanceModifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            "last",
+                            style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 13.sp),
+                        )
+                        Text(
+                            "GLANCE",
+                            style = TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 13.sp,
+                            ),
+                        )
+                        Spacer(modifier = GlanceModifier.defaultWeight())
+                        Text(
+                            statText(context, overdue, soon),
+                            style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp),
+                        )
+                    }
                 }
             }
         }
     }
+}
+
+private fun readCounts(context: Context): Pair<Int, Int> {
+    val raw = SharedDataStore.readSnapshot(context) ?: return 0 to 0
+    return try {
+        val counts = JSONObject(raw).optJSONObject("counts") ?: return 0 to 0
+        counts.optInt("overdue", 0) to counts.optInt("soon", 0)
+    } catch (e: Exception) {
+        0 to 0
+    }
+}
+
+private fun statText(context: Context, overdue: Int, soon: Int): String = when {
+    overdue > 0 && soon > 0 -> "$overdue overdue · $soon soon"
+    overdue > 0 -> "$overdue overdue"
+    soon > 0 -> "$soon soon"
+    else -> context.getString(R.string.widget_all_caught_up)
 }
 
 class HeatmapWidgetReceiver : GlanceAppWidgetReceiver() {

--- a/src/native/snapshot.ts
+++ b/src/native/snapshot.ts
@@ -4,7 +4,8 @@ import { pushWidgetSnapshot } from './widgetBridge'
 import dayjs from 'dayjs'
 
 // How many days of completion history to ship to the heatmap widget.
-const HEATMAP_DAYS = 120
+// ~27 weeks, so the 26-week widget grid is fully covered (with week alignment).
+const HEATMAP_DAYS = 190
 
 export type ChoreState = 'fresh' | 'soon' | 'overdue' | 'none'
 


### PR DESCRIPTION
Polish for the heatmap widget.

## Changes

- **26 weeks** of history instead of 18. The snapshot only carried ~17 weeks (`HEATMAP_DAYS = 120`), so older columns would have rendered blank — bumped to **190 days (~27 weeks)** to fully cover the wider grid with week-alignment slack.
- **Use the leftover vertical space.** With the wide grid fit to width, there was blank space below; it now holds a footer row: the **lastGLANCE wordmark** (left) and a **live stat** (right) from the snapshot counts — `N overdue · N soon`, or `N overdue` / `N soon`, or "All caught up". A weighted spacer pins the footer to the bottom regardless of widget height.

## Testing

- ✅ Web build green; **112/112** tests pass.
- ⚠️ **Native unverified here** (no Android SDK). On device, confirm the grid shows 26 weeks and the footer fills the bottom (and the stat reads correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_