### PR TITLE
Bump version to 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.12.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.13.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version bump to `1.13.0`, releasing the Tasker/Android intents transport merged in #185.

- `package.json`: `1.12.0` to `1.13.0`
- `package-lock.json`: regenerated (version fields only)
- `README.md`: version badge updated to `1.13.0`

Minor bump: the release adds a new feature (the `app.lastglance.*` intents transport) with no breaking changes.

## Testing

Metadata-only change. `npm install` ran to sync the lockfile; the working tree diff is limited to the three files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rMA6k4fWxkKm1Tw2QaeuM

---
_Generated by [Claude Code](https://claude.ai/code/session_017rMA6k4fWxkKm1Tw2QaeuM)_