### PR TITLE
Android: app shortcuts (Soon/Search/Add + top-overdue) and Add-chore widget

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
 
         <provider
@@ -72,6 +75,18 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/soon_list_widget_info" />
+        </receiver>
+
+        <receiver
+            android:name=".glance.AddChoreWidgetReceiver"
+            android:label="@string/widget_label_add"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/add_chore_widget_info" />
         </receiver>
     </application>
 

--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -21,19 +21,38 @@ public class MainActivity extends BridgeActivity {
         captureWidgetDeepLink(intent);
     }
 
-    // Widget body-taps launch this activity with a lastglance:// URI. Stash the
-    // target so the web app can route it on foreground (see consumeDeepLink /
-    // routeWidgetDeepLink). The web app owns navigation; we just hand off.
+    // Widget body-taps and launcher shortcuts launch this activity with a
+    // lastglance:// URI (and, for static shortcuts, an "lglink" extra fallback in
+    // case the URI is dropped). Stash the target so the web app can route it on
+    // foreground (see consumeDeepLink / routeWidgetDeepLink). The web app owns
+    // navigation; we just hand off.
     private void captureWidgetDeepLink(Intent intent) {
         if (intent == null) return;
+        String link = null;
         Uri data = intent.getData();
-        if (data == null || !"lastglance".equals(data.getScheme())) return;
+        if (data != null && "lastglance".equals(data.getScheme())) {
+            link = linkFromUri(data);
+        }
+        if (link == null) {
+            link = intent.getStringExtra("lglink"); // already in internal token form
+        }
+        if (link != null) SharedDataStore.writePendingDeepLink(this, link);
+    }
+
+    // Map a lastglance:// URI to the internal pending-deep-link token the web app
+    // consumes. Returns null for anything unrecognized.
+    private String linkFromUri(Uri data) {
         String host = data.getHost();
         if ("chore".equals(host)) {
             String syncId = data.getLastPathSegment();
-            if (syncId != null) SharedDataStore.writePendingDeepLink(this, "chore:" + syncId);
+            return syncId != null ? "chore:" + syncId : null;
         } else if ("filter".equals(host)) {
-            SharedDataStore.writePendingDeepLink(this, "filter:soon");
+            return "filter:soon";
+        } else if ("action".equals(host)) {
+            String action = data.getLastPathSegment();
+            if ("search".equals(action)) return "action:search";
+            if ("add".equals(action)) return "action:add";
         }
+        return null;
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
@@ -33,6 +33,9 @@ public class WidgetBridgePlugin extends Plugin {
         refreshGlanceWidget(context, HeatmapWidgetReceiver.class);
         refreshGlanceWidget(context, SingleChoreWidgetReceiver.class);
         refreshGlanceWidget(context, SoonListWidgetReceiver.class);
+        // The Add-chore widget is a static action surface — no snapshot refresh
+        // needed. Dynamic "top overdue" launcher shortcuts do track the snapshot.
+        WidgetShortcuts.refresh(context, json);
         call.resolve();
     }
 

--- a/android/app/src/main/java/com/lastglance/app/WidgetShortcuts.java
+++ b/android/app/src/main/java/com/lastglance/app/WidgetShortcuts.java
@@ -1,0 +1,131 @@
+package com.lastglance.app;
+
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.content.pm.ShortcutInfoCompat;
+import androidx.core.content.pm.ShortcutManagerCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.core.graphics.drawable.IconCompat;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+// Pushes "top overdue chores" as dynamic launcher shortcuts from the same
+// snapshot the widgets read. Each shortcut deep-links to that chore's log modal
+// via lastglance://chore/<syncId>, mirroring a widget tap. Refreshed whenever the
+// web app updates the snapshot. The "Me" filter is respected for free — the
+// snapshot is already filtered upstream (see src/native/snapshot.ts).
+final class WidgetShortcuts {
+    private static final int MAX = 3;
+
+    static void refresh(Context context, String json) {
+        try {
+            List<ShortcutInfoCompat> shortcuts = build(context, json);
+            // Replace the whole dynamic set so stale chores drop off.
+            ShortcutManagerCompat.removeAllDynamicShortcuts(context);
+            if (!shortcuts.isEmpty()) {
+                ShortcutManagerCompat.addDynamicShortcuts(context, shortcuts);
+            }
+        } catch (Exception ignored) {
+            // Best-effort; shortcuts are a convenience, never critical.
+        }
+    }
+
+    private static List<ShortcutInfoCompat> build(Context context, String json) throws Exception {
+        List<ShortcutInfoCompat> out = new ArrayList<>();
+        JSONArray chores = new JSONObject(json).optJSONArray("chores");
+        if (chores == null) return out;
+
+        // Soon/overdue chores, most-overdue (highest ratio) first.
+        List<JSONObject> ranked = new ArrayList<>();
+        for (int i = 0; i < chores.length(); i++) {
+            JSONObject ch = chores.getJSONObject(i);
+            String state = ch.optString("state");
+            if ("soon".equals(state) || "overdue".equals(state)) ranked.add(ch);
+        }
+        Collections.sort(ranked, new Comparator<JSONObject>() {
+            @Override public int compare(JSONObject a, JSONObject b) {
+                return Double.compare(b.optDouble("ratio", 0), a.optDouble("ratio", 0));
+            }
+        });
+
+        int rank = 0;
+        for (JSONObject ch : ranked) {
+            if (rank >= MAX) break;
+            String syncId = ch.optString("syncId");
+            String name = ch.optString("name");
+            if (syncId.isEmpty() || name.isEmpty()) continue;
+            Intent intent = new Intent(context, MainActivity.class)
+                    .setAction(Intent.ACTION_VIEW)
+                    .setData(Uri.parse("lastglance://chore/" + syncId));
+            ShortcutInfoCompat.Builder b = new ShortcutInfoCompat.Builder(context, "chore_" + syncId)
+                    .setShortLabel(name)
+                    .setLongLabel(name)
+                    .setRank(rank)
+                    .setIntent(intent);
+            IconCompat icon = choreIcon(context, ch);
+            if (icon != null) b.setIcon(icon);
+            out.add(b.build());
+            rank++;
+        }
+        return out;
+    }
+
+    // The chore's Lucide icon, tinted to its recency color (like the widgets),
+    // rendered to a bitmap so the launcher shows the color. Null → launcher uses
+    // the app's default badge.
+    private static IconCompat choreIcon(Context context, JSONObject ch) {
+        try {
+            String pascal = ch.optString("icon", null);
+            if (pascal == null || pascal.isEmpty()) return null;
+            int resId = context.getResources().getIdentifier(
+                    lucideResName(pascal), "drawable", context.getPackageName());
+            if (resId == 0) return null;
+            Drawable d = AppCompatResources.getDrawable(context, resId);
+            if (d == null) return null;
+            d = DrawableCompat.wrap(d.mutate());
+            String hex = ch.isNull("color") ? "#94a3b8" : ch.optString("color", "#94a3b8");
+            DrawableCompat.setTint(d, parseColor(hex));
+            int size = Math.round(48 * context.getResources().getDisplayMetrics().density);
+            int pad = Math.round(size * 0.18f);
+            Bitmap bmp = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bmp);
+            d.setBounds(pad, pad, size - pad, size - pad);
+            d.draw(canvas);
+            return IconCompat.createWithBitmap(bmp);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // PascalCase Lucide name → ic_lucide_snake_case, identical to the widget side.
+    private static String lucideResName(String pascal) {
+        StringBuilder sb = new StringBuilder("ic_lucide_");
+        for (int i = 0; i < pascal.length(); i++) {
+            char c = pascal.charAt(i);
+            if (c >= 'A' && c <= 'Z' && i > 0) sb.append('_');
+            sb.append(Character.toLowerCase(c));
+        }
+        return sb.toString();
+    }
+
+    private static int parseColor(String hex) {
+        try {
+            return Color.parseColor(hex);
+        } catch (Exception e) {
+            return Color.parseColor("#22c55e");
+        }
+    }
+}

--- a/android/app/src/main/java/com/lastglance/app/glance/AddChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/AddChoreWidget.kt
@@ -1,0 +1,77 @@
+package com.lastglance.app.glance
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.ColorFilter
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.GlanceTheme
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.layout.width
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.lastglance.app.R
+
+// A small one-tap "Add chore" launcher: opens the app straight into the new-chore
+// form (for the active category) via the shared lastglance://action/add deep link.
+// No snapshot needed — it's a pure action surface, so nothing to refresh.
+private val ADD_GREEN = Color(0xFF22C55E)
+
+class AddChoreWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        provideContent {
+            GlanceTheme {
+                Box(
+                    modifier = GlanceModifier
+                        .fillMaxSize()
+                        .background(GlanceTheme.colors.surface)
+                        .cornerRadius(16.dp)
+                        .padding(horizontal = 12.dp, vertical = 8.dp)
+                        .clickable(actionStartActivity(openAddIntent(context))),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Image(
+                            provider = ImageProvider(R.drawable.ic_lucide_circle_plus),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(ColorProvider(ADD_GREEN)),
+                            modifier = GlanceModifier.size(22.dp),
+                        )
+                        Spacer(modifier = GlanceModifier.width(8.dp))
+                        Text(
+                            context.getString(R.string.widget_add_chore),
+                            style = TextStyle(
+                                color = GlanceTheme.colors.onSurface,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 14.sp,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+class AddChoreWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = AddChoreWidget()
+}

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -73,6 +73,13 @@ internal fun openSoonIntent(context: Context): Intent =
         .setData(Uri.parse("lastglance://filter/soon"))
         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
 
+// Opens the app straight into the new-chore form (Add-chore widget / shortcut).
+internal fun openAddIntent(context: Context): Intent =
+    Intent(context, MainActivity::class.java)
+        .setAction(Intent.ACTION_VIEW)
+        .setData(Uri.parse("lastglance://action/add"))
+        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+
 internal data class ChoreData(
     val syncId: String,
     val name: String,

--- a/android/app/src/main/res/drawable/ic_shortcut_add.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_add.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:strokeColor="#16A34A" android:strokeWidth="2" android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M12 2a10 10 0 1 0 0 20 10 10 0 1 0 0-20z"/>
+    <path android:strokeColor="#16A34A" android:strokeWidth="2" android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M8 12h8"/>
+    <path android:strokeColor="#16A34A" android:strokeWidth="2" android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M12 8v8"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_shortcut_search.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_search.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:strokeColor="#16A34A" android:strokeWidth="2" android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16z"/>
+    <path android:strokeColor="#16A34A" android:strokeWidth="2" android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M21 21l-4.3-4.3"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_shortcut_soon.xml
+++ b/android/app/src/main/res/drawable/ic_shortcut_soon.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:strokeColor="#16A34A" android:strokeWidth="2" android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:pathData="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/>
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -16,4 +16,14 @@
     <string name="widget_label_activity">lastGLANCE Heatmap</string>
     <string name="widget_label_chore">lastGLANCE Chore</string>
     <string name="widget_label_soon">lastGLANCE Soon</string>
+    <string name="widget_label_add">lastGLANCE Add</string>
+    <string name="add_chore_widget_description">One tap to add a new chore.</string>
+    <string name="widget_add_chore">Add chore</string>
+    <!-- App shortcuts (long-press the launcher icon) -->
+    <string name="shortcut_soon_short">Soon</string>
+    <string name="shortcut_soon_long">What needs attention</string>
+    <string name="shortcut_search_short">Search</string>
+    <string name="shortcut_search_long">Search chores</string>
+    <string name="shortcut_add_short">Add chore</string>
+    <string name="shortcut_add_long">Add a new chore</string>
 </resources>

--- a/android/app/src/main/res/xml/add_chore_widget_info.xml
+++ b/android/app/src/main/res/xml/add_chore_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:updatePeriodMillis="0"
+    android:resizeMode="horizontal"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:previewImage="@mipmap/ic_launcher"
+    android:description="@string/add_chore_widget_description" />

--- a/android/app/src/main/res/xml/shortcuts.xml
+++ b/android/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Long-press launcher shortcuts. Each launches MainActivity with a
+     lastglance:// deep link (and an lglink extra fallback) that the web app
+     routes on foreground (see MainActivity.captureWidgetDeepLink /
+     routeWidgetDeepLink). Dynamic "top overdue" shortcuts are added at runtime
+     from the snapshot (see WidgetShortcuts). -->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="soon"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_soon"
+        android:shortcutShortLabel="@string/shortcut_soon_short"
+        android:shortcutLongLabel="@string/shortcut_soon_long">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.lastglance.app"
+            android:targetClass="com.lastglance.app.MainActivity"
+            android:data="lastglance://filter/soon">
+            <extra android:name="lglink" android:value="filter:soon" />
+        </intent>
+    </shortcut>
+    <shortcut
+        android:shortcutId="search"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_search"
+        android:shortcutShortLabel="@string/shortcut_search_short"
+        android:shortcutLongLabel="@string/shortcut_search_long">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.lastglance.app"
+            android:targetClass="com.lastglance.app.MainActivity"
+            android:data="lastglance://action/search">
+            <extra android:name="lglink" android:value="action:search" />
+        </intent>
+    </shortcut>
+    <shortcut
+        android:shortcutId="add"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_add"
+        android:shortcutShortLabel="@string/shortcut_add_short"
+        android:shortcutLongLabel="@string/shortcut_add_long">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.lastglance.app"
+            android:targetClass="com.lastglance.app.MainActivity"
+            android:data="lastglance://action/add">
+            <extra android:name="lglink" android:value="action:add" />
+        </intent>
+    </shortcut>
+</shortcuts>

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -345,10 +345,18 @@ sync round-trip.
 ### Phase 3 — Notifications actions, shortcuts, (optional) background sync
 
 - **Actionable notifications:** ✅ DONE in Phase 1 (Mark done / Send to dayGLANCE).
-- **App shortcuts** (`res/xml/shortcuts.xml`): "Soon", "Log a chore" → navigate
-  intents. **The only remaining Phase 3 item.** Make the shortcut targets the
-  shared `lastglance://` deep links (routed through the existing router) so the
-  iOS equivalent later is just the native declaration.
+- **App shortcuts:** ✅ DONE. Static (`res/xml/shortcuts.xml`): **Soon**, **Search**,
+  **Add chore**, each launching MainActivity with a shared `lastglance://` deep
+  link (plus an `lglink` extra fallback) routed through the existing router — two
+  new router targets (`action:search` → `lg:open-search`, `action:add` →
+  `lg:new-chore`) handled in `Ribbon`. Dynamic: **top-overdue chores**
+  (`WidgetShortcuts.java`) pushed from the snapshot on every update (icons tinted
+  to recency color; respects the "Me" filter for free), deep-linking to each
+  chore's log modal. Note: launchers cap the *visible* count (~4–5), so the
+  static + dynamic ranks may want tuning after on-device use.
+- **Add-chore widget:** ✅ DONE. A small Glance action tile (`AddChoreWidget.kt`)
+  that opens the new-chore form via the same `lastglance://action/add` link — no
+  snapshot needed.
 - **Background CRDT sync (stretch):** the only feature needing a background data
   runtime. Forces the headless-JS-vs-native-mirror decision. Defer until there's
   real demand; current "sync on open" is unchanged behavior.

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -177,6 +177,31 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const ribbonModalOpenRef = useRef(false)
   ribbonModalOpenRef.current = showSearch || selectedChore !== null || addingCategory || newChoreCategory !== null
 
+  // Launcher shortcuts / the Add widget: open Search or the new-chore form. New
+  // chore needs a category, which may not have loaded yet on a cold-start launch,
+  // so stash the request and open it once data arrives (mirrors pending-open).
+  const pendingNewChoreRef = useRef(false)
+  const openNewChore = useCallback(() => {
+    const cat = viewDataRef.current[activeCategoryIndexRef.current]?.category
+      ?? viewDataRef.current[0]?.category
+    if (cat) { setNewChoreCategory(cat); return true }
+    return false
+  }, [])
+  useEffect(() => {
+    function onOpenSearch() { setShowSearch(true) }
+    function onNewChore() { if (!openNewChore()) pendingNewChoreRef.current = true }
+    window.addEventListener('lg:open-search', onOpenSearch)
+    window.addEventListener('lg:new-chore', onNewChore)
+    return () => {
+      window.removeEventListener('lg:open-search', onOpenSearch)
+      window.removeEventListener('lg:new-chore', onNewChore)
+    }
+  }, [openNewChore])
+
+  useEffect(() => {
+    if (pendingNewChoreRef.current && openNewChore()) pendingNewChoreRef.current = false
+  }, [localData, openNewChore])
+
   // Keyboard shortcuts owned by Ribbon: search, category nav, new chore
   useEffect(() => {
     function onKey(e: KeyboardEvent) {

--- a/src/native/pendingDeepLink.ts
+++ b/src/native/pendingDeepLink.ts
@@ -1,10 +1,11 @@
 import { consumeDeepLink } from './widgetBridge'
 import { setPendingOpenChore } from './pendingOpenChore'
 
-// Route a widget body-tap target captured natively (see MainActivity). A chore
-// tap reuses the durable pending-open mechanism (the Ribbon consumes it once its
-// data has loaded, so cold-start ordering doesn't matter); a "soon" tap asks the
-// app to switch on the attention filter.
+// Route a target captured natively from a widget tap or launcher shortcut (see
+// MainActivity). A chore tap reuses the durable pending-open mechanism (the
+// Ribbon consumes it once its data has loaded, so cold-start ordering doesn't
+// matter); a "soon" tap switches on the attention filter; the action targets open
+// search / the new-chore form (Ribbon owns both and handles cold-start retry).
 export async function routeWidgetDeepLink(): Promise<void> {
   const link = await consumeDeepLink()
   if (!link) return
@@ -13,5 +14,9 @@ export async function routeWidgetDeepLink(): Promise<void> {
     window.dispatchEvent(new Event('lg:open-chore-pending'))
   } else if (link === 'filter:soon') {
     window.dispatchEvent(new Event('lg:widget-filter-soon'))
+  } else if (link === 'action:search') {
+    window.dispatchEvent(new Event('lg:open-search'))
+  } else if (link === 'action:add') {
+    window.dispatchEvent(new Event('lg:new-chore'))
   }
 }


### PR DESCRIPTION
Phase 3 app shortcuts + a small Add-chore widget. Everything routes through the shared `lastglance://` deep-link router, so the iOS equivalents are later just native declarations.

## Static launcher shortcuts (long-press the app icon)
`res/xml/shortcuts.xml` — three shortcuts, each launching `MainActivity` with a `lastglance://` deep link **and** an `lglink` extra fallback (belt-and-suspenders in case a launcher drops the URI):
- **Soon** → `lastglance://filter/soon` (existing target — switches on the attention filter)
- **Search** → `lastglance://action/search` (**new** target)
- **Add chore** → `lastglance://action/add` (**new** target)

Two new router targets wire the new ones up: `action:search` → `lg:open-search`, `action:add` → `lg:new-chore`, both handled in **`Ribbon`** (which owns `SearchModal` and the new-chore form). Add-chore opens the form for the **active category** — same behavior as the existing `N` keyboard shortcut. Because a cold-start launch may fire before categories load, the new-chore request is **stashed and replayed once data arrives** (mirrors the pending-open-chore mechanism), so a shortcut tap from a killed app still lands.

## Dynamic "top overdue" shortcuts
`WidgetShortcuts.java` pushes the **top 3 most-overdue chores** as dynamic shortcuts from the **same snapshot the widgets read**, refreshed on every snapshot update. Each deep-links to that chore's log modal (`lastglance://chore/<syncId>`), icons **tinted to the recency color** like the widgets. The multi-user **"Me" filter is respected for free** — the snapshot is already filtered upstream.

> **Launcher cap:** launchers only show ~4–5 shortcuts total, so with 3 static + 3 dynamic not all are visible at once. Static rank first by default; I can tune static/dynamic ranks once you see the mix on-device.

## Add-chore widget
`AddChoreWidget.kt` — a small Glance action tile (`+ Add chore`) that opens the new-chore form via `lastglance://action/add`. Pure action surface, **no snapshot needed**, so nothing to refresh.

## Icons
Static shortcut icons are dedicated green vectors (`ic_shortcut_soon/search/add`) so they read on both light and dark launcher popups (the generated Lucide drawables are black-stroked and meant to be tinted at render time, which shortcut icons don't get). The Add widget reuses `ic_lucide_circle_plus` tinted green via Glance.

## Testing
- ✅ Web build green; **112/112** tests pass; all new XML validated.
- ⚠️ **Native unverified here** (no Android SDK). On device, please confirm:
  - Long-pressing the icon shows **Soon / Search / Add chore** (+ your top-overdue chores), each landing on the right screen — including from a cold start.
  - The **Add-chore widget** opens the new-chore form.
  - Static shortcut icons are legible in both light and dark.
  - If the visible shortcut mix isn't what you want, tell me the priority and I'll tune ranks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_