### PR TITLE
fix(android): resolve Color import ambiguity in HeatmapWidget

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
@@ -18,7 +18,6 @@ import androidx.glance.appwidget.GlanceAppWidgetReceiver
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
 import androidx.glance.background
 import androidx.glance.layout.Alignment
@@ -88,7 +87,7 @@ class HeatmapWidget : GlanceAppWidget() {
                         Text(
                             "GLANCE",
                             style = TextStyle(
-                                color = ColorProvider(Color(0xFF3DDC84)),
+                                color = ColorProvider(androidx.compose.ui.graphics.Color(0xFF3DDC84)),
                                 fontWeight = FontWeight.Bold,
                                 fontStyle = FontStyle.Italic,
                                 fontSize = 16.sp,


### PR DESCRIPTION
The Canvas renderer uses android.graphics.Color (parseColor) while the wordmark needs androidx.compose.ui.graphics.Color — importing both made Color ambiguous. Drop the compose import and fully-qualify the single wordmark usage.


Claude-Session: https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA