### PR TITLE
Keep the log form visible on mobile in the completion details sheet

### DIFF
--- a/src/components/LogModal/LogModal.tsx
+++ b/src/components/LogModal/LogModal.tsx
@@ -98,7 +98,7 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
       ">
 
         {/* ── Left / top: log form ── */}
-        <div className="flex flex-col p-6 gap-4 overflow-y-auto min-h-0 lg:w-72 lg:shrink-0 lg:border-r lg:border-slate-100 dark:lg:border-slate-700/60 lg:self-stretch">
+        <div className="flex flex-col p-6 gap-4 overflow-y-auto min-h-0 shrink-0 lg:w-72 lg:border-r lg:border-slate-100 dark:lg:border-slate-700/60 lg:self-stretch">
           <div className="flex items-start justify-between gap-2">
             <div>
               <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100">{chore.name}</h2>
@@ -189,7 +189,10 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
               {completions.length === 0 ? (
                 <p className="text-sm text-slate-400 dark:text-slate-600 py-4 text-center">{t('logModal.noCompletions')}</p>
               ) : (
-                <div>
+                // On the stacked (mobile/tablet) layout, cap the list to about
+                // one completion so the log form above stays visible; scroll for
+                // more. The lg side-by-side layout keeps the full-height list.
+                <div className="max-h-20 overflow-y-auto lg:max-h-none lg:overflow-visible">
                   {completions.map((evt, i) => {
                     const prev = completions[i + 1]
                     const gapDays = prev


### PR DESCRIPTION
## Summary

On the stacked (mobile/tablet) layout of the completion details sheet (`LogModal`), when a chore had several logged completions the history could grow and cover the log form at the top, hiding the controls for logging prior completions.

The root cause is a flexbox asymmetry: the history column uses `flex-1` with a zero flex-basis, so it carries no shrink weight. When the sheet runs out of vertical room, all the overflow is taken out of the form above instead of the history scrolling internally.

## What changed

- Made the log form `shrink-0` in the stacked layout so it keeps its natural height and stays visible; the history now takes the remaining space and scrolls.
- Capped the completions list to about one row on mobile (`max-h-20`) with its own scroll, so a long history no longer crowds the form. Scroll within the list to see more completions.
- The `lg` side-by-side desktop layout is unchanged (form is a fixed-width column, history keeps its full-height list).

CSS-only change; no logic touched. Typecheck, lint, and production build all pass.

## Note for testing

The `max-h-20` cap (about one completion row plus a peek of the next, as a scroll affordance) is a best-guess value, since this was reasoned from the layout rather than verified on a device. If it cuts off awkwardly or shows too much/little on your screen, it is a one-line tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjsWPU51nSpgEbgkf4wxxT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjsWPU51nSpgEbgkf4wxxT)_