### PR TITLE
Android: Soon widget min width 180dp (2-cell default); picker timing logs

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreConfigActivity.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreConfigActivity.kt
@@ -41,7 +41,9 @@ class SingleChoreConfigActivity : AppCompatActivity() {
     private lateinit var adapter: ArrayAdapter<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val t0 = System.currentTimeMillis()
         super.onCreate(savedInstanceState)
+        android.util.Log.d("lgWidgetCfg", "onCreate (process+super) reached")
         setResult(RESULT_CANCELED) // backing out cancels placement
         setTitle(R.string.widget_config_title)
 
@@ -78,6 +80,7 @@ class SingleChoreConfigActivity : AppCompatActivity() {
             LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT),
         )
         setContentView(root)
+        android.util.Log.d("lgWidgetCfg", "setContentView done +${System.currentTimeMillis() - t0}ms")
 
         search.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable?) { applyFilter(s?.toString().orEmpty()) }
@@ -93,7 +96,9 @@ class SingleChoreConfigActivity : AppCompatActivity() {
         // thread so the dialog appears immediately (just the automatic option),
         // then fill in the chores.
         MainScope().launch {
+            val ts = System.currentTimeMillis()
             val items = withContext(Dispatchers.IO) { readChores(this@SingleChoreConfigActivity) }
+            android.util.Log.d("lgWidgetCfg", "readChores done +${System.currentTimeMillis() - ts}ms (${items.size} chores)")
             all.clear()
             all.add(null to getString(R.string.widget_config_auto))
             for ((syncId, name) in items) all.add(syncId to name)

--- a/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
@@ -23,12 +23,12 @@ import androidx.glance.appwidget.lazy.items
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
-import androidx.glance.layout.Box
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.width
@@ -93,8 +93,14 @@ class SoonListWidget : GlanceAppWidget() {
                 .clickable(actionStartActivity(openChoreIntent(context, chore.syncId))),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // The icon is tinted to the recency color, so it carries the color cue
-            // — no separate bar, to leave room for the name at narrow (2-cell) widths.
+            Spacer(
+                modifier = GlanceModifier
+                    .width(5.dp)
+                    .height(26.dp)
+                    .cornerRadius(2.dp)
+                    .background(ColorProvider(Color(chore.colorInt))),
+            )
+            Spacer(modifier = GlanceModifier.width(8.dp))
             if (chore.iconResId != 0) {
                 Image(
                     provider = ImageProvider(chore.iconResId),
@@ -116,31 +122,27 @@ class SoonListWidget : GlanceAppWidget() {
                 )
                 Text(
                     chore.elapsed,
-                    maxLines = 1,
                     style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 11.sp),
                 )
             }
-            Spacer(modifier = GlanceModifier.width(6.dp))
-            // Compact check button (instead of a wide "Done" label) so names fit.
-            Box(
+            Spacer(modifier = GlanceModifier.width(8.dp))
+            Text(
+                context.getString(R.string.widget_done),
+                style = TextStyle(
+                    color = ColorProvider(Color.White),
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 12.sp,
+                ),
                 modifier = GlanceModifier
-                    .size(34.dp)
-                    .cornerRadius(10.dp)
                     .background(ColorProvider(Color(0xFF22C55E)))
+                    .cornerRadius(8.dp)
+                    .padding(horizontal = 10.dp, vertical = 5.dp)
                     .clickable(
                         actionRunCallback<CompleteChoreCallback>(
                             actionParametersOf(SYNC_ID_KEY to chore.syncId),
                         ),
                     ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Image(
-                    provider = ImageProvider(R.drawable.ic_lucide_check),
-                    contentDescription = context.getString(R.string.widget_done),
-                    colorFilter = ColorFilter.tint(ColorProvider(Color.White)),
-                    modifier = GlanceModifier.size(18.dp),
-                )
-            }
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SoonListWidget.kt
@@ -23,12 +23,12 @@ import androidx.glance.appwidget.lazy.items
 import androidx.glance.appwidget.provideContent
 import androidx.glance.background
 import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
-import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
 import androidx.glance.layout.width
@@ -93,14 +93,8 @@ class SoonListWidget : GlanceAppWidget() {
                 .clickable(actionStartActivity(openChoreIntent(context, chore.syncId))),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Spacer(
-                modifier = GlanceModifier
-                    .width(5.dp)
-                    .height(26.dp)
-                    .cornerRadius(2.dp)
-                    .background(ColorProvider(Color(chore.colorInt))),
-            )
-            Spacer(modifier = GlanceModifier.width(8.dp))
+            // The icon is tinted to the recency color, so it carries the color cue
+            // — no separate bar, to leave room for the name at narrow (2-cell) widths.
             if (chore.iconResId != 0) {
                 Image(
                     provider = ImageProvider(chore.iconResId),
@@ -122,27 +116,31 @@ class SoonListWidget : GlanceAppWidget() {
                 )
                 Text(
                     chore.elapsed,
+                    maxLines = 1,
                     style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 11.sp),
                 )
             }
-            Spacer(modifier = GlanceModifier.width(8.dp))
-            Text(
-                context.getString(R.string.widget_done),
-                style = TextStyle(
-                    color = ColorProvider(Color.White),
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 12.sp,
-                ),
+            Spacer(modifier = GlanceModifier.width(6.dp))
+            // Compact check button (instead of a wide "Done" label) so names fit.
+            Box(
                 modifier = GlanceModifier
+                    .size(34.dp)
+                    .cornerRadius(10.dp)
                     .background(ColorProvider(Color(0xFF22C55E)))
-                    .cornerRadius(8.dp)
-                    .padding(horizontal = 10.dp, vertical = 5.dp)
                     .clickable(
                         actionRunCallback<CompleteChoreCallback>(
                             actionParametersOf(SYNC_ID_KEY to chore.syncId),
                         ),
                     ),
-            )
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    provider = ImageProvider(R.drawable.ic_lucide_check),
+                    contentDescription = context.getString(R.string.widget_done),
+                    colorFilter = ColorFilter.tint(ColorProvider(Color.White)),
+                    modifier = GlanceModifier.size(18.dp),
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/res/xml/soon_list_widget_info.xml
+++ b/android/app/src/main/res/xml/soon_list_widget_info.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="150dp"
+    android:minWidth="180dp"
     android:minHeight="150dp"
-    android:minResizeWidth="150dp"
+    android:minResizeWidth="180dp"
     android:targetCellWidth="2"
     android:targetCellHeight="3"
     android:updatePeriodMillis="0"

--- a/android/app/src/main/res/xml/soon_list_widget_info.xml
+++ b/android/app/src/main/res/xml/soon_list_widget_info.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="220dp"
+    android:minWidth="150dp"
     android:minHeight="150dp"
-    android:minResizeWidth="220dp"
-    android:targetCellWidth="3"
+    android:minResizeWidth="150dp"
+    android:targetCellWidth="2"
     android:targetCellHeight="3"
     android:updatePeriodMillis="0"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
## Soon widget — width only

The Soon row keeps its **original** design (recency color bar + "Done" label, two-line name/elapsed). The only change is the minimum width:

- `minWidth`/`minResizeWidth` → **180dp**, between the prior 160/140 and the briefly-tried 220/220, with a **2-cell default** (`targetCellWidth` 2).

> An earlier revision of this branch redesigned the row (dropped the color bar, swapped the "Done" label for a check-icon button, capped elapsed to one line). That was out of scope and has been **reverted** — content is back to the original; only the width changed.

## Picker 5s delay — instrumentation to find it

There's **no custom `Application`**, so the config activity isn't pulling in heavy app init — which makes a 5s launch abnormal, and I don't want to keep guessing. Added timing logs (tag `lgWidgetCfg`) at: process/super reached, `setContentView` done (+ms), and `readChores` done (+ms, chore count).

**To diagnose, please run while opening the Chore picker:**
```
adb logcat -s lgWidgetCfg:D
```
and paste the 3 lines. That tells us whether the 5s is before the dialog draws (process/launch) or in the chore-list load — and we fix the right thing.

## Testing
- ✅ Native-only; web build/tests unaffected; XML valid.
- ⚠️ Native unverified here. Confirm the Soon list looks like the original at its 2-cell min width, and grab the logcat timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_