### PR TITLE
Android: Quick Settings tiles for Add chore and Soon

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -88,6 +88,30 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/add_chore_widget_info" />
         </receiver>
+
+        <!-- Quick Settings tiles. Launch the app through the shared lastglance://
+             router; the Soon tile shows a live count subtitle from the snapshot. -->
+        <service
+            android:name=".tiles.AddChoreTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_lucide_circle_plus"
+            android:label="@string/tile_add_chore"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".tiles.SoonTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_lucide_flame"
+            android:label="@string/tile_soon"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
     </application>
 
     <!-- Permissions -->

--- a/android/app/src/main/java/com/lastglance/app/tiles/QsTiles.kt
+++ b/android/app/src/main/java/com/lastglance/app/tiles/QsTiles.kt
@@ -1,0 +1,82 @@
+package com.lastglance.app.tiles
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import com.lastglance.app.R
+import com.lastglance.app.SharedDataStore
+import com.lastglance.app.glance.openAddIntent
+import com.lastglance.app.glance.openSoonIntent
+import org.json.JSONObject
+
+// Quick Settings tiles. Both just launch the app through the shared lastglance://
+// router — the same targets as the shortcuts and widgets — collapsing the shade.
+// The Soon tile additionally shows a live "N overdue · N soon" subtitle read from
+// the snapshot. No new routing: openAddIntent / openSoonIntent are reused.
+
+private fun TileService.launchAndCollapse(intent: Intent) {
+    if (Build.VERSION.SDK_INT >= 34) {
+        val flags = PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        startActivityAndCollapse(PendingIntent.getActivity(this, 0, intent, flags))
+    } else {
+        @Suppress("DEPRECATION")
+        startActivityAndCollapse(intent)
+    }
+}
+
+class AddChoreTileService : TileService() {
+    override fun onStartListening() {
+        super.onStartListening()
+        qsTile?.apply {
+            state = Tile.STATE_INACTIVE
+            updateTile()
+        }
+    }
+
+    override fun onClick() {
+        super.onClick()
+        // If the device is locked, defer the launch until after unlock.
+        if (isLocked) unlockAndRun { launchAndCollapse(openAddIntent(this)) }
+        else launchAndCollapse(openAddIntent(this))
+    }
+}
+
+class SoonTileService : TileService() {
+    override fun onStartListening() {
+        super.onStartListening()
+        val tile = qsTile ?: return
+        val (overdue, soon) = readCounts(this)
+        // "Active" (highlighted) when something actually needs attention.
+        tile.state = if (overdue > 0 || soon > 0) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+        if (Build.VERSION.SDK_INT >= 29) {
+            tile.subtitle = subtitle(this, overdue, soon)
+        }
+        tile.updateTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        if (isLocked) unlockAndRun { launchAndCollapse(openSoonIntent(this)) }
+        else launchAndCollapse(openSoonIntent(this))
+    }
+}
+
+private fun subtitle(context: Context, overdue: Int, soon: Int): String = when {
+    overdue > 0 && soon > 0 -> "$overdue overdue · $soon soon"
+    overdue > 0 -> "$overdue overdue"
+    soon > 0 -> "$soon soon"
+    else -> context.getString(R.string.widget_all_caught_up)
+}
+
+private fun readCounts(context: Context): Pair<Int, Int> {
+    val raw = SharedDataStore.readSnapshot(context) ?: return 0 to 0
+    return try {
+        val counts = JSONObject(raw).optJSONObject("counts") ?: return 0 to 0
+        counts.optInt("overdue", 0) to counts.optInt("soon", 0)
+    } catch (e: Exception) {
+        0 to 0
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -26,4 +26,7 @@
     <string name="shortcut_search_long">Search chores</string>
     <string name="shortcut_add_short">Add chore</string>
     <string name="shortcut_add_long">Add a new chore</string>
+    <!-- Quick Settings tiles -->
+    <string name="tile_add_chore">Add chore</string>
+    <string name="tile_soon">Soon</string>
 </resources>


### PR DESCRIPTION
Two Quick Settings tiles, building on the shortcut/widget routing from #169. Both launch the app through the shared `lastglance://` router (reusing `openAddIntent` / `openSoonIntent`), so there's no new routing surface.

## Tiles
- **Add chore** → `lastglance://action/add` — opens the new-chore form from the shade.
- **Soon** → `lastglance://filter/soon` — opens the attention list, and shows a **live "N overdue · N soon" subtitle** read from the snapshot in `onStartListening` (refreshed each time the shade opens). The tile is **highlighted (active)** only when something actually needs attention, dim otherwise.

## Mechanics
- Launch via `startActivityAndCollapse` — `PendingIntent` on API 34+, the `Intent` overload below — so the shade collapses on tap.
- Deferred behind `unlockAndRun` when the device is locked.
- Icons reuse the Lucide drawables (`ic_lucide_circle_plus`, `ic_lucide_flame`); the QS host tints them to the system theme, so monochrome source is fine.
- `minSdk` is 24 (= `TileService`'s floor), so no version guard on the service itself.

## Adding them
Manual only, per the chosen scope — the tiles appear in the Quick Settings **edit** tray and you drag them into your active set (no in-app "add tile" prompt).

Not included (also per scope): a Search tile and a dynamic "most overdue" tile.

## Testing
- ✅ Native-only; web build/tests unaffected; manifest + strings XML validated.
- ⚠️ **Native unverified here** (no Android SDK). On device, please confirm:
  - Both tiles appear in the QS editor and can be added.
  - **Add chore** opens the new-chore form (incl. from a cold start / locked device).
  - **Soon** opens the attention list and its subtitle shows the right counts, updating as chores change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_