### PR TITLE
chore(release): v1.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.11.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.11.1-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.11.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -327,7 +327,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.8.4;
+				MARKETING_VERSION = 1.11.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release **v1.11.1** (patch bump from 1.11.0).

## Bumps
- **`package.json`** + **`package-lock.json`** → `1.11.1` (the single source of truth).
- **`README.md`** version badge → `1.11.1`.
- **Android** derives automatically from package.json — no gradle edit needed:
  - `versionName` → **1.11.1**
  - `versionCode` → **11101** (`1*10000 + 11*100 + 1`)
- **iOS** marketing version (`MARKETING_VERSION`) synced to **1.11.1** via `scripts/sync-ios-version.mjs`. (iOS/Android build numbers per-upload are handled at upload time, as documented.)

## Verification
- ✅ `npm run build` green.
- ✅ **112/112** tests pass.

## Notes
- No CHANGELOG in the repo and no existing git tags, so nothing else to update. If you'd like, after merge I can tag **`v1.11.1`** on `main` and/or draft a GitHub release — say the word.
- For the closed-testing upload itself: the signed AAB build (`./gradlew bundleRelease` with `android/keystore.properties`) runs on your machine — this PR just lands the version numbers it'll pick up. If you need an interim Play upload before the next release, the build script's `-PappVersionCode=` override (e.g. `11102`) is there for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)