### PR TITLE
build(android): release script with --build N for test uploads

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,6 +20,8 @@ def derivedVersionCode = versionParts[0].toInteger() * 1000000 + versionParts[1]
 // current release's but below the NEXT release's derived code. Pick from that
 // band (e.g. between 1.12.0's 1120000 and 1.13.0's 1130000, use 1120001, ...):
 //   ./gradlew bundleRelease -PappVersionCode=1120001
+// Easier (computes the code for you, can't fat-finger it):
+//   npm run release:android -- --build 1     (see scripts/android-release.mjs)
 // Omit the property and the code derives from package.json exactly as before, so
 // real releases keep their clean derived numbering.
 def appVersionCode = (project.findProperty("appVersionCode") ?: derivedVersionCode).toString().toInteger()

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gen:icons": "node scripts/gen-lucide-drawables.mjs",
     "cap:sync": "npm run build && cap sync",
     "build:android": "npm run build && cap sync android",
+    "release:android": "node scripts/android-release.mjs",
     "build:ios": "npm run build && cap sync ios && node scripts/sync-ios-version.mjs",
     "sync:ios-version": "node scripts/sync-ios-version.mjs",
     "cap:android": "npm run cap:sync && cap open android",

--- a/scripts/android-release.mjs
+++ b/scripts/android-release.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Build a signed Android App Bundle (AAB) with the correct versionCode, derived
+// from package.json so you can't fat-finger the digits.
+//
+//   node scripts/android-release.mjs              # release build  (versionCode = base)
+//   node scripts/android-release.mjs --build 3    # test build #3  (versionCode = base + 3)
+//   node scripts/android-release.mjs --build 3 --dry-run   # just print the numbers
+//
+// versionName is always package.json's version (e.g. 1.12.0). The base
+// versionCode is major*1000000 + minor*10000 + patch*100 (matching
+// android/app/build.gradle), e.g. 1.12.0 -> 1120000. `--build N` (1..99) adds N
+// for internal/closed test uploads, which each need a strictly higher code than
+// the last. Keep incrementing N for every test upload, then PROMOTE the build
+// that passes to production (don't rebuild a lower code for it). For a real
+// version change, bump package.json first (npm version <major|minor|patch>).
+
+import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+// --- args ---
+const argv = process.argv.slice(2)
+const dryRun = argv.includes('--dry-run')
+let build = 0
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i]
+  if (a === '--build' || a === '-b') build = Number(argv[++i])
+  else if (a.startsWith('--build=')) build = Number(a.slice('--build='.length))
+}
+if (build !== 0 && (!Number.isInteger(build) || build < 1 || build > 99)) {
+  console.error('Error: --build N must be a whole number from 1 to 99.')
+  console.error('  (That is the per-patch test band. Need more than 99? Bump the patch')
+  console.error('   version with `npm version patch` and start over at --build 1.)')
+  process.exit(1)
+}
+
+// --- version math (keep in sync with android/app/build.gradle) ---
+const version = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).version
+const parts = version.split('.').map(Number)
+if (parts.length !== 3 || parts.some(n => !Number.isInteger(n))) {
+  console.error(`Error: package.json version is not major.minor.patch: "${version}"`)
+  process.exit(1)
+}
+const [major, minor, patch] = parts
+const base = major * 1_000_000 + minor * 10_000 + patch * 100
+const versionCode = base + build
+
+const label = build ? `test build #${build}` : 'release build'
+console.log(`\nlastGLANCE Android ${label}`)
+console.log(`  versionName  ${version}`)
+console.log(`  versionCode  ${versionCode}${build ? `  (${base} + ${build})` : ''}`)
+console.log('')
+
+if (dryRun) process.exit(0)
+
+// --- build ---
+function run(cmd, args, opts = {}) {
+  console.log(`$ ${cmd} ${args.join(' ')}`)
+  execFileSync(cmd, args, { stdio: 'inherit', cwd: root, ...opts })
+}
+
+run('npm', ['run', 'build'])                       // web app
+run('npx', ['cap', 'sync', 'android'])             // copy into native project
+const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew'
+run(gradlew, ['bundleRelease', `-PappVersionCode=${versionCode}`], { cwd: resolve(root, 'android') })
+
+console.log('\nDone.')
+console.log('  AAB: android/app/build/outputs/bundle/release/app-release.aab')
+console.log(`  Upload as versionName ${version}, versionCode ${versionCode}.`)
+if (build) console.log('  Tip: promote this exact bundle to production once it passes; do not rebuild a lower code.')


### PR DESCRIPTION
Follow-up to the versionCode formula fix (#176): a release helper so test-build version codes can't be fat-fingered again.

## Usage
```sh
npm run release:android -- --build 3      # test build #3
npm run release:android                    # clean release build
node scripts/android-release.mjs --build 3 --dry-run   # just print the numbers
```

It reads the version from `package.json` and computes the versionCode the same way `build.gradle` does (`major*1000000 + minor*10000 + patch*100`):
- **no flag** → base, e.g. `1.12.0` → **1120000**
- **`--build N`** (1..99) → base + N, e.g. `--build 3` → **1120003**

Then it runs the whole pipeline: `npm run build` → `cap sync android` → `./gradlew bundleRelease -PappVersionCode=<code>`, and prints the AAB path + the exact versionName/versionCode to upload.

## Guardrails (so you can't repeat the 111020 mess)
- You pick a small **build number**, not a raw 7-digit code, so a stray digit is impossible.
- `--build` is validated to **1..99**; `100`, negatives, and non-numbers are rejected with a hint to bump the patch version instead.
- `--dry-run` previews the numbers without building.
- Reminds you to **promote the passing test bundle to production** rather than rebuild a lower code.

`build.gradle`'s override comment now points at the script.

## Verification
- ✅ Computation + guardrails tested via `--dry-run` (1120000 / 1120003 / 1120099; `--build 100` and `--build abc` correctly rejected). The gradle/build steps run on your machine (no Android SDK here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7DCMa592JhFyZybcprTJA)_