### PR TITLE
Android: widget polish — wordmark, heatmap void, list width, picker labels

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
 
         <receiver
             android:name=".glance.HeatmapWidgetReceiver"
+            android:label="@string/widget_label_activity"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -51,6 +52,7 @@
 
         <receiver
             android:name=".glance.SingleChoreWidgetReceiver"
+            android:label="@string/widget_label_chore"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -62,6 +64,7 @@
 
         <receiver
             android:name=".glance.SoonListWidgetReceiver"
+            android:label="@string/widget_label_soon"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
@@ -18,6 +18,7 @@ import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -28,9 +29,11 @@ import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
+import androidx.glance.text.FontStyle
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
 import com.lastglance.app.R
 import com.lastglance.app.SharedDataStore
 import org.json.JSONObject
@@ -60,28 +63,35 @@ class HeatmapWidget : GlanceAppWidget() {
                         .padding(12.dp)
                         .clickable(actionStartActivity(openSoonIntent(context))),
                 ) {
+                    // The grid takes all the space above the footer and centers
+                    // within it (no big void dumped at the bottom).
                     Image(
                         provider = ImageProvider(bitmap),
                         contentDescription = null,
-                        modifier = GlanceModifier.fillMaxWidth(),
+                        modifier = GlanceModifier.defaultWeight().fillMaxWidth(),
                         contentScale = ContentScale.Fit,
                     )
-                    // Fill any leftover height, then a footer: wordmark + a live stat.
-                    Spacer(modifier = GlanceModifier.defaultWeight())
+                    // Footer: the lastGLANCE wordmark (last + italic green GLANCE,
+                    // matching the app) and a live stat.
                     Row(
                         modifier = GlanceModifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
                             "last",
-                            style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 13.sp),
+                            style = TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 16.sp,
+                            ),
                         )
                         Text(
                             "GLANCE",
                             style = TextStyle(
-                                color = GlanceTheme.colors.onSurface,
+                                color = ColorProvider(Color(0xFF3DDC84)),
                                 fontWeight = FontWeight.Bold,
-                                fontSize = 13.sp,
+                                fontStyle = FontStyle.Italic,
+                                fontSize = 16.sp,
                             ),
                         )
                         Spacer(modifier = GlanceModifier.defaultWeight())

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,4 +11,7 @@
     <string name="widget_done">Done</string>
     <string name="widget_all_caught_up">All caught up</string>
     <string name="widget_config_auto">Most overdue (automatic)</string>
+    <string name="widget_label_activity">lastGLANCE Activity</string>
+    <string name="widget_label_chore">lastGLANCE Chore</string>
+    <string name="widget_label_soon">lastGLANCE Soon</string>
 </resources>

--- a/android/app/src/main/res/xml/heatmap_widget_info.xml
+++ b/android/app/src/main/res/xml/heatmap_widget_info.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:minWidth="250dp"
-    android:minHeight="110dp"
+    android:minHeight="100dp"
+    android:minResizeHeight="70dp"
     android:targetCellWidth="4"
-    android:targetCellHeight="2"
+    android:targetCellHeight="1"
     android:updatePeriodMillis="0"
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"

--- a/android/app/src/main/res/xml/soon_list_widget_info.xml
+++ b/android/app/src/main/res/xml/soon_list_widget_info.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
+    android:minWidth="160dp"
     android:minHeight="150dp"
-    android:targetCellWidth="3"
+    android:minResizeWidth="140dp"
+    android:targetCellWidth="2"
     android:targetCellHeight="3"
     android:updatePeriodMillis="0"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
Fixes from on-device feedback.

## Changes

1. **Stylized wordmark.** The heatmap footer now renders the app's actual lockup — `last` (bold, theme color) + `GLANCE` (bold **italic green** `#3DDC84`) — matching `App.tsx`. The wordmark SVG is just system-font text, so Roboto reproduces it faithfully and stays theme-aware (shipping the white-on-transparent PNG would vanish in light mode).
2. **Heatmap bottom void.** The grid was pinned to the top with the footer dumped at the bottom, leaving a big gap. The grid now takes the space above the footer and centers within it (weighted `Image`), and the default height is reduced (`targetCellHeight` 2 → 1) so it hugs the content.
3. **Soon list width.** `minWidth` 250 → 160 and `targetCellWidth` 3 → 2 (with `minResizeWidth`), so it can sit narrow and leave room for another widget beside it.
4. **Picker labels.** Each widget now has a distinct label — **lastGLANCE Activity / Chore / Soon** — instead of all showing as "lastGLANCE". This is the answer to "where's the widget that lets me pick a chore / stack several": it's **lastGLANCE Chore** (the configurable single-chore tile — place multiple, each set to a different chore).

## Testing

- ✅ Native-only change; web build/tests unaffected. XML valid.
- ⚠️ **Native unverified here.** On device: confirm the wordmark reads as the green-italic lockup, the heatmap has no big void (and resizes shorter), the Soon list goes narrow, and the three widgets are distinctly named in the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_