### PR TITLE
Fix bottom-sheet modals covered by Android gesture nav bar (#179)

### DIFF
--- a/src/components/ActivityLogModal/ActivityLogModal.tsx
+++ b/src/components/ActivityLogModal/ActivityLogModal.tsx
@@ -57,7 +57,7 @@ export function ActivityLogModal({ onClose }: Props) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[85vh]">

--- a/src/components/BackupModal/BackupModal.tsx
+++ b/src/components/BackupModal/BackupModal.tsx
@@ -141,7 +141,7 @@ export function BackupModal({ engine, onClose, onImported }: Props) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl border border-slate-200 dark:border-slate-700/50">

--- a/src/components/CategoryFormModal/CategoryFormModal.tsx
+++ b/src/components/CategoryFormModal/CategoryFormModal.tsx
@@ -74,7 +74,7 @@ export function CategoryFormModal({ category, parentCategoryId, parentIcon, root
   return createPortal(
     <>
       <div
-        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
         onClick={e => { if (e.target === e.currentTarget) onClose() }}
       >
         <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 space-y-4 shadow-2xl border border-slate-200 dark:border-slate-700/50">

--- a/src/components/CategorySection/CategorySection.tsx
+++ b/src/components/CategorySection/CategorySection.tsx
@@ -672,7 +672,7 @@ function ConfirmDialog({
   useEscapeKey(onCancel)
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onCancel() }}
     >
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 space-y-4 shadow-2xl border border-slate-200 dark:border-slate-700/50">

--- a/src/components/ChoreFormModal/ChoreFormModal.tsx
+++ b/src/components/ChoreFormModal/ChoreFormModal.tsx
@@ -127,7 +127,7 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
   return createPortal(
     <>
       <div
-        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
         onClick={e => { if (e.target === e.currentTarget) onClose() }}
       >
         <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 space-y-4 shadow-2xl border border-slate-200 dark:border-slate-700/50">

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -58,7 +58,7 @@ export function HelpModal({ onClose, onOpenShortcuts }: Props) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">

--- a/src/components/IconPicker/IconPicker.tsx
+++ b/src/components/IconPicker/IconPicker.tsx
@@ -27,7 +27,7 @@ export function IconPicker({ selected, onSelect, onClose }: Props) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/70 backdrop-blur-sm"
+      className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/70 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700/50 rounded-t-2xl sm:rounded-2xl shadow-2xl flex flex-col max-h-[85svh]">

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -197,7 +197,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
 
   const modal = createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90vh]">

--- a/src/components/LogModal/LogModal.tsx
+++ b/src/components/LogModal/LogModal.tsx
@@ -87,7 +87,7 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="

--- a/src/components/PassphraseModal/PassphraseModal.tsx
+++ b/src/components/PassphraseModal/PassphraseModal.tsx
@@ -32,7 +32,7 @@ export function PassphraseModal({ onSubmit, onClose }: Props) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl border border-slate-200 dark:border-slate-700/50">

--- a/src/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal/ShortcutsModal.tsx
@@ -43,7 +43,7 @@ export function ShortcutsModal({ onClose }: Props) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-60 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -294,7 +294,7 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) handleClose() }}
     >
       <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90vh]">

--- a/src/components/UsersModal/UsersModal.tsx
+++ b/src/components/UsersModal/UsersModal.tsx
@@ -143,7 +143,7 @@ export function UsersModal({ engine, onUserMutated, onClose }: Props) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
       <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90vh]">

--- a/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/src/components/WelcomeModal/WelcomeModal.tsx
@@ -22,7 +22,7 @@ export function WelcomeModal({ onGetStarted, onClearSample, clearing }: Props) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onGetStarted() }}
     >
       <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl border border-slate-200 dark:border-slate-700/50">

--- a/src/index.css
+++ b/src/index.css
@@ -46,3 +46,16 @@
     padding-top: max(0.5rem, env(safe-area-inset-top));
   }
 }
+
+/* Modal overlays cover the full screen; on mobile the panel is a bottom sheet
+   anchored to the bottom edge (items-end), where Android's transparent gesture
+   nav draws over its actions (issue #179). Pad the overlay's bottom by the
+   safe-area inset so the sheet is lifted clear of the nav bar — the overlay's
+   own backdrop still fills the screen behind the bar. Mobile only: at >=sm
+   (640px) the modal re-centers as a floating dialog and no longer touches the
+   edge, so the inset isn't needed there. */
+@media (max-width: 639.98px) {
+  .app-safe-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}


### PR DESCRIPTION
Fixes #179.

## Problem

On mobile, the modals render as bottom sheets (`items-end`, `rounded-t-2xl`) anchored to the screen's bottom edge. Because each is a `fixed inset-0` portal, it sits *outside* the app root's `paddingBottom: env(safe-area-inset-bottom)` (`src/App.tsx:441`). With `targetSdk 36` edge-to-edge, Android's transparent gesture nav bar draws *over* the sheet — so its bottom action buttons (Save/Cancel, etc.) get partially covered, as reported in #179.

The main screen already handled its own bottom inset; this was specific to the modal/sheet overlays.

## Fix

Add a small `.app-safe-bottom` utility in `src/index.css` that pads the overlay container's bottom by the safe-area inset:

```css
@media (max-width: 639.98px) {
  .app-safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
}
```

Applied to the overlay container of all 14 bottom-sheet modals. This lifts the sheet clear of the nav bar, while the overlay's own backdrop still fills the screen behind the bar (no visible gap).

Design choices:
- **On the overlay container, not each panel** — uniform, touches no modal's internal layout, and avoids magic numbers coupled to per-panel padding (`p-6` vs internal-scroll footers).
- **Scoped to `<640px`** — at `>=sm` the modal re-centers as a floating dialog that no longer touches the bottom edge, so the inset isn't needed there.

SearchModal is a top-anchored palette (`items-start`) with no bottom action bar, so it's unaffected and left untouched.

## Testing

- `npm run build` (tsc + vite) — passes; verified the rule compiled into the CSS bundle
- `npm run lint` — clean (0 warnings)
- `npm test` — 124/124 pass

**Caveat:** this is a visual layout fix and no Android emulator was available in this environment, so I could not confirm on-device that the sheets now clear the nav bar. The approach mirrors the existing top-inset handling (`.app-safe-top`) and uses standard `env(safe-area-inset-bottom)`. A quick device/emulator check on one bottom sheet (e.g. the chore form) would be the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vhf1yZFWMjZwESDBStk9es

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vhf1yZFWMjZwESDBStk9es)_