### PR TITLE
Add Tasker/Android intents transport

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,33 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <!-- Tasker/automation Activity path: an Activity-target intent can
+                 launch/foreground the app and carry a payload (works on cold
+                 start; onCreate/onNewIntent store it). The broadcast <receiver>
+                 below handles the backgrounded/killed case. -->
+            <intent-filter>
+                <action android:name="app.lastglance.CREATE" />
+                <action android:name="app.lastglance.COMPLETE" />
+                <action android:name="app.lastglance.OPEN" />
+                <action android:name="app.lastglance.QUERY" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
+
+        <!-- Tasker/automation broadcast path: fires even when the app is
+             backgrounded or killed (manifest-declared, so Android instantiates
+             the receiver regardless of process state). Stored and drained by the
+             web app via the IntentsBridge plugin. -->
+        <receiver
+            android:name=".intents.IntentReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="app.lastglance.CREATE" />
+                <action android:name="app.lastglance.COMPLETE" />
+                <action android:name="app.lastglance.OPEN" />
+                <action android:name="app.lastglance.QUERY" />
+            </intent-filter>
+        </receiver>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -6,14 +6,23 @@ import android.os.Bundle;
 
 import com.getcapacitor.BridgeActivity;
 
+import com.lastglance.app.intents.IntentReceiver;
+import com.lastglance.app.intents.IntentsBridgePlugin;
+
+import org.json.JSONObject;
+
 public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         // Register app-local plugins before the bridge starts.
         registerPlugin(WidgetBridgePlugin.class);
+        registerPlugin(IntentsBridgePlugin.class);
         super.onCreate(savedInstanceState);
         captureWidgetDeepLink(getIntent());
         captureSharedText(getIntent());
+        // Cold start via a Tasker Activity intent: the web app drains the slot on
+        // mount, so just store it here (no wake needed — nothing is listening yet).
+        captureTaskerIntent(getIntent(), false);
     }
 
     @Override
@@ -21,6 +30,46 @@ public class MainActivity extends BridgeActivity {
         super.onNewIntent(intent);
         captureWidgetDeepLink(intent);
         captureSharedText(intent);
+        // Warm Activity intent (app already running): store it AND wake the WebView.
+        captureTaskerIntent(intent, true);
+    }
+
+    // Capture an Activity-target Tasker intent (app.lastglance.*). The manifest
+    // <receiver> handles the broadcast path (background/killed); this handles the
+    // Activity path a sender uses to foreground/cold-start the app. Stores the
+    // intent in the same {action, payload} shape IntentReceiver uses so the web
+    // drain is uniform. When `wake` is true, poke a running WebView via the same
+    // internal INTENT_RECEIVED signal the broadcast path uses.
+    private void captureTaskerIntent(Intent intent, boolean wake) {
+        if (intent == null) return;
+        String action = intent.getAction();
+        if (action == null || !action.startsWith("app.lastglance.")) return;
+        if (!action.equals("app.lastglance.CREATE")
+            && !action.equals("app.lastglance.COMPLETE")
+            && !action.equals("app.lastglance.OPEN")
+            && !action.equals("app.lastglance.QUERY")) {
+            return;
+        }
+
+        JSONObject payloadObj;
+        try {
+            String raw = intent.getStringExtra("payload");
+            payloadObj = (raw != null) ? new JSONObject(raw) : new JSONObject();
+        } catch (Exception e) {
+            payloadObj = new JSONObject();
+        }
+        try {
+            String pending = new JSONObject().put("action", action).put("payload", payloadObj).toString();
+            SharedDataStore.writePendingIntent(this, pending);
+        } catch (Exception e) {
+            return;
+        }
+
+        if (wake) {
+            Intent poke = new Intent(IntentReceiver.INTENT_RECEIVED);
+            poke.setPackage(getPackageName());
+            sendBroadcast(poke);
+        }
     }
 
     // A share from another app (ACTION_SEND, text/plain) seeds a new chore. Prefer

--- a/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
+++ b/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
@@ -22,6 +22,12 @@ public final class SharedDataStore {
     // Text shared into the app (ACTION_SEND) to seed a new chore's name, captured
     // by MainActivity and consumed by the web app on foreground.
     private static final String KEY_SHARED_CHORE = "pending_shared_chore";
+    // A single inbound Android/Tasker intent (app.lastglance.*), captured by the
+    // manifest IntentReceiver (broadcast) or MainActivity (Activity launch),
+    // drained by the web app via the IntentsBridge plugin. JSON: {action,payload}.
+    // Single-depth on purpose: each Activity intent is self-sufficient and a live
+    // broadcast wakes the WebView immediately, so bursts don't queue here.
+    private static final String KEY_PENDING_INTENT = "pending_intent";
 
     private SharedDataStore() {}
 
@@ -78,6 +84,18 @@ public final class SharedDataStore {
     public static String readAndClearPendingSharedChore(Context context) {
         String value = prefs(context).getString(KEY_SHARED_CHORE, null);
         if (value != null) prefs(context).edit().remove(KEY_SHARED_CHORE).apply();
+        return value;
+    }
+
+    // Store an inbound Android/Tasker intent as a JSON string {action, payload}.
+    public static void writePendingIntent(Context context, String json) {
+        prefs(context).edit().putString(KEY_PENDING_INTENT, json).apply();
+    }
+
+    // Read + clear the pending intent slot. Returns null when empty.
+    public static String readAndClearPendingIntent(Context context) {
+        String value = prefs(context).getString(KEY_PENDING_INTENT, null);
+        if (value != null) prefs(context).edit().remove(KEY_PENDING_INTENT).apply();
         return value;
     }
 }

--- a/android/app/src/main/java/com/lastglance/app/intents/IntentReceiver.java
+++ b/android/app/src/main/java/com/lastglance/app/intents/IntentReceiver.java
@@ -1,0 +1,58 @@
+package com.lastglance.app.intents;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import com.lastglance.app.SharedDataStore;
+
+import org.json.JSONObject;
+
+// The broadcast entry point for the Android/Tasker intents transport. Because it
+// is declared in the manifest, Android instantiates it EVEN IF the app process
+// is dead — so a Tasker CREATE/COMPLETE/OPEN/QUERY broadcast is captured whether
+// the app is foregrounded, backgrounded, or killed.
+//
+// It stores the intent to a persistent slot (drained by the web app via the
+// IntentsBridge plugin on next run) and, if a MainActivity is alive, wakes it
+// with an internal package-scoped broadcast so the WebView drains immediately.
+//
+// See docs/tasker-intents-architecture.md §4.2.
+public class IntentReceiver extends BroadcastReceiver {
+
+    // Internal, package-scoped signal that a new intent has landed. MainActivity
+    // registers a runtime receiver for this to poke the WebView while running.
+    public static final String INTENT_RECEIVED = "com.lastglance.app.INTENT_RECEIVED";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if (action == null) return;
+
+        // Re-serialize the payload through JSONObject rather than trusting the raw
+        // extra: a crafted `payload` string can't inject structure this way.
+        JSONObject payloadObj;
+        try {
+            String raw = intent.getStringExtra("payload");
+            payloadObj = (raw != null) ? new JSONObject(raw) : new JSONObject();
+        } catch (Exception e) {
+            payloadObj = new JSONObject();
+        }
+
+        try {
+            String pending = new JSONObject()
+                .put("action", action)
+                .put("payload", payloadObj)
+                .toString();
+            SharedDataStore.writePendingIntent(context, pending);
+        } catch (Exception e) {
+            return;
+        }
+
+        // Wake a running MainActivity (no-op if the app is killed — the slot is
+        // drained on next launch). Package-scoped so no other app receives it.
+        Intent wake = new Intent(INTENT_RECEIVED);
+        wake.setPackage(context.getPackageName());
+        context.sendBroadcast(wake);
+    }
+}

--- a/android/app/src/main/java/com/lastglance/app/intents/IntentsBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/intents/IntentsBridgePlugin.java
@@ -1,0 +1,90 @@
+package com.lastglance.app.intents;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import androidx.core.content.ContextCompat;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import com.lastglance.app.SharedDataStore;
+
+// The JS-callable surface of the Android/Tasker intents transport, the Capacitor
+// equivalent of dayGLANCE's @JavascriptInterface NativeBridge
+// (see docs/tasker-intents-architecture.md §4.4 / §8.1).
+//
+//   getPendingIntent()   read + clear the single pending-intent slot
+//   reportIntentResult() emit app.lastglance.RESULT (the handled outcome / QUERY reply)
+//   sendNotifyBroadcast()emit app.lastglance.NOTIFY (a chore changed state)
+//
+// It also owns the "wake the WebView" path: a runtime receiver for the internal
+// INTENT_RECEIVED signal, registered for the plugin's whole lifetime
+// (load → handleOnDestroy) so background delivery works — registering on
+// resume/pause would go deaf exactly when Tasker fires at a backgrounded app.
+// On receive it fires the `pendingIntent` event; the web bridge drains in response.
+@CapacitorPlugin(name = "IntentsBridge")
+public class IntentsBridgePlugin extends Plugin {
+
+    private static final String ACTION_RESULT = "app.lastglance.RESULT";
+    private static final String ACTION_NOTIFY = "app.lastglance.NOTIFY";
+
+    private final BroadcastReceiver intentReceivedReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            notifyListeners("pendingIntent", new JSObject());
+        }
+    };
+
+    @Override
+    public void load() {
+        ContextCompat.registerReceiver(
+            getContext(),
+            intentReceivedReceiver,
+            new IntentFilter(IntentReceiver.INTENT_RECEIVED),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        );
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        try {
+            getContext().unregisterReceiver(intentReceivedReceiver);
+        } catch (IllegalArgumentException e) {
+            // Not registered (e.g. load() never ran) — nothing to do.
+        }
+    }
+
+    @PluginMethod
+    public void getPendingIntent(PluginCall call) {
+        String json = SharedDataStore.readAndClearPendingIntent(getContext());
+        JSObject ret = new JSObject();
+        ret.put("value", json != null ? json : "");
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void reportIntentResult(PluginCall call) {
+        String action = call.getString("action");
+        String result = call.getString("result");
+        Intent intent = new Intent(ACTION_RESULT);
+        intent.putExtra("action", action);
+        intent.putExtra("result", result);
+        getContext().sendBroadcast(intent);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void sendNotifyBroadcast(PluginCall call) {
+        String payload = call.getString("payload");
+        Intent intent = new Intent(ACTION_NOTIFY);
+        intent.putExtra("payload", payload);
+        getContext().sendBroadcast(intent);
+        call.resolve();
+    }
+}

--- a/docs/tasker-integration.md
+++ b/docs/tasker-integration.md
@@ -1,0 +1,167 @@
+# Driving lastGLANCE from Tasker (Android intents)
+
+lastGLANCE (Android) can be driven by another Android app — **Tasker**,
+MacroDroid, Automate, or anything that can send an intent. You can create
+chores, mark them done, foreground the app, and read live counts, all without
+touching the screen.
+
+This is **Android-only**. iOS has no equivalent broadcast mechanism.
+
+> Implementation details live in [`tasker-intents-architecture.md`](./tasker-intents-architecture.md).
+> This page is the end-user recipe.
+
+---
+
+## The actions
+
+Every inbound action is an Android intent whose **action string** is one of the
+four below, carrying a single **`payload` String extra** containing a JSON
+object.
+
+| Action string | What it does |
+|---|---|
+| `app.lastglance.CREATE`   | Create a chore |
+| `app.lastglance.COMPLETE` | Log a completion for a chore (match by title) |
+| `app.lastglance.OPEN`     | Foreground the app, optionally routing the UI |
+| `app.lastglance.QUERY`    | Reply with current counts (via a RESULT broadcast) |
+
+Two broadcasts go the other way:
+
+| Action string | Meaning |
+|---|---|
+| `app.lastglance.RESULT` | The outcome of a handled action (also the QUERY reply) |
+| `app.lastglance.NOTIFY` | Fired when a chore is completed via `COMPLETE` |
+
+### Broadcast vs Activity — which to send
+
+- **Broadcast** (Tasker → *Send Intent*, **Package** left blank or targeting the
+  receiver) works while lastGLANCE is **foregrounded, backgrounded, or killed**.
+  When the app is killed the intent is **stored and applied the next time the app
+  runs** — it is not lost, but it is not processed live.
+- **Activity** (Tasker → *Send Intent*, **Target: Activity**) **launches /
+  foregrounds** the app and applies the intent on cold start. Use this for
+  `OPEN`, or when you need a killed app to act *now* (Android forbids launching
+  an Activity from the background, so the app will come to the foreground).
+
+A good pattern: send as a **broadcast** first and treat the `RESULT` broadcast as
+a liveness probe; if no `RESULT` arrives within a second or two, resend as an
+**Activity** intent.
+
+---
+
+## Payloads
+
+### CREATE — `app.lastglance.CREATE`
+
+```json
+{ "title": "Descale the kettle", "project": "Kitchen" }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `title` | ✅ | The chore name. |
+| `project` | — | A **category** name. If it exists (case-insensitive) the chore goes there; if not, the category is created. Omit it and the chore lands in an auto-created **"Inbox"** category. |
+
+New chores are created with **no cadence** (they won't turn amber/red until you
+give them a target cadence in the app).
+
+**Idempotent:** sending the same `title` into the same category twice does **not**
+create a duplicate — the second call returns the existing chore with a warning.
+So a double-firing Tasker profile is safe.
+
+### COMPLETE — `app.lastglance.COMPLETE`
+
+```json
+{ "title": "Mop kitchen" }
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `title` | ✅ | Matched against chore names: an **exact** (case-insensitive) match wins; otherwise a **unique substring** match is accepted (the RESULT carries a `warning` noting the fuzzy match). |
+| `completed_at` | — | ISO-8601 timestamp with offset (e.g. `2026-07-02T09:30:00+02:00`). Defaults to now. |
+
+If the title matches **nothing** or is **ambiguous** (more than one chore), the
+action fails and the RESULT `error` explains which.
+
+### OPEN — `app.lastglance.OPEN`
+
+```json
+{ "tab": "soon" }
+```
+
+Send as an **Activity** intent (Target: Activity) so it can foreground the app.
+
+| `tab` value | Result |
+|---|---|
+| `soon` / `due` / `attention` | Foreground and switch on the **Soon** (needs-attention) filter |
+| `search` / `find` | Foreground and open **search** |
+| `add` / `new` / `create` | Foreground and open the **new-chore** form |
+| *(anything else / omitted)* | Just foreground the app |
+
+### QUERY — `app.lastglance.QUERY`
+
+```json
+{}
+```
+
+No payload fields. lastGLANCE replies with a `RESULT` broadcast (see below).
+To read the reply, the app must be **running** (send `QUERY` as a broadcast to a
+foregrounded/backgrounded app, or `OPEN` it first).
+
+---
+
+## Reading replies: the RESULT broadcast
+
+After every handled action lastGLANCE broadcasts `app.lastglance.RESULT` with two
+String extras:
+
+- `action` — the **original** action you sent (e.g. `app.lastglance.COMPLETE`), so
+  your profile's `%action` matches what it fired.
+- `result` — a **JSON string** you parse (Tasker: *Variable → Structure Output
+  (JSON)* on the receiving variable, or the *JSON Read* action).
+
+`result` always contains:
+
+| Key | Meaning |
+|---|---|
+| `success` | `true` / `false` |
+| `chore_id` | The affected chore's stable id (CREATE / COMPLETE) |
+| `error` | Present when `success` is `false` |
+| `warning` | Present on a non-fatal note (fuzzy match, duplicate ignored) |
+
+A `QUERY` reply additionally carries these count variables (named so they read
+naturally after parsing):
+
+| Key | Meaning |
+|---|---|
+| `%lg_count_due` | Chores needing attention now (amber/red — soon **and** overdue) |
+| `%lg_count_overdue` | Chores past their target cadence |
+| `%lg_count_done_today` | Completions logged today |
+| `%lg_count_total` | Total chores across all categories |
+
+To receive `RESULT` (and `NOTIFY`) in Tasker, add a **Profile → Event → System →
+Intent Received** with the matching action string.
+
+## The NOTIFY broadcast
+
+When a chore is completed **via a `COMPLETE` intent**, lastGLANCE broadcasts
+`app.lastglance.NOTIFY` with a `payload` String extra (JSON). Use it to have
+automation react to completions. The JSON's inner `payload` object includes
+`source_entity_id` (the chore id), `title`, and `completed_at`.
+
+> Completions made **inside the app** do not currently emit this broadcast — only
+> those driven through the `COMPLETE` intent do.
+
+---
+
+## Gotchas
+
+- **OPEN needs Target: Activity.** A broadcast can't foreground the app.
+- **RESULT/QUERY need a receiver profile.** Without an *Intent Received* profile
+  listening for `app.lastglance.RESULT`, the reply goes nowhere.
+- **Parse the `result` string.** It's one JSON string, not separate extras.
+- **The pending slot is single-depth.** Two intents fired in the same instant can
+  overwrite each other before the app reads the first. Space bursts out, or make
+  each send self-sufficient. (Activity intents each cold-start cleanly.)
+- **Namespace.** Everything is under `app.lastglance.*`, distinct from dayGLANCE's
+  `app.dayglance.*`, so the two apps never cross-talk if both are installed.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { usePendingCompletions } from '@/hooks/usePendingCompletions'
 import { usePendingDeepLink } from '@/hooks/usePendingDeepLink'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
 import { useDbIntentsPoller } from '@/hooks/useDbIntentsPoller'
+import { useAndroidIntentBridge } from '@/hooks/useAndroidIntentBridge'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
@@ -361,6 +362,9 @@ function AppInner() {
   // GLANCEvault DB intents transport — gated by isDbIntentsEnabled(); a no-op
   // unless the per-user opt-in is on. WebDAV intents above remain the default.
   useDbIntentsPoller(loadHeatmap)
+  // Android/Tasker intents transport — lets another Android app drive lastGLANCE
+  // via app.lastglance.* intents. No-op off native Android.
+  useAndroidIntentBridge(loadHeatmap)
   // OUTBOUND: drain the durable intents outbox on mount, on focus, and on the
   // poll cadence (enqueue also triggers a flush). Guarantees queued intents are
   // delivered/retried and never lost across restarts.

--- a/src/hooks/useAndroidIntentBridge.ts
+++ b/src/hooks/useAndroidIntentBridge.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from 'react'
+import type { PluginListenerHandle } from '@capacitor/core'
+import { handleIntent, type IntentResult } from '@/intents/handleIntent'
+import { buildIntentContext } from '@/intents/intentContext'
+import { BROADCAST_ACTION_MAP } from '@/intents/androidIntents'
+import {
+  isAndroid,
+  nativeGetPendingIntent,
+  nativeReportIntentResult,
+  addPendingIntentListener,
+} from '@/native/intentsBridge'
+
+// The Android/Tasker intents transport bridge (see
+// docs/tasker-intents-architecture.md §3.2), ported to Capacitor. Mounted once
+// near the app root. It:
+//   1. drains the native pending-intent slot on mount (catches app-opened-via-
+//      intent / cold start), on the plugin's `pendingIntent` event (a live
+//      intent while running), and on return to foreground;
+//   2. MAPS the fully-qualified action to the short handler constant (the
+//      action-string gotcha, §5);
+//   3. runs the pure handleIntent(), then reports the result back to native
+//      under the ORIGINAL action so the sender's %action matches.
+//
+// No-op off Android. `onChanged` refreshes derived UI (the heatmap) after a
+// mutating action.
+export function useAndroidIntentBridge(onChanged?: () => void): void {
+  const onChangedRef = useRef(onChanged)
+  onChangedRef.current = onChanged
+
+  useEffect(() => {
+    if (!isAndroid()) return
+
+    let cancelled = false
+    let listener: PluginListenerHandle | null = null
+    // The pending slot is single-depth; guard against overlapping drains and, if
+    // a new intent arrived while we were busy, drain again once we're done.
+    let draining = false
+    let rerun = false
+
+    const drainOnce = async (): Promise<void> => {
+      const intent = await nativeGetPendingIntent()
+      if (!intent || cancelled) return
+      const { action, payload } = intent
+      const mapped = BROADCAST_ACTION_MAP[action] ?? action
+      let result: IntentResult
+      try {
+        result = await handleIntent(mapped, payload, buildIntentContext(() => onChangedRef.current?.()))
+      } catch (err) {
+        result = { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+      // Report under the ORIGINAL fully-qualified action, not the mapped one.
+      await nativeReportIntentResult(action, JSON.stringify(result))
+    }
+
+    const drain = async (): Promise<void> => {
+      if (draining) {
+        rerun = true
+        return
+      }
+      draining = true
+      try {
+        do {
+          rerun = false
+          await drainOnce()
+        } while (rerun && !cancelled)
+      } finally {
+        draining = false
+      }
+    }
+
+    addPendingIntentListener(() => { void drain() }).then(h => {
+      if (cancelled) h?.remove()
+      else listener = h
+    })
+
+    // Cold start / app opened via an Activity intent: the payload is already in
+    // the slot before any event fires, so drain immediately on mount.
+    void drain()
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void drain()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      cancelled = true
+      document.removeEventListener('visibilitychange', onVisibility)
+      listener?.remove()
+    }
+  }, [])
+}

--- a/src/intents/androidIntents.ts
+++ b/src/intents/androidIntents.ts
@@ -1,0 +1,59 @@
+// Android / Tasker intents transport — constants.
+//
+// lastGLANCE can be driven by another Android app (Tasker, MacroDroid, Automate,
+// …) via Android intents. This mirrors the dayGLANCE design (see
+// docs/tasker-intents-architecture.md) but under the `app.lastglance.*`
+// namespace so the two apps never cross-talk when installed together.
+//
+// The *short* action constants (`create`, `complete`, …) come from the shared
+// @glance-apps/intents package and are IDENTICAL across the GLANCE apps, so the
+// pure handler and the file transports stay compatible. Only the fully-qualified
+// Android action strings and the Tasker return-variable names are app-specific.
+
+import { ACTIONS } from '@glance-apps/intents'
+
+// Fully-qualified Android actions a sender uses. Registered in the manifest both
+// as a broadcast <receiver> (works while backgrounded/killed) and as <activity>
+// intent-filters (so a sender can foreground the app on a cold start).
+export const LG_ANDROID_ACTIONS = {
+  CREATE: 'app.lastglance.CREATE',
+  COMPLETE: 'app.lastglance.COMPLETE',
+  OPEN: 'app.lastglance.OPEN',
+  QUERY: 'app.lastglance.QUERY',
+} as const
+
+// Outbound broadcasts lastGLANCE fires back to the sender.
+export const LG_ANDROID_OUTBOUND = {
+  // The outcome of a handled inbound action (also the QUERY reply / liveness ack).
+  RESULT: 'app.lastglance.RESULT',
+  // Fired when a chore is completed via the COMPLETE action, so automation can react.
+  NOTIFY: 'app.lastglance.NOTIFY',
+} as const
+
+// THE ACTION-STRING GOTCHA (see architecture doc §5): native stores the
+// fully-qualified action (`app.lastglance.COMPLETE`), but handleIntent switches
+// on the SHORT constants (`complete`). Map at the bridge; report RESULT back
+// under the ORIGINAL action so the sender's %action matches what it sent.
+//
+// Typed as Record<string, Action> so a missing case is caught at the call site.
+export const BROADCAST_ACTION_MAP: Record<string, string> = {
+  [LG_ANDROID_ACTIONS.CREATE]: ACTIONS.CREATE,
+  [LG_ANDROID_ACTIONS.COMPLETE]: ACTIONS.COMPLETE,
+  [LG_ANDROID_ACTIONS.OPEN]: ACTIONS.OPEN,
+  [LG_ANDROID_ACTIONS.QUERY]: ACTIONS.QUERY,
+}
+
+// QUERY reply variables, Tasker-style `%`-prefixed so they read naturally after
+// the receiving profile parses the RESULT JSON. lastGLANCE-specific (`%lg_`),
+// distinct from dayGLANCE's `%dg_` set, and named for a chore/cadence app rather
+// than a task/due-date app.
+export const LG_QUERY_VARS = {
+  // Chores that have aged into the amber/red "needs attention" zone (soon+overdue).
+  COUNT_DUE: '%lg_count_due',
+  // Chores past their cadence (actually overdue).
+  COUNT_OVERDUE: '%lg_count_overdue',
+  // Completions logged today (local calendar day).
+  COUNT_DONE_TODAY: '%lg_count_done_today',
+  // Total chores across all categories.
+  COUNT_TOTAL: '%lg_count_total',
+} as const

--- a/src/intents/handleIntent.test.ts
+++ b/src/intents/handleIntent.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ACTIONS } from '@glance-apps/intents'
+import { handleIntent, matchChoreByTitle, type IntentChore, type IntentContext } from './handleIntent'
+import { LG_QUERY_VARS } from './androidIntents'
+
+const CHORE_A: IntentChore = {
+  id: 1,
+  sync_id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  name: 'Mop kitchen',
+  category_id: 10,
+  target_cadence_days: 14,
+  elapsed_days: 20, // ratio 1.43 → overdue (and due)
+}
+const CHORE_B: IntentChore = {
+  id: 2,
+  sync_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  name: 'Clean bathrooms',
+  category_id: 10,
+  target_cadence_days: 7,
+  elapsed_days: 6, // ratio 0.86 → due (needs attention) but not overdue
+}
+const CHORE_C: IntentChore = {
+  id: 3,
+  sync_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+  name: 'Wash car',
+  category_id: 20,
+  target_cadence_days: 30,
+  elapsed_days: 3, // ratio 0.1 → neither
+}
+
+function fullContext(overrides: Partial<IntentContext> = {}): IntentContext {
+  return {
+    listChores: vi.fn(async () => [CHORE_A, CHORE_B, CHORE_C]),
+    ensureCategory: vi.fn(async () => 10),
+    createChore: vi.fn(async () => ({ id: 99, sync_id: 'new-sync-id' })),
+    getDoneToday: vi.fn(async () => 4),
+    logCompletion: vi.fn(async () => {}),
+    navigate: vi.fn(),
+    onChoreCompleted: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('handleIntent – CREATE', () => {
+  it('creates a chore, mapping project → category', async () => {
+    const ctx = fullContext({
+      listChores: vi.fn(async () => []),
+      ensureCategory: vi.fn(async () => 42),
+    })
+    const res = await handleIntent(ACTIONS.CREATE, { title: 'Descale kettle', project: 'Kitchen' }, ctx)
+    expect(res.success).toBe(true)
+    expect(res.chore_id).toBe('new-sync-id')
+    expect(ctx.ensureCategory).toHaveBeenCalledWith('Kitchen')
+    expect(ctx.createChore).toHaveBeenCalledWith({ name: 'Descale kettle', categoryId: 42 })
+  })
+
+  it('resolves the Inbox (null) when no project is given', async () => {
+    const ctx = fullContext({ listChores: vi.fn(async () => []) })
+    await handleIntent(ACTIONS.CREATE, { title: 'Buy stamps' }, ctx)
+    expect(ctx.ensureCategory).toHaveBeenCalledWith(null)
+  })
+
+  it('is idempotent: a duplicate (name, category) returns the existing chore, no create', async () => {
+    const ctx = fullContext()
+    const res = await handleIntent(ACTIONS.CREATE, { title: 'Mop kitchen', project: 'Home' }, ctx)
+    expect(res.success).toBe(true)
+    expect(res.chore_id).toBe(CHORE_A.sync_id)
+    expect(res.warning).toMatch(/already exists/i)
+    expect(ctx.createChore).not.toHaveBeenCalled()
+  })
+
+  it('rejects a payload with no title', async () => {
+    const res = await handleIntent(ACTIONS.CREATE, { project: 'Home' }, fullContext())
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/Invalid CREATE/)
+  })
+
+  it('skeleton mode echoes the title without mutating', async () => {
+    const res = await handleIntent(ACTIONS.CREATE, { title: 'Dust shelves' }, {})
+    expect(res).toEqual({ success: true, title: 'Dust shelves' })
+  })
+})
+
+describe('handleIntent – COMPLETE', () => {
+  it('logs a completion for an exact title match', async () => {
+    const ctx = fullContext()
+    const res = await handleIntent(ACTIONS.COMPLETE, { title: 'Wash car' }, ctx)
+    expect(res.success).toBe(true)
+    expect(res.chore_id).toBe(CHORE_C.sync_id)
+    expect(res.warning).toBeUndefined()
+    expect(ctx.logCompletion).toHaveBeenCalledWith(CHORE_C.id, undefined)
+    expect(ctx.onChoreCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({ sync_id: CHORE_C.sync_id, name: 'Wash car' }),
+    )
+  })
+
+  it('passes completed_at through to logCompletion', async () => {
+    const ctx = fullContext()
+    const when = '2026-06-01T09:30:00.000Z'
+    await handleIntent(ACTIONS.COMPLETE, { title: 'Wash car', completed_at: when }, ctx)
+    expect(ctx.logCompletion).toHaveBeenCalledWith(CHORE_C.id, when)
+  })
+
+  it('fuzzy-matches a unique substring and warns', async () => {
+    const ctx = fullContext()
+    const res = await handleIntent(ACTIONS.COMPLETE, { title: 'car' }, ctx)
+    expect(res.success).toBe(true)
+    expect(res.chore_id).toBe(CHORE_C.sync_id)
+    expect(res.warning).toMatch(/Fuzzy-matched/)
+  })
+
+  it('errors when no chore matches', async () => {
+    const res = await handleIntent(ACTIONS.COMPLETE, { title: 'Feed the dragon' }, fullContext())
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/No chore matches/)
+  })
+
+  it('errors when a fuzzy title is ambiguous', async () => {
+    // "clean" is a substring of two chores → ambiguous, no exact match.
+    const ctx = fullContext({
+      listChores: vi.fn(async () => [
+        { ...CHORE_B, id: 2, sync_id: 'b1', name: 'Clean bathrooms' },
+        { ...CHORE_B, id: 3, sync_id: 'b2', name: 'Clean windows' },
+      ]),
+    })
+    const res = await handleIntent(ACTIONS.COMPLETE, { title: 'clean' }, ctx)
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/matches 2 chores/)
+    expect(ctx.logCompletion).not.toHaveBeenCalled()
+  })
+
+  it('skeleton mode echoes the title without mutating', async () => {
+    const res = await handleIntent(ACTIONS.COMPLETE, { title: 'Wash car' }, {})
+    expect(res).toEqual({ success: true, title: 'Wash car' })
+  })
+})
+
+describe('handleIntent – OPEN', () => {
+  it.each([
+    ['soon', 'soon'],
+    ['due', 'soon'],
+    ['search', 'search'],
+    ['add', 'add'],
+    ['whatever', 'app'],
+    [undefined, 'app'],
+  ])('routes tab=%s → %s', async (tab, expected) => {
+    const ctx = fullContext()
+    const res = await handleIntent(ACTIONS.OPEN, tab === undefined ? {} : { tab }, ctx)
+    expect(res.success).toBe(true)
+    expect(ctx.navigate).toHaveBeenCalledWith(expected)
+  })
+})
+
+describe('handleIntent – QUERY', () => {
+  it('returns %lg_ counts computed from cadence state', async () => {
+    const res = await handleIntent(ACTIONS.QUERY, {}, fullContext())
+    expect(res.success).toBe(true)
+    expect(res[LG_QUERY_VARS.COUNT_DUE]).toBe(2) // CHORE_A (overdue) + CHORE_B (attention)
+    expect(res[LG_QUERY_VARS.COUNT_OVERDUE]).toBe(1) // CHORE_A only
+    expect(res[LG_QUERY_VARS.COUNT_DONE_TODAY]).toBe(4)
+    expect(res[LG_QUERY_VARS.COUNT_TOTAL]).toBe(3)
+  })
+
+  it('skeleton mode reports zeros', async () => {
+    const res = await handleIntent(ACTIONS.QUERY, {}, {})
+    expect(res.success).toBe(true)
+    expect(res[LG_QUERY_VARS.COUNT_TOTAL]).toBe(0)
+  })
+})
+
+describe('handleIntent – unknown action', () => {
+  it('returns an error', async () => {
+    const res = await handleIntent('frobnicate', {}, fullContext())
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/Unknown action/)
+  })
+})
+
+describe('matchChoreByTitle', () => {
+  const chores = [CHORE_A, CHORE_B, CHORE_C]
+  it('prefers an exact case-insensitive match over a substring', () => {
+    const withDupPrefix: IntentChore = { ...CHORE_A, id: 5, sync_id: 'x', name: 'Mop kitchen floor' }
+    const m = matchChoreByTitle([CHORE_A, withDupPrefix], 'Mop kitchen')
+    expect(m).toEqual({ kind: 'one', chore: CHORE_A, fuzzy: false })
+  })
+  it('reports none', () => {
+    expect(matchChoreByTitle(chores, 'nope')).toEqual({ kind: 'none' })
+  })
+})

--- a/src/intents/handleIntent.ts
+++ b/src/intents/handleIntent.ts
@@ -1,0 +1,226 @@
+// The pure, transport-agnostic intent handler.
+//
+// A single async function `handleIntent(action, payload, ctx)` that maps a SHORT
+// action constant (`create`/`complete`/`open`/`query`) + payload onto a chore
+// state change and returns a plain result object. It has NO Android knowledge:
+// the Android/Tasker bridge (useAndroidIntentBridge) is one caller, but the
+// handler could be driven by any transport. This mirrors dayGLANCE's
+// handleIntent (see docs/tasker-intents-architecture.md §3.1), adapted to
+// lastGLANCE's chore/cadence domain instead of tasks/due-dates.
+//
+// SKELETON MODE: every state-changing collaborator on `ctx` is optional. When a
+// collaborator is absent the handler validates + normalizes the payload and
+// returns success WITHOUT mutating anything — handy for tests and dry runs.
+//
+// IDEMPOTENCY: automation double-fires. CREATE dedupes by (name, category): a
+// second identical CREATE returns the existing chore's id with a warning rather
+// than adding a duplicate.
+
+import { ACTIONS, CreateSchema, CompleteSchema, OpenSchema } from '@glance-apps/intents'
+import { needsAttention, getFillRatio } from '@/utils/cadence'
+import { LG_QUERY_VARS } from './androidIntents'
+
+// The result object, serialized to JSON as the RESULT `result` extra. Plain keys
+// (success/chore_id/error/warning) parse naturally in a Tasker JSON structure;
+// QUERY adds the `%lg_*` count variables (see androidIntents.ts).
+export interface IntentResult {
+  success: boolean
+  chore_id?: string
+  error?: string
+  warning?: string
+  [k: string]: unknown
+}
+
+// A chore, reduced to what the handler needs. `elapsed_days` is the computed
+// age since last completion (null = never completed); together with
+// `target_cadence_days` it drives the "due"/"overdue" counts.
+export interface IntentChore {
+  id: number
+  sync_id: string
+  name: string
+  category_id: number
+  target_cadence_days: number | null
+  elapsed_days: number | null
+}
+
+// Where OPEN routes once the app is foregrounded. Maps onto the app's existing
+// deep-link events (see intentContext.ts).
+export type OpenTarget = 'soon' | 'search' | 'add' | 'app'
+
+export interface IntentContext {
+  // Read the current chores (with computed elapsed_days). Required by COMPLETE
+  // and QUERY; when absent those actions run in skeleton mode.
+  listChores?: () => Promise<IntentChore[]>
+  // Resolve a category by name to its id, creating it if missing. `null` (no
+  // `project` in the CREATE payload) resolves the dedicated Inbox category.
+  ensureCategory?: (name: string | null) => Promise<number>
+  // Create a chore in a category; returns its new id + stable sync_id.
+  createChore?: (input: { name: string; categoryId: number }) => Promise<{ id: number; sync_id: string }>
+  // Count completions logged today (local calendar day). Used by QUERY.
+  getDoneToday?: () => Promise<number>
+  // Log a completion for a chore.
+  logCompletion?: (choreId: number, completedAt?: string) => Promise<void>
+  // Foreground + route the UI (OPEN).
+  navigate?: (target: OpenTarget) => void
+  // Fired after a COMPLETE succeeds, so the caller can emit an outbound NOTIFY
+  // broadcast and refresh derived UI.
+  onChoreCompleted?: (chore: { sync_id: string; name: string; completedAt: string }) => void
+}
+
+// Maps the OPEN payload's free-form `tab` onto a concrete UI target. Unknown /
+// absent values just foreground the app.
+function resolveOpenTarget(tab: string | undefined): OpenTarget {
+  switch ((tab ?? '').toLowerCase()) {
+    case 'soon':
+    case 'due':
+    case 'attention':
+      return 'soon'
+    case 'search':
+    case 'find':
+      return 'search'
+    case 'add':
+    case 'new':
+    case 'create':
+      return 'add'
+    default:
+      return 'app'
+  }
+}
+
+// Finds the single chore a COMPLETE payload refers to by title. Exact
+// case-insensitive match wins; failing that, a unique substring ("fuzzy") match
+// is accepted with a warning. Returns a discriminated result so the caller can
+// turn "none" / "ambiguous" into a helpful error.
+type MatchResult =
+  | { kind: 'one'; chore: IntentChore; fuzzy: boolean }
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; count: number }
+
+export function matchChoreByTitle(chores: IntentChore[], title: string): MatchResult {
+  const needle = title.trim().toLowerCase()
+  const exact = chores.filter(c => c.name.trim().toLowerCase() === needle)
+  if (exact.length === 1) return { kind: 'one', chore: exact[0], fuzzy: false }
+  if (exact.length > 1) return { kind: 'ambiguous', count: exact.length }
+
+  const partial = chores.filter(c => c.name.toLowerCase().includes(needle))
+  if (partial.length === 1) return { kind: 'one', chore: partial[0], fuzzy: true }
+  if (partial.length > 1) return { kind: 'ambiguous', count: partial.length }
+  return { kind: 'none' }
+}
+
+async function handleCreate(payload: unknown, ctx: IntentContext): Promise<IntentResult> {
+  const parsed = CreateSchema.safeParse(payload)
+  if (!parsed.success) {
+    return { success: false, error: `Invalid CREATE payload: ${parsed.error.issues[0]?.message ?? 'validation failed'}` }
+  }
+  const { title, project } = parsed.data
+
+  // Skeleton mode: no way to persist — just echo the normalized title.
+  if (!ctx.ensureCategory || !ctx.createChore) {
+    return { success: true, title }
+  }
+
+  const categoryId = await ctx.ensureCategory(project ?? null)
+
+  // Idempotency: a re-fired CREATE for the same (name, category) returns the
+  // existing chore instead of duplicating it.
+  if (ctx.listChores) {
+    const existing = (await ctx.listChores()).find(
+      c => c.category_id === categoryId && c.name.trim().toLowerCase() === title.trim().toLowerCase(),
+    )
+    if (existing) {
+      return { success: true, chore_id: existing.sync_id, warning: 'Chore already exists; not duplicated' }
+    }
+  }
+
+  const created = await ctx.createChore({ name: title, categoryId })
+  return { success: true, chore_id: created.sync_id }
+}
+
+async function handleComplete(payload: unknown, ctx: IntentContext): Promise<IntentResult> {
+  const parsed = CompleteSchema.safeParse(payload)
+  if (!parsed.success) {
+    return { success: false, error: `Invalid COMPLETE payload: ${parsed.error.issues[0]?.message ?? 'validation failed'}` }
+  }
+  const { title, completed_at } = parsed.data
+
+  // Skeleton mode.
+  if (!ctx.listChores || !ctx.logCompletion) {
+    return { success: true, title }
+  }
+
+  const match = matchChoreByTitle(await ctx.listChores(), title)
+  if (match.kind === 'none') return { success: false, error: `No chore matches "${title}"` }
+  if (match.kind === 'ambiguous') {
+    return { success: false, error: `"${title}" matches ${match.count} chores; be more specific` }
+  }
+
+  const { chore } = match
+  const completedAt = completed_at ?? new Date().toISOString()
+  await ctx.logCompletion(chore.id, completed_at)
+  ctx.onChoreCompleted?.({ sync_id: chore.sync_id, name: chore.name, completedAt })
+
+  const result: IntentResult = { success: true, chore_id: chore.sync_id }
+  if (match.fuzzy) result.warning = `Fuzzy-matched "${title}" to "${chore.name}"`
+  return result
+}
+
+function handleOpen(payload: unknown, ctx: IntentContext): IntentResult {
+  const parsed = OpenSchema.safeParse(payload)
+  if (!parsed.success) {
+    return { success: false, error: `Invalid OPEN payload: ${parsed.error.issues[0]?.message ?? 'validation failed'}` }
+  }
+  const target = resolveOpenTarget(parsed.data.tab)
+  ctx.navigate?.(target)
+  return { success: true }
+}
+
+async function handleQuery(ctx: IntentContext): Promise<IntentResult> {
+  // Skeleton mode: report zeros so the shape is stable for the sender.
+  if (!ctx.listChores) {
+    return {
+      success: true,
+      [LG_QUERY_VARS.COUNT_DUE]: 0,
+      [LG_QUERY_VARS.COUNT_OVERDUE]: 0,
+      [LG_QUERY_VARS.COUNT_DONE_TODAY]: 0,
+      [LG_QUERY_VARS.COUNT_TOTAL]: 0,
+    }
+  }
+
+  const chores = await ctx.listChores()
+  let due = 0
+  let overdue = 0
+  for (const c of chores) {
+    if (needsAttention(c.target_cadence_days, c.elapsed_days)) due++
+    if (c.target_cadence_days !== null && c.elapsed_days !== null && getFillRatio(c.elapsed_days, c.target_cadence_days) >= 1) {
+      overdue++
+    }
+  }
+
+  return {
+    success: true,
+    [LG_QUERY_VARS.COUNT_DUE]: due,
+    [LG_QUERY_VARS.COUNT_OVERDUE]: overdue,
+    [LG_QUERY_VARS.COUNT_DONE_TODAY]: ctx.getDoneToday ? await ctx.getDoneToday() : 0,
+    [LG_QUERY_VARS.COUNT_TOTAL]: chores.length,
+  }
+}
+
+export async function handleIntent(
+  action: string,
+  payload: unknown,
+  ctx: IntentContext = {},
+): Promise<IntentResult> {
+  switch (action) {
+    case ACTIONS.CREATE:
+      return handleCreate(payload, ctx)
+    case ACTIONS.COMPLETE:
+      return handleComplete(payload, ctx)
+    case ACTIONS.OPEN:
+      return handleOpen(payload, ctx)
+    case ACTIONS.QUERY:
+      return handleQuery(ctx)
+    default:
+      return { success: false, error: `Unknown action: ${action}` }
+  }
+}

--- a/src/intents/intentContext.ts
+++ b/src/intents/intentContext.ts
@@ -1,0 +1,142 @@
+// Wires the pure handleIntent() to lastGLANCE's real DB, navigation, and the
+// outbound NOTIFY broadcast. Kept separate from the transport hook so the hook
+// stays thin and this glue is importable/testable on its own.
+
+import dayjs from 'dayjs'
+import { db } from '@/db/client'
+import { getCategories, createCategory, createChore as dbCreateChore, logCompletion as dbLogCompletion } from '@/db/queries'
+import { getMeUserSyncId } from '@/multiuser/settings'
+import { addActivityEntry } from './config'
+import { nativeSendNotifyBroadcast } from '@/native/intentsBridge'
+import type { IntentChore, IntentContext, OpenTarget } from './handleIntent'
+import { ACTIONS, EVENTS, SOURCE_APPS, eventId } from '@glance-apps/intents'
+
+// The category intent-created chores land in when the CREATE payload names no
+// `project` (or names one that doesn't exist and we fall through to a default).
+const INBOX_CATEGORY_NAME = 'Inbox'
+
+// Loads every chore with its computed `elapsed_days` (age since last completion),
+// the same derivation getChoresForCategory uses, but across all categories in a
+// single pass over completionEvents.
+async function listChores(): Promise<IntentChore[]> {
+  const [chores, events] = await Promise.all([db.chores.toArray(), db.completionEvents.toArray()])
+  const lastByChore = new Map<number, string>()
+  for (const evt of events) {
+    const prev = lastByChore.get(evt.chore_id)
+    if (!prev || evt.completed_at.localeCompare(prev) > 0) lastByChore.set(evt.chore_id, evt.completed_at)
+  }
+  return chores.map(c => {
+    const last = c.id != null ? lastByChore.get(c.id) : undefined
+    const elapsed = last ? dayjs().diff(dayjs(last), 'minute') / (60 * 24) : null
+    return {
+      id: c.id!,
+      sync_id: c.sync_id,
+      name: c.name,
+      category_id: c.category_id,
+      target_cadence_days: c.target_cadence_days,
+      elapsed_days: elapsed !== null ? Math.round(elapsed * 10) / 10 : null,
+    }
+  })
+}
+
+// Finds a category by name (case-insensitive), creating it if absent. A null
+// name (no `project` in the payload) resolves the shared Inbox category.
+async function ensureCategory(name: string | null): Promise<number> {
+  const target = (name ?? INBOX_CATEGORY_NAME).trim()
+  const categories = await getCategories()
+  const existing = categories.find(c => c.name.trim().toLowerCase() === target.toLowerCase())
+  if (existing) return existing.id
+  return createCategory(target)
+}
+
+async function createChore(input: { name: string; categoryId: number }): Promise<{ id: number; sync_id: string }> {
+  const id = await dbCreateChore({
+    name: input.name,
+    category_id: input.categoryId,
+    target_cadence_days: null,
+    notify_when_overdue: false,
+    auto_schedule_to_dayglance: false,
+    preferred_schedule_behavior: null,
+    seasonal_start: null,
+    seasonal_end: null,
+    assigned_user_sync_ids: [],
+  })
+  const created = await db.chores.get(id)
+  return { id, sync_id: created?.sync_id ?? '' }
+}
+
+async function getDoneToday(): Promise<number> {
+  const events = await db.completionEvents.toArray()
+  const today = dayjs().format('YYYY-MM-DD')
+  return events.filter(e => dayjs(e.completed_at).format('YYYY-MM-DD') === today).length
+}
+
+// OPEN routing reuses the app's existing deep-link events (see
+// native/pendingDeepLink.ts). 'app' just foregrounds — nothing to route.
+function navigate(target: OpenTarget): void {
+  switch (target) {
+    case 'soon':
+      window.dispatchEvent(new Event('lg:widget-filter-soon'))
+      break
+    case 'search':
+      window.dispatchEvent(new Event('lg:open-search'))
+      break
+    case 'add':
+      window.dispatchEvent(new Event('lg:new-chore'))
+      break
+    case 'app':
+      break
+  }
+}
+
+// Emits the outbound NOTIFY broadcast for a chore just completed via the Tasker
+// COMPLETE action, so a local listener (Tasker, MacroDroid) can react. Plaintext
+// only — a keyless local listener can't use anything else. Uses the shared
+// NotifySchema field names so the payload is consistent with the file transport.
+function onChoreCompleted(chore: { sync_id: string; name: string; completedAt: string }): void {
+  const now = new Date()
+  const payload = {
+    schema_version: 1,
+    event_id: eventId(now),
+    emitted_at: now.toISOString(),
+    emitted_by: SOURCE_APPS.LASTGLANCE,
+    action: ACTIONS.NOTIFY,
+    payload: {
+      event_id: eventId(now),
+      source_app: SOURCE_APPS.LASTGLANCE,
+      source_entity_id: chore.sync_id,
+      event: EVENTS.COMPLETED,
+      task_id: chore.sync_id,
+      title: chore.name,
+      timestamp: chore.completedAt,
+      completed_at: chore.completedAt,
+    },
+  }
+  nativeSendNotifyBroadcast(JSON.stringify(payload))
+}
+
+// Builds the production IntentContext. `onChanged` refreshes derived UI (heatmap)
+// after a mutating action, mirroring how the pollers call loadHeatmap.
+export function buildIntentContext(onChanged?: () => void): IntentContext {
+  return {
+    listChores,
+    ensureCategory,
+    createChore: async (input) => {
+      const created = await createChore(input)
+      addActivityEntry({ type: 'received', message: `Created "${input.name}" via Tasker` })
+      onChanged?.()
+      return created
+    },
+    getDoneToday,
+    logCompletion: async (choreId, completedAt) => {
+      await dbLogCompletion(choreId, { completedAt, completedByUserSyncId: getMeUserSyncId() })
+      window.dispatchEvent(new CustomEvent('lg:chore-logged'))
+      onChanged?.()
+    },
+    navigate,
+    onChoreCompleted: (chore) => {
+      addActivityEntry({ type: 'received', message: `Completed "${chore.name}" via Tasker` })
+      onChoreCompleted(chore)
+    },
+  }
+}

--- a/src/native/intentsBridge.ts
+++ b/src/native/intentsBridge.ts
@@ -1,0 +1,85 @@
+import { Capacitor, registerPlugin, type PluginListenerHandle } from '@capacitor/core'
+
+// Native bridge to the Android/Tasker intents transport. The native side stores
+// an inbound intent (from a manifest broadcast receiver or an Activity launch)
+// in a single SharedPreferences slot; the web app drains it here, runs the pure
+// handleIntent(), and reports the result back out as an app.lastglance.RESULT
+// broadcast. No-op on web/PWA and iOS (no plugin registered there).
+//
+// This is the Capacitor equivalent of dayGLANCE's addJavascriptInterface bridge
+// (see docs/tasker-intents-architecture.md §8.1): getPendingIntent is now async,
+// and the native "wake the WebView" poke becomes a plugin `pendingIntent` event.
+export interface IntentsBridgePlugin {
+  // Read + clear the single pending-intent slot. `value` is '' when empty, else
+  // a JSON string `{ action, payload }`.
+  getPendingIntent(): Promise<{ value: string }>
+  // Emit the RESULT broadcast: the outcome of a handled action, under the
+  // ORIGINAL fully-qualified action so the sender's %action matches.
+  reportIntentResult(options: { action: string; result: string }): Promise<void>
+  // Emit the NOTIFY broadcast (a chore changed state), plaintext, for a local
+  // listener like Tasker to react to.
+  sendNotifyBroadcast(options: { payload: string }): Promise<void>
+  // Fired by native when a new intent lands while the app is running, so the web
+  // app drains immediately rather than waiting for the next visibility/focus.
+  addListener(eventName: 'pendingIntent', listenerFunc: () => void): Promise<PluginListenerHandle>
+}
+
+const IntentsBridge = registerPlugin<IntentsBridgePlugin>('IntentsBridge')
+
+export function isAndroid(): boolean {
+  return Capacitor.getPlatform() === 'android'
+}
+
+export interface PendingIntent {
+  action: string
+  payload: Record<string, unknown>
+}
+
+// Reads and clears the native pending-intent slot. Returns null when empty or on
+// any error, so callers never have to touch the plugin directly.
+export async function nativeGetPendingIntent(): Promise<PendingIntent | null> {
+  if (!isAndroid()) return null
+  try {
+    const res = await IntentsBridge.getPendingIntent()
+    const raw = res?.value
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return null
+    const obj = parsed as Record<string, unknown>
+    if (typeof obj.action !== 'string') return null
+    const payload = (obj.payload && typeof obj.payload === 'object' ? obj.payload : {}) as Record<string, unknown>
+    return { action: obj.action, payload }
+  } catch {
+    return null
+  }
+}
+
+export async function nativeReportIntentResult(action: string, resultJson: string): Promise<void> {
+  if (!isAndroid()) return
+  try {
+    await IntentsBridge.reportIntentResult({ action, result: resultJson })
+  } catch {
+    // A missing plugin / transient bridge error is non-fatal: the handler has
+    // already applied its state change; only the outbound ack is lost.
+  }
+}
+
+export async function nativeSendNotifyBroadcast(payloadJson: string): Promise<void> {
+  if (!isAndroid()) return
+  try {
+    await IntentsBridge.sendNotifyBroadcast({ payload: payloadJson })
+  } catch {
+    // Best-effort; a dropped NOTIFY just means a local listener misses one event.
+  }
+}
+
+// Subscribes to the native "an intent just landed" poke. Returns a handle to
+// remove the listener, or null off Android / on error.
+export async function addPendingIntentListener(cb: () => void): Promise<PluginListenerHandle | null> {
+  if (!isAndroid()) return null
+  try {
+    return await IntentsBridge.addListener('pendingIntent', cb)
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Lets another Android app (Tasker, MacroDroid, Automate, …) drive lastGLANCE via `app.lastglance.*` intents. This is a port of the dayGLANCE design documented in `docs/tasker-intents-architecture.md`, adapted to lastGLANCE's **chore/cadence** domain (not tasks/due-dates) and its **Java + Capacitor** native stack (not Kotlin + raw WebView).

The transport is a new, standalone subsystem — it does **not** touch the existing file-based (WebDAV / GLANCEvault) intents used for dayGLANCE interop.

| Inbound action | Behavior |
|---|---|
| `app.lastglance.CREATE` | Create a chore. `project` → category (created if missing), else auto **"Inbox"**. Idempotent by (name, category). |
| `app.lastglance.COMPLETE` | Log a completion, matched by title (exact, then unique-substring fuzzy). |
| `app.lastglance.OPEN` | Foreground + route via existing deep-link events (soon / search / add). |
| `app.lastglance.QUERY` | Reply (RESULT) with `%lg_count_due` / `%lg_count_overdue` / `%lg_count_done_today` / `%lg_count_total`. |

Outbound: `app.lastglance.RESULT` after every action (and as the QUERY reply / liveness ack), plus `app.lastglance.NOTIFY` when a chore is completed **via the COMPLETE intent**.

## Changes

**Web (`src/`)**
- `intents/handleIntent.ts` — pure, transport-agnostic handler with skeleton mode + (name, category) idempotency.
- `intents/androidIntents.ts` — `app.lastglance.*` constants, broadcast→short-action map (the action-string gotcha), `%lg_` QUERY vars.
- `native/intentsBridge.ts` — `IntentsBridge` Capacitor plugin wrapper.
- `intents/intentContext.ts` — wires the handler to Dexie, navigation deep-link events, and the outbound NOTIFY broadcast.
- `hooks/useAndroidIntentBridge.ts` — drains the native slot on mount / plugin event / foreground, maps + runs + reports; mounted in `App.tsx`.

**Native (`android/.../` Java)**
- `intents/IntentReceiver.java` — manifest broadcast entry point (works backgrounded/killed).
- `intents/IntentsBridgePlugin.java` — `getPendingIntent` / `reportIntentResult` (RESULT) / `sendNotifyBroadcast` (NOTIFY); owns the `INTENT_RECEIVED` wake receiver for its whole lifetime.
- `SharedDataStore.java` — single-depth pending-intent slot.
- `MainActivity.java` — register plugin; capture Activity-target intents on cold start (`onCreate`) and warm (`onNewIntent`).
- `AndroidManifest.xml` — `app.lastglance.*` on both a `<receiver>` and the `<activity>`.

**Docs** — `docs/tasker-integration.md` end-user guide.

## Testing

- `npm run build` ✅ · `npm run lint` ✅ (0 warnings) · `npm test` ✅ (146/146, incl. 22 new `handleIntent` tests)
- Android was **not** gradle-compiled (no Android SDK in the CI environment). The Java is statically checked against the Capacitor `Plugin` API and `androidx.core` 1.17.0 (`RECEIVER_NOT_EXPORTED` available); a local `cap sync android && ./gradlew assembleDebug` is recommended before merge.

## Notes

- **NOTIFY scope**: fires only for completions made through the COMPLETE intent, not for in-app completions (would require hooking 6 call sites with no chore-carrying event). Called out as a future extension in the doc.
- **Namespace**: `app.lastglance.*` is distinct from dayGLANCE's `app.dayglance.*`, so the two apps never cross-talk if both are installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rMA6k4fWxkKm1Tw2QaeuM

---
_Generated by [Claude Code](https://claude.ai/code/session_017rMA6k4fWxkKm1Tw2QaeuM)_