### PR TITLE
chore(release): v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.11.1-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.12.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.1;
+				MARKETING_VERSION = 1.12.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -327,7 +327,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.11.1;
+				MARKETING_VERSION = 1.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Supersedes the 1.11.1 bump. Moving to **1.12.0** for the initial Android release.

## Why
- The derived versionCode for 1.11.1 (**11101**) was already consumed by a pre-release upload during iteration, so Play won't accept it again on any track.
- A **minor** bump fits this release better anyway: it's the full initial Android feature set (widgets, notifications, launcher shortcuts, Quick Settings tiles, share target), not a patch.
- 1.12.0 derives a clean **versionCode 11200**, so no `-PappVersionCode` override is needed.

## Bumps
- **`package.json`** + **`package-lock.json`** → `1.12.0`
- **`README.md`** version badge → `1.12.0`
- **Android** (auto-derived): `versionName` **1.12.0**, `versionCode` **11200**
- **iOS** `MARKETING_VERSION` → `1.12.0`

## Verification
- ✅ `npm run build` green.
- ✅ **112/112** tests pass.

After merge I can tag **`v1.12.0`** on `main`. (Your earlier-drafted release notes just need their title changed from 1.11.1 to 1.12.0.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_