### PR TITLE
Android: share target — create a chore from shared text/links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!-- Share target: shared text/links seed a new chore. -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -13,12 +13,29 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(WidgetBridgePlugin.class);
         super.onCreate(savedInstanceState);
         captureWidgetDeepLink(getIntent());
+        captureSharedText(getIntent());
     }
 
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         captureWidgetDeepLink(intent);
+        captureSharedText(intent);
+    }
+
+    // A share from another app (ACTION_SEND, text/plain) seeds a new chore. Prefer
+    // the subject (often a page title) over the raw text/URL for the chore name;
+    // the web app opens the new-chore form pre-filled on foreground.
+    private void captureSharedText(Intent intent) {
+        if (intent == null || !Intent.ACTION_SEND.equals(intent.getAction())) return;
+        String type = intent.getType();
+        if (type == null || !type.startsWith("text/")) return;
+        String subject = intent.getStringExtra(Intent.EXTRA_SUBJECT);
+        String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+        String name = (subject != null && !subject.trim().isEmpty()) ? subject : text;
+        if (name != null && !name.trim().isEmpty()) {
+            SharedDataStore.writePendingSharedChore(this, name.trim());
+        }
     }
 
     // Widget body-taps and launcher shortcuts launch this activity with a

--- a/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
+++ b/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
@@ -19,6 +19,9 @@ public final class SharedDataStore {
     // A widget body-tap target ("chore:<syncId>" or "filter:soon") captured by
     // MainActivity, consumed by the web app on foreground.
     private static final String KEY_DEEPLINK = "pending_deeplink";
+    // Text shared into the app (ACTION_SEND) to seed a new chore's name, captured
+    // by MainActivity and consumed by the web app on foreground.
+    private static final String KEY_SHARED_CHORE = "pending_shared_chore";
 
     private SharedDataStore() {}
 
@@ -65,6 +68,16 @@ public final class SharedDataStore {
     public static String readAndClearPendingDeepLink(Context context) {
         String value = prefs(context).getString(KEY_DEEPLINK, null);
         if (value != null) prefs(context).edit().remove(KEY_DEEPLINK).apply();
+        return value;
+    }
+
+    public static void writePendingSharedChore(Context context, String value) {
+        prefs(context).edit().putString(KEY_SHARED_CHORE, value).apply();
+    }
+
+    public static String readAndClearPendingSharedChore(Context context) {
+        String value = prefs(context).getString(KEY_SHARED_CHORE, null);
+        if (value != null) prefs(context).edit().remove(KEY_SHARED_CHORE).apply();
         return value;
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/WidgetBridgePlugin.java
@@ -58,6 +58,16 @@ public class WidgetBridgePlugin extends Plugin {
         call.resolve(ret);
     }
 
+    // Hand the pending shared text (for a new chore's name) to the web app, and
+    // clear it.
+    @PluginMethod
+    public void consumeSharedChore(PluginCall call) {
+        String value = SharedDataStore.readAndClearPendingSharedChore(getContext());
+        JSObject ret = new JSObject();
+        ret.put("text", value);
+        call.resolve(ret);
+    }
+
     // Nudge a Glance widget to recompose from the freshly written snapshot.
     private static void refreshGlanceWidget(Context context, Class<?> receiver) {
         ComponentName component = new ComponentName(context, receiver);

--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -360,6 +360,14 @@ sync round-trip.
 - **Add-chore widget:** ✅ DONE. A small Glance action tile (`AddChoreWidget.kt`)
   that opens the new-chore form via the same `lastglance://action/add` link — no
   snapshot needed.
+- **Share target:** ✅ DONE. An `ACTION_SEND` (`text/plain`) intent-filter on
+  MainActivity makes lastGLANCE a share target; shared text/links are stashed
+  (`SharedDataStore.pending_shared_chore`, prefer `EXTRA_SUBJECT` title over the
+  raw URL) and consumed on foreground (`consumeSharedChore`) to open the new-chore
+  form **pre-filled** in the active category. Reuses the `lg:new-chore` handler
+  (now carrying an optional name) and the cold-start pending-retry. Name is the
+  only free-text chore field, so that's what gets seeded. iOS analog: a Share
+  Extension writing to the App Group, same web prefill.
 - **Background CRDT sync (stretch):** the only feature needing a background data
   runtime. Forces the headless-JS-vs-native-mirror decision. Defer until there's
   real demand; current "sync on open" is unchanged behavior.

--- a/src/components/ChoreFormModal/ChoreFormModal.tsx
+++ b/src/components/ChoreFormModal/ChoreFormModal.tsx
@@ -15,6 +15,9 @@ interface Props {
   category: Category
   allCategories?: Category[]
   chore?: Chore
+  // Seed for the name on a new chore (e.g. text shared into the app). Ignored
+  // when editing an existing chore.
+  initialName?: string
   onClose: () => void
   onSaved: () => void
 }
@@ -50,10 +53,10 @@ function sortHierarchically(categories: Category[]): Category[] {
   return roots.flatMap(r => [r, ...(childrenByParent.get(r.id) ?? [])])
 }
 
-export function ChoreFormModal({ category, allCategories, chore, onClose, onSaved }: Props) {
+export function ChoreFormModal({ category, allCategories, chore, initialName, onClose, onSaved }: Props) {
   const { t } = useTranslation()
   const isEdit = Boolean(chore)
-  const [name, setName] = useState(chore?.name ?? '')
+  const [name, setName] = useState(chore?.name ?? initialName ?? '')
   const [cadence, setCadence] = useState(
     chore?.target_cadence_days != null ? String(chore.target_cadence_days) : ''
   )

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -72,6 +72,8 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const [selectedChore, setSelectedChore] = useState<ChoreWithLastCompletion | null>(null)
   const [addingCategory, setAddingCategory] = useState(false)
   const [newChoreCategory, setNewChoreCategory] = useState<Category | null>(null)
+  // Seed name for the new-chore form (e.g. from a share); '' for a blank add.
+  const [newChoreName, setNewChoreName] = useState('')
 
   const [showSearch, setShowSearch] = useState(false)
 
@@ -177,19 +179,23 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const ribbonModalOpenRef = useRef(false)
   ribbonModalOpenRef.current = showSearch || selectedChore !== null || addingCategory || newChoreCategory !== null
 
-  // Launcher shortcuts / the Add widget: open Search or the new-chore form. New
-  // chore needs a category, which may not have loaded yet on a cold-start launch,
-  // so stash the request and open it once data arrives (mirrors pending-open).
-  const pendingNewChoreRef = useRef(false)
-  const openNewChore = useCallback(() => {
+  // Launcher shortcuts / the Add widget / a share: open Search or the new-chore
+  // form (optionally pre-filled with a shared name). A new chore needs a category,
+  // which may not have loaded yet on a cold-start launch, so stash the request and
+  // open it once data arrives (mirrors pending-open).
+  const pendingNewChoreRef = useRef<{ name: string } | null>(null)
+  const openNewChore = useCallback((name = '') => {
     const cat = viewDataRef.current[activeCategoryIndexRef.current]?.category
       ?? viewDataRef.current[0]?.category
-    if (cat) { setNewChoreCategory(cat); return true }
+    if (cat) { setNewChoreName(name); setNewChoreCategory(cat); return true }
     return false
   }, [])
   useEffect(() => {
     function onOpenSearch() { setShowSearch(true) }
-    function onNewChore() { if (!openNewChore()) pendingNewChoreRef.current = true }
+    function onNewChore(e: Event) {
+      const name = (e as CustomEvent<{ name?: string }>).detail?.name ?? ''
+      if (!openNewChore(name)) pendingNewChoreRef.current = { name }
+    }
     window.addEventListener('lg:open-search', onOpenSearch)
     window.addEventListener('lg:new-chore', onNewChore)
     return () => {
@@ -199,7 +205,8 @@ export function Ribbon({ editMode, onLogged }: Props) {
   }, [openNewChore])
 
   useEffect(() => {
-    if (pendingNewChoreRef.current && openNewChore()) pendingNewChoreRef.current = false
+    const pending = pendingNewChoreRef.current
+    if (pending && openNewChore(pending.name)) pendingNewChoreRef.current = null
   }, [localData, openNewChore])
 
   // Keyboard shortcuts owned by Ribbon: search, category nav, new chore
@@ -753,8 +760,9 @@ export function Ribbon({ editMode, onLogged }: Props) {
         <ChoreFormModal
           category={newChoreCategory}
           allCategories={localData.flatMap(d => [d.category, ...d.subcategories.map(s => s.category)])}
-          onClose={() => setNewChoreCategory(null)}
-          onSaved={() => { setNewChoreCategory(null); refresh() }}
+          initialName={newChoreName}
+          onClose={() => { setNewChoreCategory(null); setNewChoreName('') }}
+          onSaved={() => { setNewChoreCategory(null); setNewChoreName(''); refresh() }}
         />
       )}
     </>

--- a/src/native/pendingDeepLink.ts
+++ b/src/native/pendingDeepLink.ts
@@ -1,4 +1,4 @@
-import { consumeDeepLink } from './widgetBridge'
+import { consumeDeepLink, consumeSharedChore } from './widgetBridge'
 import { setPendingOpenChore } from './pendingOpenChore'
 
 // Route a target captured natively from a widget tap or launcher shortcut (see
@@ -8,15 +8,23 @@ import { setPendingOpenChore } from './pendingOpenChore'
 // search / the new-chore form (Ribbon owns both and handles cold-start retry).
 export async function routeWidgetDeepLink(): Promise<void> {
   const link = await consumeDeepLink()
-  if (!link) return
-  if (link.startsWith('chore:')) {
-    setPendingOpenChore(link.slice('chore:'.length))
-    window.dispatchEvent(new Event('lg:open-chore-pending'))
-  } else if (link === 'filter:soon') {
-    window.dispatchEvent(new Event('lg:widget-filter-soon'))
-  } else if (link === 'action:search') {
-    window.dispatchEvent(new Event('lg:open-search'))
-  } else if (link === 'action:add') {
-    window.dispatchEvent(new Event('lg:new-chore'))
+  if (link) {
+    if (link.startsWith('chore:')) {
+      setPendingOpenChore(link.slice('chore:'.length))
+      window.dispatchEvent(new Event('lg:open-chore-pending'))
+    } else if (link === 'filter:soon') {
+      window.dispatchEvent(new Event('lg:widget-filter-soon'))
+    } else if (link === 'action:search') {
+      window.dispatchEvent(new Event('lg:open-search'))
+    } else if (link === 'action:add') {
+      window.dispatchEvent(new Event('lg:new-chore'))
+    }
+  }
+
+  // A share from another app opens the new-chore form pre-filled with the shared
+  // title/text as the chore name (same handler as the Add entry points).
+  const shared = await consumeSharedChore()
+  if (shared) {
+    window.dispatchEvent(new CustomEvent('lg:new-chore', { detail: { name: shared } }))
   }
 }

--- a/src/native/widgetBridge.ts
+++ b/src/native/widgetBridge.ts
@@ -12,6 +12,8 @@ export interface WidgetBridgePlugin {
   drainPendingCompletions(): Promise<{ completions: string }>
   // Return and clear the pending widget body-tap target, or null.
   consumeDeepLink(): Promise<{ deepLink: string | null }>
+  // Return and clear text shared into the app to seed a new chore, or null.
+  consumeSharedChore(): Promise<{ text: string | null }>
 }
 
 const WidgetBridge = registerPlugin<WidgetBridgePlugin>('WidgetBridge')
@@ -48,6 +50,16 @@ export async function consumeDeepLink(): Promise<string | null> {
   try {
     const res = await WidgetBridge.consumeDeepLink()
     return res?.deepLink ?? null
+  } catch {
+    return null
+  }
+}
+
+export async function consumeSharedChore(): Promise<string | null> {
+  if (Capacitor.getPlatform() !== 'android') return null
+  try {
+    const res = await WidgetBridge.consumeSharedChore()
+    return res?.text ?? null
   } catch {
     return null
   }


### PR DESCRIPTION
Makes lastGLANCE a **share target**: share a link/text from any app → the new-chore form opens pre-filled. Reuses the deep-link/new-chore plumbing, so it's a small addition with no new dependencies.

## Flow
1. **Manifest:** an `ACTION_SEND` + `text/plain` intent-filter on `MainActivity` puts lastGLANCE in the system share sheet.
2. **Capture** (`MainActivity.captureSharedText`): reads the shared content, preferring **`EXTRA_SUBJECT`** (often the page title) over the raw URL/text, and stashes it in a new `SharedDataStore` slot (`pending_shared_chore`) — mirrors `captureWidgetDeepLink`.
3. **Consume** (`consumeSharedChore` plugin method → `routeWidgetDeepLink` on foreground): dispatches `lg:new-chore` carrying the shared name.
4. **Prefill:** the `lg:new-chore` handler in `Ribbon` now takes an optional name; `ChoreFormModal` gains an `initialName` prop that seeds the name for a **new** chore. Opens in the **active category** (per your choice).

## Reuse / robustness
- Same `lg:new-chore` path as the Add shortcut/widget — the no-name (`new Event(...)`) callers are unaffected (name falls back to `''`).
- The **cold-start pending-retry** we built for the Add shortcut applies: a share from a killed app replays once categories load, so the prefilled form still opens.

## Design note
A chore's only free-text field is its **name**, so the shared title/text seeds the name (you edit, set cadence/category, save). There's no separate notes/URL field to stash the link in.

## iOS
The analog is a **Share Extension** (separate target) writing to an App Group; the web prefill logic here is shared.

## Testing
- ✅ Web build green; **112/112** tests pass; manifest validated.
- ⚠️ **Native unverified here** (no Android SDK). On device, please confirm: lastGLANCE appears in the share sheet for a link/text; sharing opens the new-chore form with the title/text filled in, in the active category; works from both a running and a killed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_