### PR TITLE
Android: fix config picker (persist + dialog + search) and bigger heatmap text

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
             android:name=".glance.SingleChoreConfigActivity"
             android:exported="true"
             android:label="@string/single_chore_widget_description"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.Dialog">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>

--- a/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
+++ b/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
@@ -58,19 +58,6 @@ public final class SharedDataStore {
         return raw;
     }
 
-    // Per-widget chosen chore (single-chore tile config). Null/absent = auto
-    // (most-overdue). Keyed by appWidgetId.
-    public static void writeWidgetChore(Context context, int appWidgetId, String syncId) {
-        SharedPreferences.Editor e = prefs(context).edit();
-        if (syncId == null) e.remove("widget_chore_" + appWidgetId);
-        else e.putString("widget_chore_" + appWidgetId, syncId);
-        e.apply();
-    }
-
-    public static String readWidgetChore(Context context, int appWidgetId) {
-        return prefs(context).getString("widget_chore_" + appWidgetId, null);
-    }
-
     public static void writePendingDeepLink(Context context, String value) {
         prefs(context).edit().putString(KEY_DEEPLINK, value).apply();
     }

--- a/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
@@ -81,7 +81,7 @@ class HeatmapWidget : GlanceAppWidget() {
                             style = TextStyle(
                                 color = GlanceTheme.colors.onSurface,
                                 fontWeight = FontWeight.Bold,
-                                fontSize = 16.sp,
+                                fontSize = 24.sp,
                             ),
                         )
                         Text(
@@ -90,13 +90,13 @@ class HeatmapWidget : GlanceAppWidget() {
                                 color = ColorProvider(androidx.compose.ui.graphics.Color(0xFF3DDC84)),
                                 fontWeight = FontWeight.Bold,
                                 fontStyle = FontStyle.Italic,
-                                fontSize = 16.sp,
+                                fontSize = 24.sp,
                             ),
                         )
                         Spacer(modifier = GlanceModifier.defaultWeight())
                         Text(
                             statText(context, overdue, soon),
-                            style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 12.sp),
+                            style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 18.sp),
                         )
                     }
                 }

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreConfigActivity.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreConfigActivity.kt
@@ -5,23 +5,43 @@ import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.widget.ArrayAdapter
+import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.ListView
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
 import com.lastglance.app.R
 import com.lastglance.app.SharedDataStore
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 
+// The per-widget chosen chore, stored in the widget's own Glance state (keyed by
+// glanceId) — the canonical Glance mechanism. SingleChoreWidget reads it via
+// currentState.
+internal val CHORE_PREF_KEY = stringPreferencesKey("chore")
+
 // Configuration screen shown when a single-chore tile is placed: pick which chore
-// it tracks (or "automatic" = most overdue). Plain Activity + ListView so it needs
-// no Compose-UI dependencies. Choices come from the snapshot the web app pushes.
+// it tracks (or "automatic" = most overdue), with a search box for large lists.
+// Plain Activity + ListView (no Compose-UI deps); shown as a dialog. Choices come
+// from the snapshot the web app pushes.
 class SingleChoreConfigActivity : Activity() {
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
+    // (syncId, label); the first entry is the "automatic" option with a null syncId.
+    private val all = ArrayList<Pair<String?, String>>()
+    private val shown = ArrayList<Pair<String?, String>>()
+    private lateinit var adapter: ArrayAdapter<String>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // If the user backs out, the host cancels placement.
-        setResult(RESULT_CANCELED)
+        setResult(RESULT_CANCELED) // backing out cancels placement
+        setTitle(R.string.widget_config_title)
 
         appWidgetId = intent?.extras?.getInt(
             AppWidgetManager.EXTRA_APPWIDGET_ID,
@@ -32,35 +52,64 @@ class SingleChoreConfigActivity : Activity() {
             return
         }
 
-        // First row is the automatic option (syncId null); the rest are chores.
-        val labels = ArrayList<String>()
-        val syncIds = ArrayList<String?>()
-        labels.add(getString(R.string.widget_config_auto))
-        syncIds.add(null)
-        for ((syncId, name) in readChores(this)) {
-            labels.add(name)
-            syncIds.add(syncId)
-        }
+        all.add(null to getString(R.string.widget_config_auto))
+        for ((syncId, name) in readChores(this)) all.add(syncId to name)
+        shown.addAll(all)
 
-        val list = ListView(this)
-        list.adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, labels)
-        list.setOnItemClickListener { _, _, position, _ ->
-            SharedDataStore.writeWidgetChore(this, appWidgetId, syncIds[position])
-            kickWidget()
-            setResult(
-                RESULT_OK,
-                Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId),
-            )
-            finish()
+        val pad = (16 * resources.displayMetrics.density).toInt()
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(pad, pad, pad, 0)
         }
-        setContentView(list)
+        val search = EditText(this).apply {
+            hint = getString(R.string.widget_config_search)
+            setSingleLine()
+        }
+        val list = ListView(this)
+        adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, shown.map { it.second }.toMutableList())
+        list.adapter = adapter
+        root.addView(
+            search,
+            LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT),
+        )
+        root.addView(
+            list,
+            LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT),
+        )
+        setContentView(root)
+
+        search.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {
+                val q = s?.toString()?.trim()?.lowercase().orEmpty()
+                shown.clear()
+                shown.add(all[0]) // keep the automatic option pinned at the top
+                for (i in 1 until all.size) {
+                    if (q.isEmpty() || all[i].second.lowercase().contains(q)) shown.add(all[i])
+                }
+                adapter.clear()
+                adapter.addAll(shown.map { it.second })
+                adapter.notifyDataSetChanged()
+            }
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+        })
+
+        list.setOnItemClickListener { _, _, position, _ ->
+            choose(shown[position].first)
+        }
     }
 
-    private fun kickWidget() {
-        val intent = Intent(this, SingleChoreWidgetReceiver::class.java)
-            .setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
-            .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, intArrayOf(appWidgetId))
-        sendBroadcast(intent)
+    private fun choose(syncId: String?) {
+        MainScope().launch {
+            val glanceId = GlanceAppWidgetManager(this@SingleChoreConfigActivity).getGlanceIdBy(appWidgetId)
+            updateAppWidgetState(this@SingleChoreConfigActivity, glanceId) { prefs ->
+                if (syncId == null) prefs.remove(CHORE_PREF_KEY) else prefs[CHORE_PREF_KEY] = syncId
+            }
+            SingleChoreWidget().update(this@SingleChoreConfigActivity, glanceId)
+            setResult(RESULT_OK, Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId))
+            finish()
+        }
     }
 
     private fun readChores(context: Context): List<Pair<String, String>> {

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -16,9 +16,10 @@ import androidx.glance.action.ActionParameters
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionStartActivity
+import androidx.datastore.preferences.core.Preferences
 import androidx.glance.appwidget.GlanceAppWidget
-import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.currentState
 import androidx.glance.appwidget.action.ActionCallback
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.cornerRadius
@@ -260,13 +261,12 @@ class CompleteChoreCallback : ActionCallback {
 
 class SingleChoreWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
-        // A per-widget configured chore (set in SingleChoreConfigActivity) wins;
-        // otherwise fall back to the most-overdue chore.
-        val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(id)
-        val configured = SharedDataStore.readWidgetChore(context, appWidgetId)
-        val chore = if (configured != null) ChoreSnapshot.pickBySyncId(context, configured)
-            else ChoreSnapshot.pickMostOverdue(context)
         provideContent {
+            // A per-widget configured chore (set in SingleChoreConfigActivity, stored
+            // in this widget's Glance state) wins; else fall back to most-overdue.
+            val configured = currentState<Preferences>()[CHORE_PREF_KEY]
+            val chore = if (configured != null) ChoreSnapshot.pickBySyncId(context, configured)
+                else ChoreSnapshot.pickMostOverdue(context)
             GlanceTheme {
                 Content(context, chore)
             }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="widget_done">Done</string>
     <string name="widget_all_caught_up">All caught up</string>
     <string name="widget_config_auto">Most overdue (automatic)</string>
+    <string name="widget_config_title">Choose a chore</string>
+    <string name="widget_config_search">Search chores</string>
     <string name="widget_label_activity">lastGLANCE Activity</string>
     <string name="widget_label_chore">lastGLANCE Chore</string>
     <string name="widget_label_soon">lastGLANCE Soon</string>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -19,4 +19,7 @@
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
         <item name="android:background">@drawable/splash</item>
     </style>
+
+    <!-- Floating dialog for the single-chore widget config picker (day/night). -->
+    <style name="AppTheme.Dialog" parent="Theme.AppCompat.DayNight.Dialog" />
 </resources>


### PR DESCRIPTION
From on-device feedback.

## 1. Heatmap text ~1.5×
Wordmark 16 → 24sp, stat 12 → 18sp.

## 2. Single-chore config picker — rebuilt
- **Selection now persists.** Root cause: the chosen chore was stored in appWidgetId-keyed SharedPreferences and read back via `GlanceAppWidgetManager.getAppWidgetId` — which wasn't resolving to the configured value, so the tile always fell back to most-overdue. Switched to the **canonical Glance state mechanism**: `updateAppWidgetState`/`currentState<Preferences>()` keyed by `glanceId`, with an explicit `update()` after writing. Removed the dead SharedDataStore methods.
- **No longer full-screen / behind the status bar.** Shown as a **floating dialog** (`AppTheme.Dialog`, day/night) instead of a full-screen activity.
- **Search box** to filter chores (for users with many), with "Most overdue (automatic)" pinned at the top.

## Testing
- ✅ Native-only; web build/tests unaffected; XML valid; no dangling refs.
- ⚠️ **Unverified here.** This uses several Glance state APIs (`currentState`, `updateAppWidgetState`, `getGlanceIdBy`) and datastore `Preferences` (transitive via Glance, which exposes it in its public API). If the first build complains it can't resolve `Preferences`/`stringPreferencesKey`, the fix is a one-line explicit `androidx.datastore:datastore-preferences-core` dependency — tell me and I'll add it. Also worth confirming the AppCompat dialog theme renders fine on the plain Activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_