### PR TITLE
Fix widget "last done" label to use a calendar-day boundary

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -45,6 +45,7 @@ import com.lastglance.app.R
 import com.lastglance.app.SharedDataStore
 import org.json.JSONObject
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -182,10 +183,42 @@ internal object ChoreSnapshot {
 
     private fun elapsedLabel(chore: JSONObject): String {
         if (chore.isNull("elapsedDays")) return "never"
+        // Prefer a calendar-day boundary off the real timestamp so a chore done
+        // "last night" reads "yesterday", not "today" — matching the app's
+        // formatElapsed(). elapsedDays alone is a duration (<24h reads "today"),
+        // which is why 10pm→8am wrongly showed "today".
+        val days = calendarDaysAgo(chore.optString("lastCompletedAt", ""))
+        if (days != null) {
+            return when {
+                days <= 0 -> "today"
+                days == 1 -> "yesterday"
+                else -> "${days}d ago"
+            }
+        }
+        // Fall back to the elapsed duration when the timestamp is missing.
         val d = chore.optDouble("elapsedDays", 0.0)
         if (d < 1) return "today"
-        val days = Math.round(d)
-        return "${days}d ago"
+        return "${Math.round(d)}d ago"
+    }
+
+    // Whole calendar days between the completion's local day and today's local
+    // day, mirroring the app's dayjs().startOf('day').diff(..., 'day'). Null if
+    // the timestamp is absent or unparseable.
+    private fun calendarDaysAgo(iso: String): Int? {
+        if (iso.isEmpty()) return null
+        val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        fmt.timeZone = TimeZone.getTimeZone("UTC")
+        val date = try { fmt.parse(iso) } catch (e: Exception) { null } ?: return null
+        val then = Calendar.getInstance().apply {
+            time = date
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+        }
+        val now = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+        }
+        return Math.round((now.timeInMillis - then.timeInMillis) / 86_400_000.0).toInt()
     }
 
     private fun parseColor(hex: String): Int {


### PR DESCRIPTION
## Problem

The single-chore Glance widget derived its "last done" label from `elapsedDays`, which is a *duration* (days since last completion), not a calendar date. The old logic labelled anything under 24h as "today":

```kotlin
if (d < 1) return "today"
```

So a chore done at 10pm and viewed at 8am the next morning (~10h elapsed) showed **"today"** on the widget, while the in-app indicator correctly showed **"10h ago"**. Reporting "today" for something done the previous night is confusing.

The app's in-app indicator (`formatElapsed` in `src/utils/cadence.ts`) uses a **calendar-day boundary** for the day-level label — `dayjs().startOf('day').diff(lastCompletedAt.startOf('day'), 'day')` — which is why it crosses midnight into "yesterday".

## Fix

Rewrite `elapsedLabel()` in `SingleChoreWidget.kt` to compute whole calendar days from the real `lastCompletedAt` timestamp (already shipped in the widget snapshot, just previously unused), mirroring the app's `formatElapsed`:

- same calendar day → "today"
- one calendar day back → **"yesterday"** (the reported case)
- otherwise → "Nd ago"

Falls back to the old `elapsedDays` duration behaviour if the timestamp is missing. Uses `SimpleDateFormat`/`Calendar` (not `java.time`) to stay compatible with `minSdk 24` without core-library desugaring. Kept to day granularity on the widget per the request — no sub-day "10h ago" precision on the widget itself.

## Testing notes

This is a Kotlin change to the Android Glance widget; verifying it visually requires an Android build/emulator, which isn't available in this environment. The logic mirrors the app's existing `formatElapsed` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vhf1yZFWMjZwESDBStk9es

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vhf1yZFWMjZwESDBStk9es)_