### PR TITLE
fix(android): derive versionCode above stray six-digit pre-release codes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,19 +3,23 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 // Derive versionName/versionCode from package.json so the native build tracks
-// the web app version (e.g. 1.8.4 -> versionCode 10804) instead of drifting.
+// the web app version. versionCode = major*1000000 + minor*10000 + patch*100
+// (e.g. 1.12.0 -> 1120000). This magnitude deliberately sits well above some
+// early hand-uploaded six-digit pre-release codes (up to 111020) that would
+// otherwise outrank the derived codes; it still increases monotonically with the
+// version, with 100 spare codes per patch for pre-release overrides.
 def pkg = new groovy.json.JsonSlurper().parse(rootProject.file("../package.json"))
 def appVersionName = pkg.version as String
 def versionParts = appVersionName.tokenize('.')
-def derivedVersionCode = versionParts[0].toInteger() * 10000 + versionParts[1].toInteger() * 100 + versionParts[2].toInteger()
+def derivedVersionCode = versionParts[0].toInteger() * 1000000 + versionParts[1].toInteger() * 10000 + versionParts[2].toInteger() * 100
 
 // One-off versionCode override for uploading pre-release builds (e.g. to the
 // Play internal test track) without disturbing the derived release numbering.
 // Play requires each upload to have a strictly higher versionCode than anything
 // previously uploaded to ANY track, so an internal build needs a code above the
-// current release's but below the NEXT release's derived code — pick from that
-// band (e.g. between 1.9.0's 10900 and 1.10.0's 11000, use 10901, 10902, …):
-//   ./gradlew bundleRelease -PappVersionCode=10901
+// current release's but below the NEXT release's derived code. Pick from that
+// band (e.g. between 1.12.0's 1120000 and 1.13.0's 1130000, use 1120001, ...):
+//   ./gradlew bundleRelease -PappVersionCode=1120001
 // Omit the property and the code derives from package.json exactly as before, so
 // real releases keep their clean derived numbering.
 def appVersionCode = (project.findProperty("appVersionCode") ?: derivedVersionCode).toString().toInteger()


### PR DESCRIPTION
## The bug
The Play upload of 1.12.0 (derived versionCode **11200**) failed to roll out: *"doesn't allow any existing users to upgrade."*

Root cause, from the App bundle explorer: some early 1.11.0 pre-release builds were hand-uploaded with **six-digit** version codes, `111012`–`111020` (one digit too many, vs the intended ~11020 range). The active bundle is **111020**, which is an order of magnitude above the old derive scheme's output (`major*10000 + minor*100 + patch` → 1.12.0 = 11200). So 11200 looks like a downgrade from 111020, and every future derived code (1.13.0 → 11300, …) would stay stuck below it too.

## The fix
Change the derivation so codes sit safely above that six-digit floor and keep increasing:

```
versionCode = major*1000000 + minor*10000 + patch*100
```

- **1.12.0 → 1,120,000** (well above 111020)
- 1.12.1 → 1,120,100 · 1.13.0 → 1,130,000 · 2.0.0 → 2,000,000
- Monotonic forever; ~100 spare codes per patch for the `-PappVersionCode` override band (e.g. 1,120,001…). Well under Play's 2,100,000,000 ceiling.

versionName is untouched (still 1.12.0). Comment/override docs in `build.gradle` updated to match.

## After merge
Just rebuild and upload, **no override needed**:
```
./gradlew bundleRelease   # versionCode now derives to 1120000
```
1,120,000 > 111020, so rollout will be a valid upgrade for existing testers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_