### PR TITLE
Bump version to 1.13.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.13.2-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-1.13.3-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.13.2",
+  "version": "1.13.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Bumps the app version to 1.13.3.

- `package.json`: version 1.13.2 to 1.13.3
- `package-lock.json`: regenerated via npm install (version fields only, no dependency changes)
- `README.md`: version badge updated to 1.13.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjsWPU51nSpgEbgkf4wxxT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjsWPU51nSpgEbgkf4wxxT)_