### PR TITLE
Android: drop picker timing logs; heatmap hides stat when narrow

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
@@ -12,9 +12,11 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.LocalSize
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.appwidget.provideContent
@@ -49,11 +51,18 @@ private const val WEEKS = 26
 private const val DAYS = 7
 
 class HeatmapWidget : GlanceAppWidget() {
+    // Exact size mode so the content can react to the widget's real width — we
+    // drop the stat when it's resized narrow so the wordmark doesn't clip.
+    override val sizeMode = SizeMode.Exact
+
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val bitmap = renderHeatmap(context)
         val (overdue, soon) = readCounts(context)
         provideContent {
             GlanceTheme {
+                // At ~3 cells wide the wordmark + stat don't both fit; keep the
+                // wordmark and drop the stat below this width.
+                val showStat = LocalSize.current.width >= 280.dp
                 Column(
                     modifier = GlanceModifier
                         .fillMaxSize()
@@ -93,11 +102,13 @@ class HeatmapWidget : GlanceAppWidget() {
                                 fontSize = 24.sp,
                             ),
                         )
-                        Spacer(modifier = GlanceModifier.defaultWeight())
-                        Text(
-                            statText(context, overdue, soon),
-                            style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 18.sp),
-                        )
+                        if (showStat) {
+                            Spacer(modifier = GlanceModifier.defaultWeight())
+                            Text(
+                                statText(context, overdue, soon),
+                                style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 18.sp),
+                            )
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreConfigActivity.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreConfigActivity.kt
@@ -41,9 +41,7 @@ class SingleChoreConfigActivity : AppCompatActivity() {
     private lateinit var adapter: ArrayAdapter<String>
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val t0 = System.currentTimeMillis()
         super.onCreate(savedInstanceState)
-        android.util.Log.d("lgWidgetCfg", "onCreate (process+super) reached")
         setResult(RESULT_CANCELED) // backing out cancels placement
         setTitle(R.string.widget_config_title)
 
@@ -80,7 +78,6 @@ class SingleChoreConfigActivity : AppCompatActivity() {
             LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT),
         )
         setContentView(root)
-        android.util.Log.d("lgWidgetCfg", "setContentView done +${System.currentTimeMillis() - t0}ms")
 
         search.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable?) { applyFilter(s?.toString().orEmpty()) }
@@ -92,13 +89,12 @@ class SingleChoreConfigActivity : AppCompatActivity() {
             choose(shown[position].first)
         }
 
-        // Parsing the snapshot can be slow with many chores; load it off the main
-        // thread so the dialog appears immediately (just the automatic option),
-        // then fill in the chores.
+        // Read the snapshot off the main thread: it's a disk read (SharedPreferences)
+        // plus a JSON parse, which shouldn't run on the UI thread in onCreate
+        // (StrictMode flags it). The dialog shows the "automatic" option first, then
+        // fills in the chores once loaded.
         MainScope().launch {
-            val ts = System.currentTimeMillis()
             val items = withContext(Dispatchers.IO) { readChores(this@SingleChoreConfigActivity) }
-            android.util.Log.d("lgWidgetCfg", "readChores done +${System.currentTimeMillis() - ts}ms (${items.size} chores)")
             all.clear()
             all.add(null to getString(R.string.widget_config_auto))
             for ((syncId, name) in items) all.add(syncId to name)


### PR DESCRIPTION
Follow-up cleanup + a heatmap polish from on-device testing.

## 1. Remove the picker timing logs
The picker "5s to open" delay was traced to a **device-side launcher transition**, not our code — on-device logs showed the config activity does everything in **~30ms** (`onCreate` → chores parsed), and the gap is the Pixel's widget-placement transition timing out (~5s), confirmed by it reproducing across two launchers on the Pixel but being **instant on a Samsung**. So the `lgWidgetCfg` timing logs have done their job and are removed (logs + `System.currentTimeMillis()` scaffolding).

Kept: the **off-main-thread snapshot load** in the config activity. We added it under the (wrong) assumption that parsing was slow, but it's still correct — it's a disk read (SharedPreferences) + JSON parse that shouldn't run on the UI thread in `onCreate` (StrictMode would flag it). Its comment is corrected to state the real reason instead of the debunked "dialog appears immediately."

## 2. Heatmap: drop the stat when narrow, keep the wordmark
When the heatmap is resized down (~3 cells), the wordmark + `N overdue · N soon` stat don't both fit and the wordmark clips. The widget now uses `SizeMode.Exact` and **hides the stat below ~280dp** while always keeping the wordmark. At the default/wider size the stat still shows. (280dp is tunable if the cut-off feels off on your grid.)

## Testing
- ✅ Web build green; native-only changes otherwise unaffected.
- ⚠️ Native unverified here. On device, confirm: resizing the heatmap narrow drops the stat but keeps the wordmark intact (no clipping), and the stat returns at full width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_