### PR TITLE
feat(sync): pre-save Test Connection for GLANCEvault credentials (+ reference docs)

### DIFF
--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -5,6 +5,7 @@ import type { SyncEngine, DbSyncEngine, SyncErrorCode } from '@glance-apps/sync'
 import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, DEFAULT_SYNC_FOLDER, SYNC_FOLDER_KEY } from '@/sync/engine'
 import { syncErrorText } from '@/sync/syncErrorText'
 import { getVaultConfig, setVaultConfig } from '@/sync/vaultConfig'
+import { testVaultConnection } from '@/sync/testVaultConnection'
 import { cloudSyncProviders } from '@/utils/cloudSyncProviders'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from 'react-i18next'
@@ -29,6 +30,14 @@ interface Props {
 
 type TestStatus = 'idle' | 'testing' | 'ok' | 'fail'
 type SyncResult = 'idle' | 'ok' | 'error'
+
+// Messages for the vault "Test connection" failure outcomes. Hardcoded English
+// to match the rest of the GLANCEvault (beta) section, which is not localized.
+const VAULT_TEST_FAIL_TEXT: Record<'AUTH_FAILURE' | 'FORBIDDEN' | 'NETWORK_ERROR', string> = {
+  AUTH_FAILURE: 'Device token is incorrect.',
+  FORBIDDEN: 'Account ID not found or not permitted for this token.',
+  NETWORK_ERROR: 'Could not reach the vault at this URL.',
+}
 
 export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, vaultSyncError, vaultSyncErrorCode, vaultSkipped, onClose }: Props) {
   const { t } = useTranslation()
@@ -72,6 +81,14 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
   const [vaultUrl, setVaultUrl] = useState(() => initVault.current?.vaultUrl ?? '')
   const [vaultToken, setVaultToken] = useState(() => initVault.current?.vaultToken ?? '')
   const [vaultAccountId, setVaultAccountId] = useState(() => initVault.current?.accountId ?? '')
+
+  // Pre-save connection test for the vault credentials. 'ok' covers both good
+  // states (account initialized, or a fresh account with no salt yet); the
+  // message distinguishes them. Reset to idle whenever a field changes so a stale
+  // result can't outlive the credentials it verified.
+  const [vaultTestStatus, setVaultTestStatus] = useState<TestStatus>('idle')
+  const [vaultTestMsg, setVaultTestMsg] = useState('')
+  const vaultFieldsFilled = Boolean(vaultUrl.trim() && vaultToken.trim() && vaultAccountId.trim())
 
   const [syncing, setSyncing] = useState(false)
   const [syncResult, setSyncResult] = useState<SyncResult>('idle')
@@ -215,6 +232,34 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
       setSyncResult('error')
     }
     setSyncing(false)
+  }
+
+  // Verify the entered vault credentials BEFORE they are saved/activated, using
+  // the same authenticated getSalt probe the intents key setup uses (native-safe
+  // via vaultFetchImpl). Mirrors the WebDAV "Test connection" UX, but the logic
+  // is the vault probe — it never runs engine.test() or saves anything.
+  async function handleVaultTest() {
+    if (!vaultFieldsFilled) return
+    setVaultTestStatus('testing')
+    setVaultTestMsg('')
+    const outcome = await testVaultConnection({
+      vaultUrl: vaultUrl.trim(),
+      vaultToken: vaultToken.trim(),
+      accountId: vaultAccountId.trim(),
+    })
+    if (outcome.ok) {
+      setVaultTestStatus('ok')
+      // A fresh account legitimately has no salt yet — this is success, not a
+      // failure; the salt is established on the first sync.
+      setVaultTestMsg(
+        outcome.salt
+          ? 'Connected.'
+          : 'Connected — this account will be initialized on first sync.',
+      )
+    } else {
+      setVaultTestStatus('fail')
+      setVaultTestMsg(VAULT_TEST_FAIL_TEXT[outcome.code])
+    }
   }
 
   async function handleVaultSyncNow() {
@@ -557,7 +602,7 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
                   <input
                     type="text"
                     value={vaultUrl}
-                    onChange={e => setVaultUrl(e.target.value)}
+                    onChange={e => { setVaultUrl(e.target.value); setVaultTestStatus('idle'); setVaultTestMsg('') }}
                     placeholder="https://vault.glance-apps.com"
                     autoComplete="off"
                     className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
@@ -570,7 +615,7 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
                   <input
                     type="password"
                     value={vaultToken}
-                    onChange={e => setVaultToken(e.target.value)}
+                    onChange={e => { setVaultToken(e.target.value); setVaultTestStatus('idle'); setVaultTestMsg('') }}
                     placeholder="Bearer token"
                     autoComplete="off"
                     className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
@@ -583,7 +628,7 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
                   <input
                     type="text"
                     value={vaultAccountId}
-                    onChange={e => setVaultAccountId(e.target.value)}
+                    onChange={e => { setVaultAccountId(e.target.value); setVaultTestStatus('idle'); setVaultTestMsg('') }}
                     placeholder="Household account id"
                     autoComplete="off"
                     className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
@@ -592,6 +637,34 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
                 <p className="text-xs text-slate-400 dark:text-slate-500">
                   Saved on close. The app reloads to apply vault changes. Uses your sync passphrase for encryption.
                 </p>
+
+                {/* Pre-save credential verification. Mirrors the WebDAV "Test
+                    connection" button, but runs the vault getSalt probe so bad
+                    credentials are caught here instead of failing at first sync. */}
+                <div className="space-y-2 pt-1">
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <button
+                      onClick={handleVaultTest}
+                      disabled={vaultTestStatus === 'testing' || !vaultFieldsFilled}
+                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-40 transition-colors"
+                    >
+                      {vaultTestStatus === 'testing' && <Loader size={12} className="animate-spin" />}
+                      {t('sync.testConnection')}
+                    </button>
+                    {vaultTestStatus === 'ok' && (
+                      <span className="flex items-center gap-1.5 text-xs text-green-500 dark:text-green-400">
+                        <CheckCircle size={13} />
+                        {vaultTestMsg}
+                      </span>
+                    )}
+                    {vaultTestStatus === 'fail' && (
+                      <span className="flex items-center gap-1.5 text-xs text-red-500 dark:text-red-400">
+                        <XCircle size={13} />
+                        {vaultTestMsg}
+                      </span>
+                    )}
+                  </div>
+                </div>
               </div>
             )}
 

--- a/src/sync/testVaultConnection.test.ts
+++ b/src/sync/testVaultConnection.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Native-wiring test mocks the vault client + native HTTP so we can assert the
+// probe builds the client with the native-safe fetch adapter. The outcome tests
+// below inject getSalt directly and never touch these mocks.
+const createVaultClientMock = vi.fn()
+vi.mock('@glance-apps/sync', () => ({
+  createVaultClient: (cfg: unknown) => createVaultClientMock(cfg),
+}))
+
+const nativeHttpFetchMock = vi.fn(
+  async (method: string, url: string, headers: Record<string, string>, body: string | null) => ({
+    status: 200,
+    ok: true,
+    statusText: '',
+    // Echo the request so the test can assert the (method, url, headers, body)
+    // shape reached CapacitorHttp; also keeps every param genuinely used.
+    body: JSON.stringify({ salt: 'AAAA', request: { method, url, headers, body } }),
+  }),
+)
+// isNativePlatform is a const binding; mock the module so the probe sees `true`.
+vi.mock('@/sync/nativeHttp', () => ({
+  isNativePlatform: true,
+  nativeHttpFetch: (...args: Parameters<typeof nativeHttpFetchMock>) => nativeHttpFetchMock(...args),
+}))
+
+import { testVaultConnection, classifyVaultTestError } from './testVaultConnection'
+
+const INPUT = { vaultUrl: 'https://vault.example.com', vaultToken: 'tok', accountId: 'acct-1' }
+
+beforeEach(() => {
+  createVaultClientMock.mockReset()
+  nativeHttpFetchMock.mockClear()
+})
+
+describe('testVaultConnection — typed outcomes (getSalt mocked)', () => {
+  it('SUCCESS: a registered salt -> ok, salt present', async () => {
+    const getSalt = vi.fn(async () => new Uint8Array(16).fill(7))
+    const r = await testVaultConnection(INPUT, getSalt)
+    expect(r).toEqual({ ok: true, code: null, salt: true })
+    expect(getSalt).toHaveBeenCalledWith('acct-1')
+  })
+
+  it('SALT-NOT-ESTABLISHED: getSalt null (404) -> ok + ACCOUNT_ID_REQUIRED, NOT an error', async () => {
+    const getSalt = vi.fn(async () => null)
+    const r = await testVaultConnection(INPUT, getSalt)
+    expect(r).toEqual({ ok: true, code: 'ACCOUNT_ID_REQUIRED', salt: false })
+  })
+
+  it('SALT-NOT-ESTABLISHED: an empty salt is also treated as fresh (acceptable)', async () => {
+    const getSalt = vi.fn(async () => new Uint8Array(0))
+    const r = await testVaultConnection(INPUT, getSalt)
+    expect(r).toEqual({ ok: true, code: 'ACCOUNT_ID_REQUIRED', salt: false })
+  })
+
+  it('AUTH FAILURE: getSalt throws with status 401 -> AUTH_FAILURE', async () => {
+    const getSalt = vi.fn(async () => { throw Object.assign(new Error('get salt failed: 401'), { status: 401 }) })
+    const r = await testVaultConnection(INPUT, getSalt)
+    expect(r).toEqual({ ok: false, code: 'AUTH_FAILURE' })
+  })
+
+  it('FORBIDDEN: getSalt throws with status 403 -> FORBIDDEN', async () => {
+    const getSalt = vi.fn(async () => { throw Object.assign(new Error('get salt failed: 403'), { status: 403 }) })
+    const r = await testVaultConnection(INPUT, getSalt)
+    expect(r).toEqual({ ok: false, code: 'FORBIDDEN' })
+  })
+
+  it('NETWORK: getSalt rejects with no status (bad URL / unreachable) -> NETWORK_ERROR', async () => {
+    const getSalt = vi.fn(async () => { throw new TypeError('Failed to fetch') })
+    const r = await testVaultConnection(INPUT, getSalt)
+    expect(r).toEqual({ ok: false, code: 'NETWORK_ERROR' })
+  })
+
+  it('NETWORK: any other non-2xx (e.g. 500) falls back to NETWORK_ERROR', async () => {
+    const getSalt = vi.fn(async () => { throw Object.assign(new Error('get salt failed: 500'), { status: 500 }) })
+    const r = await testVaultConnection(INPUT, getSalt)
+    expect(r).toEqual({ ok: false, code: 'NETWORK_ERROR' })
+  })
+
+  it('never throws — a rejection is always converted to a typed outcome', async () => {
+    const getSalt = vi.fn(async () => { throw 'weird-non-error' })
+    await expect(testVaultConnection(INPUT, getSalt)).resolves.toEqual({ ok: false, code: 'NETWORK_ERROR' })
+  })
+})
+
+describe('classifyVaultTestError (pure)', () => {
+  it('401 -> AUTH_FAILURE', () => {
+    expect(classifyVaultTestError({ status: 401 })).toEqual({ ok: false, code: 'AUTH_FAILURE' })
+  })
+  it('403 -> FORBIDDEN', () => {
+    expect(classifyVaultTestError({ status: 403 })).toEqual({ ok: false, code: 'FORBIDDEN' })
+  })
+  it('no status -> NETWORK_ERROR', () => {
+    expect(classifyVaultTestError(new Error('boom'))).toEqual({ ok: false, code: 'NETWORK_ERROR' })
+  })
+})
+
+describe('native wiring — reaches the vault via vaultFetchImpl, not a plain fetch', () => {
+  it('builds the client with a native-safe fetchImpl that routes through nativeHttpFetch', async () => {
+    // Capture the config the probe passes to createVaultClient, and have the
+    // client resolve getSalt by calling that injected fetchImpl (proving the
+    // probe wired it). The fetchImpl must hit nativeHttpFetch on native.
+    let capturedFetch: typeof fetch | undefined
+    createVaultClientMock.mockImplementation((cfg: { fetchImpl?: typeof fetch }) => {
+      capturedFetch = cfg.fetchImpl
+      return {
+        async getSalt(accountId: string) {
+          // Exercise the adapter exactly like the real client would.
+          const res = await cfg.fetchImpl!(`https://vault.example.com/salt/${accountId}`, { method: 'GET', headers: {} })
+          const body = await (res as Response).json()
+          return body.salt ? new Uint8Array([0, 0, 0]) : null
+        },
+      }
+    })
+
+    const r = await testVaultConnection(INPUT) // no injected getSalt -> real defaultGetSalt path
+
+    expect(createVaultClientMock).toHaveBeenCalledTimes(1)
+    expect(capturedFetch).toBeTypeOf('function') // native-safe adapter injected, NOT undefined
+    expect(nativeHttpFetchMock).toHaveBeenCalledTimes(1) // request went through CapacitorHttp bridge
+    expect(nativeHttpFetchMock.mock.calls[0][0]).toBe('GET') // (method, url, headers, body) shape
+    expect(nativeHttpFetchMock.mock.calls[0][1]).toBe('https://vault.example.com/salt/acct-1')
+    expect(r).toEqual({ ok: true, code: null, salt: true })
+  })
+})

--- a/src/sync/testVaultConnection.ts
+++ b/src/sync/testVaultConnection.ts
@@ -1,0 +1,109 @@
+// Pre-save GLANCEvault credential verification.
+//
+// Runs an authenticated probe against the vault BEFORE the credentials are saved
+// / activated, so a bad URL / token / account is caught in the settings UI
+// instead of failing silently at the first sync cycle. The probe is the same
+// GET /salt/:accountId call the intents key setup already uses
+// (setupVaultIntentsEncryption.ts): createVaultClient(...).getSalt(accountId).
+//
+// It is native-safe by construction: it builds the client with the SAME
+// (url, init) => Response adapter over nativeHttpFetch that the intents setup
+// injects, so on the Capacitor shell the request goes through CapacitorHttp
+// (CORS-free) and on web it falls back to the global fetch (the vault serves
+// CORS). It never uses a plain global fetch directly.
+//
+// Nothing here saves, activates, derives a key, or registers a salt — it is a
+// read-only reachability + auth check. In particular a fresh account that has no
+// salt yet (getSalt -> null / 404) is an ACCEPTABLE outcome, NOT a failure: the
+// salt is established on the first sync, and flagging it as an error would block
+// first-device setup.
+
+import { createVaultClient } from '@glance-apps/sync'
+import type { SyncErrorCode } from '@glance-apps/sync'
+import { isNativePlatform, nativeHttpFetch } from '@/sync/nativeHttp'
+
+export interface VaultTestInput {
+  vaultUrl: string
+  vaultToken: string
+  accountId: string
+}
+
+// Typed, mutually-exclusive outcomes. `code` reuses @glance-apps/sync's
+// SyncErrorCode vocabulary so the UI classifies the same way the sync engine
+// would. The two `ok: true` shapes are both "credentials are good":
+//   - salt: true                  -> account already initialized.
+//   - code: 'ACCOUNT_ID_REQUIRED' -> reachable + token/account accepted, but no
+//                                    salt registered yet (fresh account). This is
+//                                    the salt-not-established state, surfaced with
+//                                    the existing typed code; it is NOT an error.
+export type VaultTestOutcome =
+  | { ok: true; code: null; salt: true }
+  | { ok: true; code: Extract<SyncErrorCode, 'ACCOUNT_ID_REQUIRED'>; salt: false }
+  | { ok: false; code: Extract<SyncErrorCode, 'AUTH_FAILURE' | 'FORBIDDEN' | 'NETWORK_ERROR'> }
+
+// Native-safe (url, init) => Response adapter over nativeHttpFetch. Identical to
+// the intents setup path's private vaultFetchImpl: undefined on web so
+// createVaultClient uses the global fetch (vault serves CORS); on native it
+// routes through CapacitorHttp and presents the { ok, status, json, text } subset
+// the vault client reads.
+function vaultFetchImpl(): typeof fetch | undefined {
+  if (!isNativePlatform) return undefined
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const r = await nativeHttpFetch(
+      init?.method ?? 'GET',
+      url,
+      (init?.headers as Record<string, string>) ?? {},
+      (init?.body as string) ?? null,
+    )
+    return {
+      ok: r.ok,
+      status: r.status,
+      json: async () => JSON.parse(r.body),
+      text: async () => r.body,
+    } as Response
+  }) as typeof fetch
+}
+
+// Maps a thrown getSalt error to a typed failure outcome. The vault client's
+// jsonOrThrow raises a VaultError carrying `.status` (the HTTP status) on a
+// non-2xx response; a network failure / bad URL / aborted request rejects with a
+// plain error that has no `.status`. Pure and exported so each branch is unit
+// testable without a server.
+export function classifyVaultTestError(err: unknown): VaultTestOutcome {
+  const status = (err as { status?: unknown })?.status
+  if (status === 401) return { ok: false, code: 'AUTH_FAILURE' }
+  if (status === 403) return { ok: false, code: 'FORBIDDEN' }
+  // Anything else — no status (network / DNS / bad URL / timeout) or any other
+  // non-2xx (e.g. 5xx) — is reported as "couldn't reach/use the vault here".
+  return { ok: false, code: 'NETWORK_ERROR' }
+}
+
+// Default salt fetcher: the real vault client, wired with the native-safe fetch.
+function defaultGetSalt(input: VaultTestInput): (accountId: string) => Promise<Uint8Array | null> {
+  const client = createVaultClient({
+    vaultUrl: input.vaultUrl,
+    vaultToken: input.vaultToken,
+    fetchImpl: vaultFetchImpl(),
+  })
+  return (accountId: string) => client.getSalt(accountId)
+}
+
+// Verifies the entered credentials by fetching the account salt. Never throws —
+// every path resolves to a typed VaultTestOutcome. `getSaltImpl` is injectable so
+// tests can drive each outcome without a live vault; production uses the real
+// client built by defaultGetSalt.
+export async function testVaultConnection(
+  input: VaultTestInput,
+  getSaltImpl: (accountId: string) => Promise<Uint8Array | null> = defaultGetSalt(input),
+): Promise<VaultTestOutcome> {
+  try {
+    const salt = await getSaltImpl(input.accountId)
+    // A non-empty salt means the account is initialized -> fully good.
+    if (salt && salt.length > 0) return { ok: true, code: null, salt: true }
+    // null (404) or empty -> no salt registered yet: fresh account, acceptable.
+    return { ok: true, code: 'ACCOUNT_ID_REQUIRED', salt: false }
+  } catch (err) {
+    return classifyVaultTestError(err)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **Test Connection** button to the GLANCEvault credential section of the Cloud Sync modal, closing the gap where bad vault credentials saved silently and only failed (invisibly) at the first sync. Also adds two read-only reference docs capturing how lastGLANCE's vault credential entry and native fetch path work, so lifeGLANCE can mirror them.

## What changed

**Feature — pre-save credential verification** (`a290140`)
- New `src/sync/testVaultConnection.ts`: a never-throwing probe that reuses the existing `createVaultClient(...).getSalt(accountId)` path, wired with the same native-safe `(url,init)=>Response` adapter over `nativeHttpFetch` that the intents setup uses — so it works on Capacitor (CORS-free) exactly like vault sync, never a plain global fetch. The error classifier is extracted as a pure, exported `classifyVaultTestError`.
- `src/components/SyncSettingsModal/SyncSettingsModal.tsx`: a Test Connection button in the GLANCEvault section, mirroring the WebDAV test button's spinner / green-✓ / red-✗ UX. Result resets when any vault field is edited.

**Typed, distinct outcomes**

| getSalt result | Outcome | Message |
|---|---|---|
| salt present | success | **Connected.** |
| no salt yet (fresh account) | success — `ACCOUNT_ID_REQUIRED` | **Connected — this account will be initialized on first sync.** |
| `401` | `AUTH_FAILURE` | Device token is incorrect. |
| `403` | `FORBIDDEN` | Account ID not found or not permitted for this token. |
| network / bad URL / other | `NETWORK_ERROR` | Could not reach the vault at this URL. |

The salt-not-established case (fresh account, `getSalt` → null/404) is treated as **acceptable, not an error**, surfaced with the existing `ACCOUNT_ID_REQUIRED` typed code — no salt is invented, so first-device setup isn't blocked.

**Reference docs** (`ccb48c8`, `702522b`) — read-only, no code:
- `docs/vault-credential-setup-reference.md` — how credential entry, verification, and activation work end to end.
- `docs/vault-native-fetch-reference.md` — how the vault transport reaches the server on native (CapacitorHttp global patch + explicit `vaultFetchImpl` injection at each vault-client site).

## Scope / safety

- **Pre-save test only**: it does not save, activate, derive a key, or register a salt. Save-on-close is unchanged (not gated).
- No changes to vault sync, the sync engine, intents, or `@glance-apps/*`.
- `VERIFIER_UNSUPPORTED` (server too old) is intentionally **not** reported here — it's a sync-time verifier check, not detectable via `getSalt`; it still surfaces at first sync via the engine's `onError` as before.

## Tests & checks

- `src/sync/testVaultConnection.test.ts` mocks `getSalt` for every outcome (success, salt-not-established incl. empty-salt edge, 401, 403, network, 500-fallback, non-Error throw), tests the pure classifier, and asserts the probe reaches the vault via the native adapter (`nativeHttpFetch`) rather than a plain fetch.
- Full suite: **124 passed (18 files)**. Lint clean. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017d7nSDd7FPSp8jTB9kbFxY)_