### PR TITLE
Bump @glance-apps/sync to 1.5.3 (pinned)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/status-bar": "^8.0.2",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.5.2",
+        "@glance-apps/sync": "1.5.3",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -2824,9 +2824,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.2.tgz",
-      "integrity": "sha512-S+O/bsGxtkDzcVBPhI8DlTiy89cfOwe9XGFaZoD3G1m2kZzOW9RnKNqHYuPSP2+Auy0RFPBQla+45nhm6WuN+A==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.5.3.tgz",
+      "integrity": "sha512-wzRVEtGcyfbzH5tMhqeKHhiXsJobU1qvdt5JRGjD1zcxEpqpETUSsOJ8n4UQzQA27ah6AESDx1aYYphJ5TkuDQ==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/status-bar": "^8.0.2",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.5.2",
+    "@glance-apps/sync": "1.5.3",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",


### PR DESCRIPTION
## What

Bumps `@glance-apps/sync` from `1.5.2` to `1.5.3`, pinned exact (no semver range), matching the existing pinning style for this dependency.

Part of keeping all GLANCE apps on the latest sync engine — unrelated to any lastGLANCE feature work.

## Changes

- `package.json`: `@glance-apps/sync` → `1.5.3`
- `package-lock.json`: version, resolved URL, and integrity hash updated to match

## Testing

- `tsc --noEmit` — clean
- `vitest run` — 146/146 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMCFWaR1uy5nrLFx3k1Wf1)_