### PR TITLE
Cap the mobile completion list to exactly one entry

### DIFF
--- a/src/components/LogModal/LogModal.tsx
+++ b/src/components/LogModal/LogModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef } from 'react'
 import { X, Trash2, NotebookPen } from 'lucide-react'
 import dayjs from 'dayjs'
 import type { ChoreWithLastCompletion, CompletionEvent } from '@/types'
@@ -31,11 +31,30 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
   const [sendState, setSendState] = useState<SendState>('idle')
   const [completions, setCompletions] = useState<CompletionEvent[]>([])
   const heatmapRef = useRef<HTMLDivElement>(null)
+  const firstCompletionRef = useRef<HTMLDivElement>(null)
+  const [listMaxHeight, setListMaxHeight] = useState<number | undefined>(undefined)
   useEscapeKey(onClose)
 
   useEffect(() => {
     getCompletionHistory(chore.id, 1000).then(c => setCompletions(c))
   }, [chore.id])
+
+  // On the stacked (mobile/tablet) layout, cap the completion list to exactly the
+  // most recent entry so the log form above stays fully visible; the rest scroll
+  // into view. The lg side-by-side layout shows the full-height list.
+  useLayoutEffect(() => {
+    function recompute() {
+      const stacked = !window.matchMedia('(min-width: 1024px)').matches
+      setListMaxHeight(
+        stacked && completions.length > 1 && firstCompletionRef.current
+          ? firstCompletionRef.current.offsetHeight
+          : undefined,
+      )
+    }
+    recompute()
+    window.addEventListener('resize', recompute)
+    return () => window.removeEventListener('resize', recompute)
+  }, [completions])
 
   useEffect(() => {
     if (!heatmapRef.current) return
@@ -189,10 +208,10 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
               {completions.length === 0 ? (
                 <p className="text-sm text-slate-400 dark:text-slate-600 py-4 text-center">{t('logModal.noCompletions')}</p>
               ) : (
-                // On the stacked (mobile/tablet) layout, cap the list to about
-                // one completion so the log form above stays visible; scroll for
-                // more. The lg side-by-side layout keeps the full-height list.
-                <div className="max-h-20 overflow-y-auto lg:max-h-none lg:overflow-visible">
+                <div
+                  className={listMaxHeight != null ? 'overflow-y-auto' : undefined}
+                  style={listMaxHeight != null ? { maxHeight: listMaxHeight } : undefined}
+                >
                   {completions.map((evt, i) => {
                     const prev = completions[i + 1]
                     const gapDays = prev
@@ -200,17 +219,19 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
                       : null
                     return (
                       <div key={evt.id}>
-                        <CompletionRow
-                          evt={evt}
-                          onDelete={() => handleDelete(evt.id)}
-                          onEditNote={async (note) => {
-                            await updateCompletionNote(evt.id, note)
-                            setCompletions(prev => prev.map(c => c.id === evt.id ? { ...c, note } : c))
-                          }}
-                          userName={multiUserEnabled && evt.completed_by_user_sync_id
-                            ? (users.find(u => u.sync_id === evt.completed_by_user_sync_id)?.name ?? null)
-                            : null}
-                        />
+                        <div ref={i === 0 ? firstCompletionRef : undefined}>
+                          <CompletionRow
+                            evt={evt}
+                            onDelete={() => handleDelete(evt.id)}
+                            onEditNote={async (note) => {
+                              await updateCompletionNote(evt.id, note)
+                              setCompletions(prev => prev.map(c => c.id === evt.id ? { ...c, note } : c))
+                            }}
+                            userName={multiUserEnabled && evt.completed_by_user_sync_id
+                              ? (users.find(u => u.sync_id === evt.completed_by_user_sync_id)?.name ?? null)
+                              : null}
+                          />
+                        </div>
                         {gapDays !== null && gapDays > 0 && (
                           <GapMarker days={gapDays} target={chore.target_cadence_days} />
                         )}


### PR DESCRIPTION
The fixed max-h-20 cap cut the list at an arbitrary pixel, leaving a sliver of the next entry's gap marker visible. Measure the most recent completion row instead and cap the list to its height, so the list ends cleanly right after one completion (matching the single-completion sheet). The rest scroll into view. Recomputed on resize and whenever the history changes; only applied on the stacked mobile/tablet layout.


Claude-Session: https://claude.ai/code/session_01XjsWPU51nSpgEbgkf4wxxT