### PR TITLE
Make WebDAV proxy optional and honest for self-hosted setups (#195, #196)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
 # Base URL of the WebDAV CORS proxy (optional).
 # Required only when your WebDAV server does not send permissive CORS headers.
-# Leave unset for direct connections or when using a reverse proxy that handles CORS.
+# Leave unset to use the same-origin proxy bundled with the Docker image.
 VITE_WEBDAV_PROXY_URL=
+
+# Skip the WebDAV CORS proxy and connect straight to your WebDAV server from the
+# browser (optional). Set to "true" only when the server sends permissive CORS
+# headers or sits behind a reverse proxy that handles CORS. Leave unset to keep
+# using the proxy.
+VITE_WEBDAV_DIRECT=

--- a/README.md
+++ b/README.md
@@ -114,11 +114,12 @@ CapacitorHttp plugin. See [docs/mobile.md](docs/mobile.md) for details.
 
 ## Configuration
 
-lastGLANCE is configured entirely in-app. One environment variable is available at build time:
+lastGLANCE is configured entirely in-app. A couple of environment variables are available at build time:
 
 | Variable | Required | Description |
 |---|---|---|
-| `VITE_WEBDAV_PROXY_URL` | No | Base URL of a [WebDAV CORS proxy](https://github.com/krelltunez/lastGLANCE/tree/main/api) to relay requests when the WebDAV server doesn't allow browser requests directly. Leave unset if your server has permissive CORS headers or you're using a reverse proxy that handles CORS. |
+| `VITE_WEBDAV_PROXY_URL` | No | Base URL of a [WebDAV CORS proxy](https://github.com/krelltunez/lastGLANCE/tree/main/api) to relay requests when the WebDAV server doesn't allow browser requests directly. Leave unset to use the same-origin proxy bundled with the Docker image. |
+| `VITE_WEBDAV_DIRECT` | No | Set to `true` to skip the CORS proxy entirely and connect straight to your WebDAV server from the browser. Use this only when your server sends permissive CORS headers or sits behind a reverse proxy that handles CORS — otherwise sync requests will fail CORS. Leave unset to keep using the proxy. |
 
 Create a `.env.local` for local development:
 

--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -111,6 +111,12 @@ function proxyRequest(method, targetUrl, headers, body) {
 }
 
 export default async function handler(req, res) {
+  // Stamp every response so the client can tell a genuine proxy reply apart from
+  // a static host that 404s /api/webdav-proxy/ or serves an SPA index.html
+  // fallback. testConnection() in src/intents/webdav.ts checks for this marker.
+  res.setHeader('X-Webdav-Proxy', 'lastglance');
+  res.setHeader('Access-Control-Expose-Headers', 'ETag, X-Webdav-Proxy');
+
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/src/intents/webdav.test.ts
+++ b/src/intents/webdav.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// webdavFetch picks its transport from two module-level consts in
+// @/sync/nativeHttp (isNativePlatform, webdavDirect). Those are evaluated at
+// import time, so each test resets the module registry and re-imports webdav.ts
+// under a fresh mock to exercise a specific transport.
+async function loadWebdav(mock: { isNativePlatform: boolean; webdavDirect: boolean }) {
+  vi.resetModules()
+  vi.doMock('@/sync/nativeHttp', () => ({
+    isNativePlatform: mock.isNativePlatform,
+    webdavDirect: mock.webdavDirect,
+    nativeHttpFetch: vi.fn(),
+    browserDirectFetch: vi.fn(),
+  }))
+  return import('./webdav')
+}
+
+const OK_PROPFIND = new Response('<multistatus/>', { status: 207 })
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => OK_PROPFIND.clone()))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.doUnmock('@/sync/nativeHttp')
+})
+
+describe('webdavFetch transport selection (browser)', () => {
+  it('default (proxy) mode: routes through the same-origin proxy with X-WebDAV-Auth', async () => {
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: false })
+    await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('/api/webdav-proxy/?url=' + encodeURIComponent('https://dav.example.com/chores/'))
+    expect(init.headers['X-WebDAV-Auth']).toBe('Basic ' + btoa('user:pass'))
+    // The proxy path must NOT leak a standard Authorization header.
+    expect(init.headers.Authorization).toBeUndefined()
+  })
+
+  it('direct mode: hits the target URL directly with a standard Authorization header', async () => {
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: true })
+    await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toBe('https://dav.example.com/chores/')
+    expect(url).not.toContain('/api/webdav-proxy/')
+    expect(init.headers.Authorization).toBe('Basic ' + btoa('user:pass'))
+    expect(init.headers['X-WebDAV-Auth']).toBeUndefined()
+  })
+})

--- a/src/intents/webdav.test.ts
+++ b/src/intents/webdav.test.ts
@@ -15,10 +15,18 @@ async function loadWebdav(mock: { isNativePlatform: boolean; webdavDirect: boole
   return import('./webdav')
 }
 
-const OK_PROPFIND = new Response('<multistatus/>', { status: 207 })
+// Responses from the real proxy carry this marker; a static host 404 / SPA
+// fallback does not.
+const PROXY_MARKER = { 'X-Webdav-Proxy': 'lastglance' }
+
+function stubFetch(status: number, headers: Record<string, string> = {}) {
+  const fn = vi.fn(async () => new Response('<multistatus/>', { status, headers }))
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
 
 beforeEach(() => {
-  vi.stubGlobal('fetch', vi.fn(async () => OK_PROPFIND.clone()))
+  vi.stubGlobal('fetch', vi.fn(async () => new Response('<multistatus/>', { status: 207, headers: PROXY_MARKER })))
 })
 
 afterEach(() => {
@@ -47,5 +55,51 @@ describe('webdavFetch transport selection (browser)', () => {
     expect(url).not.toContain('/api/webdav-proxy/')
     expect(init.headers.Authorization).toBe('Basic ' + btoa('user:pass'))
     expect(init.headers['X-WebDAV-Auth']).toBeUndefined()
+  })
+})
+
+describe('testConnection proxy reachability (issue #196)', () => {
+  it('proxy 404 WITHOUT the marker (missing sidecar / static host) -> failure, not success', async () => {
+    stubFetch(404) // no marker header — this is a plain static-host 404
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: false })
+    const r = await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/proxy not reachable/i)
+  })
+
+  it('SPA fallback 200 WITHOUT the marker (static host serves index.html) -> failure', async () => {
+    stubFetch(200) // no marker — index.html fallback masquerading as success
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: false })
+    const r = await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+    expect(r.success).toBe(false)
+    expect(r.error).toMatch(/proxy not reachable/i)
+  })
+
+  it('proxy 404 WITH the marker (server reachable, folder not created yet) -> success', async () => {
+    stubFetch(404, PROXY_MARKER)
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: false })
+    const r = await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+    expect(r).toEqual({ success: true })
+  })
+
+  it('proxy 207 WITH the marker -> success', async () => {
+    stubFetch(207, PROXY_MARKER)
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: false })
+    const r = await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+    expect(r).toEqual({ success: true })
+  })
+
+  it('proxy 401 WITH the marker -> auth failure (marker check does not mask real statuses)', async () => {
+    stubFetch(401, PROXY_MARKER)
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: false })
+    const r = await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+    expect(r).toEqual({ success: false, error: 'Authentication failed' })
+  })
+
+  it('direct mode 404 -> success without needing any marker', async () => {
+    stubFetch(404) // direct transport, no proxy marker expected
+    const { testConnection } = await loadWebdav({ isNativePlatform: false, webdavDirect: true })
+    const r = await testConnection('https://dav.example.com', 'chores', 'user', 'pass')
+    expect(r).toEqual({ success: true })
   })
 })

--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -1,4 +1,4 @@
-import { isNativePlatform, nativeHttpFetch } from '@/sync/nativeHttp'
+import { isNativePlatform, nativeHttpFetch, webdavDirect } from '@/sync/nativeHttp'
 
 export function buildAuthHeader(username: string, password: string): string {
   return 'Basic ' + btoa(`${username}:${password}`)
@@ -27,8 +27,10 @@ interface WebdavResponse {
 
 // Transport-selecting WebDAV request. On native (Capacitor) it calls the target
 // URL directly through the native HTTP stack with a standard Authorization
-// header — no CORS proxy. In the browser/PWA it routes through the CORS proxy
-// with the X-WebDAV-Auth header (which the proxy rewrites to Authorization).
+// header — no CORS proxy. When VITE_WEBDAV_DIRECT is enabled it does the same
+// from the browser with a plain fetch (the server must permit the cross-origin
+// request via CORS). Otherwise, in the browser/PWA, it routes through the CORS
+// proxy with the X-WebDAV-Auth header (which the proxy rewrites to Authorization).
 async function webdavFetch(
   method: string,
   targetUrl: string,
@@ -40,6 +42,13 @@ async function webdavFetch(
     const headers: Record<string, string> = { Authorization: authHeader, ...extraHeaders }
     const r = await nativeHttpFetch(method, targetUrl, headers, body ?? null)
     return { status: r.status, ok: r.ok, statusText: r.statusText, text: async () => r.body }
+  }
+  if (webdavDirect) {
+    return fetchWithTimeout(targetUrl, {
+      method,
+      headers: { Authorization: authHeader, ...extraHeaders },
+      ...(body !== undefined ? { body } : {}),
+    })
   }
   return fetchWithTimeout(withProxy(targetUrl), {
     method,

--- a/src/intents/webdav.ts
+++ b/src/intents/webdav.ts
@@ -18,12 +18,22 @@ function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
 }
 
 // Minimal Response-like shape shared by both transports (Response satisfies it).
+// headers is optional because the native transport returns a plain object; the
+// proxy/direct transports return a real Response with a readable Headers.
 interface WebdavResponse {
   status: number
   ok: boolean
   statusText: string
   text: () => Promise<string>
+  headers?: { get: (name: string) => string | null }
 }
+
+// Marker header the WebDAV proxy stamps on every response. It lets a proxied
+// request tell a genuine proxy reply apart from a static host that 404s the
+// /api/webdav-proxy/ path or serves an SPA index.html fallback. Keep in sync
+// with api/webdav-proxy.js and the dev middleware in vite.config.ts.
+const WEBDAV_PROXY_MARKER = 'x-webdav-proxy'
+const WEBDAV_PROXY_MARKER_VALUE = 'lastglance'
 
 // Transport-selecting WebDAV request. On native (Capacitor) it calls the target
 // URL directly through the native HTTP stack with a standard Authorization
@@ -143,11 +153,22 @@ export async function getFileOrNull(baseUrl: string, folderPath: string, filenam
 export async function testConnection(baseUrl: string, folderPath: string, username: string, password: string): Promise<{ success: boolean; error?: string }> {
   const authHeader = buildAuthHeader(username, password)
   const folderUrl = buildFolderUrl(baseUrl, folderPath) + '/'
+  const usingProxy = !isNativePlatform && !webdavDirect
   try {
     const res = await webdavFetch('PROPFIND', folderUrl, authHeader, {
       extraHeaders: { Depth: '0', 'Content-Type': 'application/xml' },
       body: PROPFIND_BODY,
     })
+    // In proxy mode a reply without the proxy marker never reached the proxy —
+    // e.g. a static host 404ing /api/webdav-proxy/, or an SPA index.html
+    // fallback returning 200. Either way the WebDAV server was never contacted,
+    // so don't report success off a misleading status code.
+    if (usingProxy && res.headers?.get(WEBDAV_PROXY_MARKER) !== WEBDAV_PROXY_MARKER_VALUE) {
+      return {
+        success: false,
+        error: 'WebDAV proxy not reachable. The /api/webdav-proxy endpoint did not respond — deploy the proxy sidecar, or set VITE_WEBDAV_DIRECT=true to connect directly.',
+      }
+    }
     if (res.status === 401) return { success: false, error: 'Authentication failed' }
     if (res.status === 403) return { success: false, error: 'Access denied' }
     if (res.ok || res.status === 207 || res.status === 404) return { success: true }

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -11,7 +11,7 @@ import type { SyncEngine, SyncStatus, SyncErrorCode, BackupFrequency } from '@gl
 import { db } from '@/db/client'
 import type { Category, Chore, CompletionEvent, User } from '@/types'
 import { buildAuthHeader, ensureFolder } from '@/intents/webdav'
-import { isNativePlatform, nativeHttpFetch } from './nativeHttp'
+import { browserDirectFetch, isNativePlatform, nativeHttpFetch, webdavDirect } from './nativeHttp'
 import type { SyncPayload, SyncSettings } from './types'
 import { getMultiUserEnabled, setMultiUserEnabled } from '@/multiuser/settings'
 
@@ -496,8 +496,10 @@ export function createEngine(proxyUrl: string | undefined, callbacks: EngineCall
     appName: 'lastGLANCE',
     proxyUrl,
     // On native (Capacitor) route WebDAV through the native HTTP stack so sync
-    // works without the CORS proxy. Takes priority over proxyUrl in the engine.
-    electronProxyFetch: isNativePlatform ? nativeHttpFetch : undefined,
+    // works without the CORS proxy. In the browser use a direct fetch when
+    // VITE_WEBDAV_DIRECT is enabled. Takes priority over proxyUrl in the engine,
+    // so leaving it undefined keeps the proxy path.
+    electronProxyFetch: isNativePlatform ? nativeHttpFetch : webdavDirect ? browserDirectFetch : undefined,
     buildPayload,
     buildBackupPayload: buildPayload,
     applyPayload,

--- a/src/sync/nativeHttp.ts
+++ b/src/sync/nativeHttp.ts
@@ -5,6 +5,13 @@ import { Capacitor, CapacitorHttp } from '@capacitor/core'
 // are not subject to the WebView's same-origin policy.
 export const isNativePlatform = Capacitor.isNativePlatform()
 
+// Opt-in browser/PWA setting: skip the WebDAV CORS proxy and talk to the target
+// server directly. Only meaningful off-native — native already connects
+// directly via CapacitorHttp. Enable with VITE_WEBDAV_DIRECT=true when the
+// WebDAV server sends permissive CORS headers or sits behind a reverse proxy
+// that does. Leaving it unset preserves the default same-origin proxy path.
+export const webdavDirect = !isNativePlatform && import.meta.env.VITE_WEBDAV_DIRECT === 'true'
+
 export interface NativeHttpResult {
   status: number
   ok: boolean
@@ -46,6 +53,35 @@ export async function nativeHttpFetch(
     ok,
     statusText: '',
     body: data,
+    headers: etag ? { etag } : undefined,
+  }
+}
+
+// Direct browser WebDAV request that bypasses the CORS proxy. Shares the
+// `ElectronProxyFetch` signature with nativeHttpFetch so the sync engine and the
+// app's WebDAV helpers can swap it in when VITE_WEBDAV_DIRECT is enabled. Unlike
+// the proxy path it sends a standard Authorization header, so the target server
+// must allow the browser request via CORS (a permissive server or a
+// CORS-handling reverse proxy). To expose the ETag cross-origin the server must
+// list it in Access-Control-Expose-Headers.
+export async function browserDirectFetch(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  body: string | null,
+): Promise<NativeHttpResult> {
+  const res = await fetch(url, {
+    method,
+    headers,
+    ...(body !== null ? { body } : {}),
+  })
+  const text = await res.text()
+  const etag = res.headers.get('etag') ?? undefined
+  return {
+    status: res.status,
+    ok: res.ok,
+    statusText: res.statusText,
+    body: text,
     headers: etag ? { etag } : undefined,
   }
 }

--- a/src/utils/cloudSyncProviders.ts
+++ b/src/utils/cloudSyncProviders.ts
@@ -1,6 +1,6 @@
 import { createProviders } from '@glance-apps/sync'
 import type { SyncEngineConfig } from '@glance-apps/sync'
-import { isNativePlatform, nativeHttpFetch } from '@/sync/nativeHttp'
+import { browserDirectFetch, isNativePlatform, nativeHttpFetch, webdavDirect } from '@/sync/nativeHttp'
 
 // createProviders only uses the transport/crypto subset of SyncEngineConfig;
 // the data lifecycle callbacks are engine-only concerns.
@@ -10,8 +10,10 @@ const lastGlanceEngineConfig = {
   cryptoDBName: 'lastglance-crypto',
   nativeHttpRequest: null,
   // On native (Capacitor) route WebDAV directly through the native HTTP stack
-  // (no CORS proxy); the browser/PWA keeps using proxyUrl.
-  electronProxyFetch: isNativePlatform ? nativeHttpFetch : null,
+  // (no CORS proxy). In the browser/PWA use a direct fetch when VITE_WEBDAV_DIRECT
+  // is enabled; otherwise fall back to proxyUrl. electronProxyFetch takes
+  // priority over proxyUrl in the engine, so a null here keeps the proxy path.
+  electronProxyFetch: isNativePlatform ? nativeHttpFetch : webdavDirect ? browserDirectFetch : null,
   proxyUrl: import.meta.env.VITE_WEBDAV_PROXY_URL ?? '',
   nativeGetSyncKey: null,
   nativeStoreSyncKey: null,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_WEBDAV_PROXY_URL?: string
+  readonly VITE_WEBDAV_DIRECT?: string
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,11 @@ function webdavProxyPlugin(): Plugin {
     apply: 'serve',
     configureServer(server: ViteDevServer) {
       server.middlewares.use('/api/webdav-proxy/', async (req: IncomingMessage, res: ServerResponse) => {
+        // Mirror the production proxy's marker header (see api/webdav-proxy.js)
+        // so testConnection() behaves identically in dev.
+        res.setHeader('X-Webdav-Proxy', 'lastglance')
+        res.setHeader('Access-Control-Expose-Headers', 'ETag, X-Webdav-Proxy')
+
         if (req.method === 'OPTIONS') {
           res.writeHead(204, {
             'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Summary

Two related fixes for self-hosted, non-Docker deployments, both reported by the same user. They are coupled: the #196 fix guides the user toward the flag added in #195.

## #195 — `VITE_WEBDAV_DIRECT` to bypass the CORS proxy

The browser/PWA transport always routed WebDAV through the same-origin `/api/webdav-proxy/` path, even when `VITE_WEBDAV_PROXY_URL` was unset or empty. An empty value did not produce a direct connection, it produced a same-origin proxy request. On the Docker image a bundled sidecar serves that path, but on a plain static build there is nothing behind it, so requests never reached the user's WebDAV server. This contradicted the documentation, which claimed leaving the variable unset yields direct connections.

- Added an explicit, opt-in `VITE_WEBDAV_DIRECT` flag. When set to `true` in the browser, WebDAV requests go straight to the target server with a standard `Authorization` header instead of through the CORS proxy.
- Wired it into both transports: the app's own helpers in `src/intents/webdav.ts`, and the sync engine via the existing `electronProxyFetch` seam (`src/sync/engine.ts` and `src/utils/cloudSyncProviders.ts`), which takes priority over `proxyUrl`.
- Added `browserDirectFetch` in `src/sync/nativeHttp.ts`, matching the `ElectronProxyFetch` contract already used for native.
- Corrected the docs in `README.md` and `.env.example`.

Flipping "unset means direct" would break every deployment that relies on the same-origin sidecar, since `VITE_WEBDAV_PROXY_URL` is a compile-time value that ships empty in the prebuilt Docker image. The new flag leaves the default untouched: unset keeps the proxy path, so no existing Docker or reverse-proxied setup is affected. Native platforms already connect directly via CapacitorHttp and are unaffected.

## #196 — "Test connection" no longer reports success when the proxy is missing

`testConnection` treated a 404 as success so that a WebDAV server reporting a not-yet-created sync folder still counts as a working connection. But that also swallowed a 404 from a static host that does not serve `/api/webdav-proxy/`, and an SPA `index.html` fallback returning 200 was reported as success too. The result was "connection successful" even though no WebDAV request ever left the browser.

- The proxy now stamps an `X-Webdav-Proxy` marker header on every response (`api/webdav-proxy.js` and the dev middleware in `vite.config.ts`).
- In proxy mode, `testConnection` rejects any reply lacking the marker with a clear "proxy not reachable" message that points at `VITE_WEBDAV_DIRECT`.
- A genuine folder-missing 404 still carries the marker (it came back through the proxy) and is still treated as success. Native and direct transports do not use the proxy and are unaffected.
- This corrects only the test-connection UI; real sync via `@glance-apps/sync` already failed correctly when the proxy was absent.

## Testing

- Added `src/intents/webdav.test.ts` covering transport selection (proxy vs direct) and proxy reachability (missing-marker 404, SPA-fallback 200, marker-bearing 404 success, and that a real 401 still surfaces).
- Full suite passes (161 tests), lint clean, typecheck clean, production build succeeds.

Closes #195
Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjsWPU51nSpgEbgkf4wxxT