### PR TITLE
docs: reconcile Android native-features plan and add iOS plan

### DIFF
--- a/docs/android-native-features-plan.md
+++ b/docs/android-native-features-plan.md
@@ -7,22 +7,29 @@ This plan was informed by a teardown of how the sibling app **dayGLANCE**
 solved timely closed-app notifications (its process is referenced throughout).
 Where lastGLANCE differs from dayGLANCE, it is called out explicitly.
 
-> **▶ RESUME HERE (last updated 2026-06-26)**
-> - **Phase 0 + Phase 1 built** on branch `claude/wonderful-mccarthy-abm730`
->   (PR #126). Web build + 58 tests green; **Android not yet compiled/device-tested.**
-> - **Phase 1** = exact-alarm overdue notifications via `@capacitor/local-notifications`
->   (Path A), **+ notification actions** (Mark done; Send to dayGLANCE when intents
->   are configured) **+ branded contribution-grid notification icon**. Device-tested
->   through step 6 (closed-app + Doze delivery) and the cold-start tap fix.
-> - **Phase 2 in progress** (action widgets + optimistic tap-to-complete). Widget
->   tech **decided: Jetpack Glance**. Phase 2a built: tap-to-complete spine +
->   single-chore Glance tile. **Glance toolchain is unverified locally — first
->   on-device build may need version adjustment.**
-> - **Settled:** Path A (B backup); "clearly same family"; no battery-opt prompt;
->   defer the WorkManager re-arm backstop until testing proves OEM killers clear alarms.
-> - **Carry-over to Phase 2:** silent "Mark done" (the official plugin opens the app
->   for every notification action; truly background completion needs native work —
->   the same optimistic-native + queue path Phase 2 builds for widgets).
+> **▶ STATUS (last updated 2026-07-12)**
+> **Android: feature-complete against this plan. iOS: not started (stock Capacitor
+> shell only) — see the companion `docs/ios-native-features-plan.md`.**
+>
+> - **Phases 0–3 are all built and in the tree.** Snapshot bridge, exact-alarm
+>   overdue notifications, action widgets with optimistic tap-to-complete, dynamic
+>   shortcuts, add-chore widget, and share target. The heatmap widget was migrated
+>   from RemoteViews to Jetpack Glance, so **every widget is now Glance**.
+> - **As-built extras beyond the original plan:** two Quick Settings tiles
+>   (`tiles/AddChoreTileService`, `tiles/SoonTileService`) and a native broadcast
+>   intents bridge (`intents/IntentReceiver` + `IntentsBridgePlugin`; actions
+>   `app.lastglance.{CREATE,COMPLETE,OPEN,QUERY}`) that exposes the shared
+>   `@glance-apps/intents` dispatcher to Tasker/automation.
+> - **Remaining on Android:** on-device verification of the last widgets and the
+>   single-chore config flow (a few were still marked "awaiting device test"); plus
+>   the deferred-by-choice items below. No new feature work outstanding.
+> - **Settled / deferred by choice:** Path A (B backup); "clearly same family"
+>   visual parity; no battery-opt prompt; silent "Mark done" left opening the app
+>   (truly background completion needs the Path B alarm layer); WorkManager
+>   OEM-killer re-arm backstop deferred until on-device testing proves alarms get
+>   cleared; background CRDT sync out of scope. Cheap known gaps not yet closed: a
+>   `TIMEZONE_CHANGED` receiver and a midnight snapshot re-render for "Xd ago"
+>   freshness while closed.
 
 ---
 
@@ -198,12 +205,13 @@ queue** in `SharedPreferences`; JS drains via `getPendingActions()` on
   light/dark. **Implemented as a classic `RemoteViews` AppWidget drawing a Canvas
   bitmap (Java), NOT Jetpack Glance** — deliberate deviation to avoid the
   Compose/Kotlin Gradle setup for a non-interactive widget and keep the change
-  dependency-free. **OPEN DECISION:** keep RemoteViews here and adopt Glance only
-  for the interactive Phase 2 widgets, or unify on Glance now. Awaiting an
-  on-device look before deciding.
+  dependency-free. **RESOLVED (post-Phase-2):** unified on Glance. The heatmap was
+  migrated to `glance/HeatmapWidget.kt` (keeping the cheaper Canvas-bitmap render,
+  shown via `Image`) and the RemoteViews provider + `widget_heatmap.xml` removed, so
+  every widget is now Glance. See the post-Phase-2 note under Phase 2.
 - Tap → `lastglance://filter/soon` (opens app only; router lands in Phase 2/3). ✅
 
-**Status:** web build + 58 tests green; **Android not yet compiled/device-tested.**
+**Status:** ✅ built and superseded by the Glance heatmap; snapshot pipeline live.
 
 **Exit criteria:** heatmap on the home screen reflects completions within one app
 foreground cycle; survives reboot (re-renders from persisted snapshot).
@@ -262,7 +270,7 @@ dayGLANCE's war story warns about).
 **Exit criteria:** kill the app, advance a chore past its cadence, alarm fires on
 time (test on Doze via `adb shell dumpsys deviceidle force-idle`).
 
-### Phase 2 — Action widgets + optimistic tap-to-complete — 🚧 IN PROGRESS
+### Phase 2 — Action widgets + optimistic tap-to-complete — ✅ BUILT
 
 **Decision (resolved):** widgets use **Jetpack Glance** (Kotlin + Compose), toolchain
 Kotlin 2.2.0 + Compose plugin + Glance 1.1.1 (`buildFeatures.compose`, `jvmTarget 21`).
@@ -342,7 +350,7 @@ not worth Path B for one button right now; "Mark done opens the app" stays.
 reopening the app shows exactly one completion logged; no double-count across a
 sync round-trip.
 
-### Phase 3 — Notifications actions, shortcuts, (optional) background sync
+### Phase 3 — Notifications actions, shortcuts, share target — ✅ BUILT (background sync deferred)
 
 - **Actionable notifications:** ✅ DONE in Phase 1 (Mark done / Send to dayGLANCE).
 - **App shortcuts:** ✅ DONE. All built as **dynamic** shortcuts in
@@ -368,6 +376,16 @@ sync round-trip.
   (now carrying an optional name) and the cold-start pending-retry. Name is the
   only free-text chore field, so that's what gets seeded. iOS analog: a Share
   Extension writing to the App Group, same web prefill.
+- **Quick Settings tiles:** ✅ DONE (not in the original plan). Two `TileService`s
+  in `tiles/` — **Add chore** (`AddChoreTileService`) and **Soon**
+  (`SoonTileService`) — route through the same `lastglance://` targets as the
+  shortcuts, so the launch/foreground handling is shared.
+- **Native intents bridge:** ✅ DONE (not in the original plan). A broadcast
+  `IntentReceiver` + `IntentsBridgePlugin` (`intents/`) exposes the shared
+  `@glance-apps/intents` dispatcher to external automation (Tasker) via the
+  `app.lastglance.{CREATE,COMPLETE,OPEN,QUERY}` actions declared on `MainActivity`
+  and the receiver. Wired on the JS side by `src/native/intentsBridge.ts` /
+  `src/hooks/useAndroidIntentBridge.ts`. See `docs/tasker-intents-architecture.md`.
 - **Background CRDT sync (stretch):** the only feature needing a background data
   runtime. Forces the headless-JS-vs-native-mirror decision. Defer until there's
   real demand; current "sync on open" is unchanged behavior.

--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -1,0 +1,202 @@
+# iOS Native Features — Implementation Plan
+
+Widgets, actionable notifications, shortcuts, and a share target for the
+lastGLANCE **iOS** app. This is the iOS counterpart to
+`docs/android-native-features-plan.md`; that document's architecture was chosen
+to be cross-platform, so this plan reuses the shared JS layer and data contracts
+and only reimplements the native rendering per platform.
+
+> **▶ STATUS (last updated 2026-07-12)**
+> **Not started. Only the stock Capacitor iOS shell exists.**
+>
+> - Present today: default `AppDelegate.swift`, the Capacitor SPM package, and a
+>   default `Info.plist`. **No custom Swift, no widget extension, no App Group, no
+>   entitlements.** `@capacitor/ios` is installed, so the web app runs in the iOS
+>   WebView, but zero native features are wired.
+> - All native JS is hard-gated to `getPlatform() === 'android'` (12 guards, 0 iOS
+>   branches), so even the cross-platform notification layer does not run on iOS.
+> - Android, by contrast, is feature-complete (Phases 0-3). Bringing iOS up is
+>   **additive**: the shared JS/design layer does not change, only the native
+>   declarations and rendering are added.
+
+---
+
+## 1. The iOS prerequisite: an App Group
+
+On Android the native side reads a JSON snapshot from `SharedPreferences` and a
+pending-action queue from the same store. On iOS the equivalent shared container
+between the main app and its widget/share extensions is an **App Group**
+(`group.app.lastglance`). Every native feature below reads or writes that
+container, so it is the first thing to stand up and it gates everything else.
+
+- Requires an Apple Developer account, an App Group capability added to the app
+  target and each extension target, and matching provisioning profiles.
+- The shared store is `UserDefaults(suiteName: "group.app.lastglance")` for small
+  JSON (snapshot, queues) and the App Group's file container for anything larger
+  (rasterized icons). This mirrors the Android `SharedDataStore` split.
+
+---
+
+## 2. What carries over from Android (no rewrite)
+
+The decision logic lives in JS behind a thin Capacitor-plugin boundary, the
+snapshot is a plain JSON contract, and navigation goes through one
+`lastglance://` router. Reusable as-is:
+
+- **`src/native/snapshot.ts`** — the snapshot JSON. iOS widgets read the same
+  contract (section 3b of the Android plan).
+- **`src/native/reminders.ts`** scheduling model — eligibility, diff-replace,
+  action types, body text. Built on `@capacitor/local-notifications`, which is
+  cross-platform.
+- **`src/native/pendingCompletions.ts` + `usePendingCompletions`** — the drain
+  that replays native-minted completions via `logCompletion(choreId, { syncId })`
+  (idempotent on a caller-supplied `sync_id`).
+- **`pendingDeepLink.ts` / `pendingOpenChore.ts`** routing, the
+  `@glance-apps/intents` action router, and the user-attribution and
+  dayGLANCE-gating logic.
+
+Only the code below is reimplemented in Swift: the WidgetBridge plugin, the
+widgets, the interactive completion mechanism, the chore-icon assets, and the
+per-platform entry-point declarations (deep links, shortcuts, share target).
+
+---
+
+## 3. Phases
+
+### Phase 0 — App Group + WidgetBridge Swift plugin (the spine)
+
+**Goal:** prove the read path end to end with zero write-back risk, exactly like
+Android Phase 0.
+
+- Add the **App Group** capability + `App.entitlements` to the app target.
+- New **Swift Capacitor plugin `WidgetBridge`** exposing the same JS interface the
+  Android plugin does, so `src/native/widgetBridge.ts` wrappers are unchanged:
+  `updateSnapshot({ json })`, `getPendingActions()`, `clearPendingActions({ ids })`,
+  `drainPendingCompletions()`, `consumeDeepLink()`. Reads/writes the App Group
+  container.
+- A minimal **WidgetKit** extension target that renders the heatmap from
+  `snapshot.heatmap` (static, non-interactive) to validate the App-Group read and
+  light/dark handling.
+- **Relax the JS guards**: introduce an `isIOS()` helper and let the snapshot push
+  path run on iOS (`getPlatform() === 'android' || 'ios'`), starting with
+  `widgetBridge.ts` and `useWidgetSnapshot.ts`.
+
+**Exit criteria:** the heatmap widget on the home screen reflects completions
+within one app foreground cycle and survives relaunch (re-renders from the
+persisted App-Group snapshot).
+
+### Phase 1 — Overdue notifications (mostly portable)
+
+`@capacitor/local-notifications` already works on iOS, so this is the cheapest
+win. The Android plan estimates it ~70-80% portable.
+
+- Relax the Android-only guards in `useReminders.ts` / `reminders.ts` /
+  `useNotifications.ts` to include iOS.
+- Handle **iOS specifics**: no exact-alarm permission prompt (drop that branch on
+  iOS); the app icon is used instead of a monochrome `smallIcon`; the **64
+  pending-notification cap** (our single-shot-per-chore model stays well under it,
+  but cap defensively); actions declared as `UNNotificationCategory` (the plugin
+  abstracts this) with the same "Mark done" / "Send to dayGLANCE" verbs.
+- Delivery timing note: iOS has no `setExactAndAllowWhileIdle` equivalent; the
+  system may batch delivery. This fits the "information, not guilt" single-shot
+  model, but timing is inherently less precise than Android exact alarms. Accept
+  for v1.
+
+**Exit criteria:** kill the app, advance a chore past its cadence, the overdue
+notification fires and its tap routes to the chore.
+
+### Phase 2 — WidgetKit widgets + tap-to-complete
+
+The big lift. ~0% code reuse from Kotlin, but the data contract and layout design
+carry over.
+
+- **WidgetKit + SwiftUI** widgets reading the App-Group snapshot: heatmap,
+  soon/overdue **list** widget, and a configurable **single-chore** widget.
+  A `TimelineProvider` supplies entries; use SwiftUI relative-date text so
+  "Xd ago" stays honest between snapshot pushes without a background runtime.
+- **Interactive tap-to-complete via AppIntents (iOS 17+)**: the Done button runs
+  an `AppIntent` that writes `{ choreSyncId, syncId, completedAt }` to the
+  App-Group completion queue and optimistically mutates the snapshot entry. JS
+  drains on next foreground through the **existing** `pendingCompletions` path.
+  Decide the minimum iOS version; pre-17 devices fall back to tap-to-open.
+- **Chore icons**: the Lucide *Android vector drawables* do not port. Rasterize
+  the Lucide SVGs to PNGs into the App Group (adapt
+  `scripts/gen-lucide-drawables.mjs` to emit PNG assets), tinted to the recency
+  color. Decide this up front; it blocks icon parity.
+- Style to read as the same family as the in-app `ChoreRow` (recency color bar +
+  elapsed text), matching the Android "clearly same family" posture.
+
+**Exit criteria:** tapping Done on the widget updates it immediately offline;
+reopening the app shows exactly one completion logged; no double-count across a
+sync round-trip.
+
+### Phase 3 — Entry points: deep links, shortcuts, share extension
+
+- **Deep-link capture**: widget body-taps use SwiftUI `widgetURL` /
+  `Link(destination:)` with `lastglance://chore/<syncId>` and
+  `lastglance://filter/soon`; the app handles the URL in the Scene/AppDelegate and
+  stashes the target in the App Group, consumed on foreground by the existing
+  `consumeDeepLink` -> `routeWidgetDeepLink` path.
+- **Shortcuts**: `UIApplicationShortcutItem` (Home-screen long-press) and/or
+  **App Shortcuts via AppIntents** (Spotlight/Siri), targeting the same
+  `lastglance://` verbs as the Android dynamic shortcuts (Add chore, Search,
+  top-overdue chores, Soon).
+- **Share Extension**: an `NSExtension` share target writing shared text/links to
+  the App Group (`pending_shared_chore`, preferring a title over the raw URL),
+  consumed on foreground by the existing `consumeSharedChore` to open the
+  new-chore form pre-filled. This is the direct analog of the Android share
+  target and reuses the same web prefill.
+- **Stretch:** Lock Screen / Control Center widgets (WidgetKit accessory families)
+  are the closest analog to the Android Quick Settings tiles; optional.
+
+There is **no iOS analog planned for background CRDT sync** (same as Android:
+out of scope; reconcile on next foreground).
+
+---
+
+## 4. iOS-specific risks & decisions
+
+- **App Group provisioning** is the critical-path setup: developer account,
+  entitlement on every target, matching profiles. Nothing else works until it is
+  in place.
+- **WidgetKit is not a live process.** Timelines refresh on a system budget, so
+  there is no arbitrary background execution. The snapshot-read model fits, but
+  freshness of relative time ("Xd ago") relies on TimelineProvider entries and/or
+  SwiftUI relative-date formatting rather than polling.
+- **AppIntents interactivity is iOS 17+.** Pick a minimum deployment target; older
+  devices get tap-to-open widgets only.
+- **64 pending local notifications** system cap; stay under it (our model does).
+- **No exact-alarm timing.** Delivery may be batched; acceptable for the
+  single-shot overdue model, but call it out to avoid a "why is it late" surprise.
+- **Icon pipeline decision up front:** rasterize Lucide SVGs to App-Group PNGs
+  (recommended, reuses the set-aside Android approach) vs render SVGs in SwiftUI.
+
+---
+
+## 5. File touch list (proposed)
+
+**Native (new, Swift):**
+- `ios/App/App/App.entitlements` — App Group capability (+ matching entitlement on
+  each extension target).
+- `ios/App/App/plugins/WidgetBridgePlugin.swift` (+ Capacitor registration) — the
+  Swift `WidgetBridge`.
+- `ios/App/GlanceWidgets/` — WidgetKit extension: SwiftUI views, `TimelineProvider`,
+  `AppIntent` completion action, App-Group store helper.
+- `ios/App/ShareExtension/` — share target writing to the App Group.
+- `ios/App/App/AppDelegate.swift` (or a Scene delegate) — `lastglance://` URL
+  handling; `UIApplicationShortcutItem` wiring if not using AppIntents.
+- `ios/App/App/Info.plist` — `CFBundleURLTypes` for `lastglance://`, notification
+  usage strings.
+
+**Shared JS (small edits, no behavior change):**
+- `src/native/widgetBridge.ts`, `src/hooks/useWidgetSnapshot.ts`,
+  `src/native/reminders.ts`, `src/hooks/useReminders.ts`,
+  `src/hooks/useNotifications.ts` — relax the `=== 'android'` guards to include
+  iOS; add an `isIOS()` helper alongside `isAndroid()`.
+- `scripts/gen-lucide-drawables.mjs` — add a PNG-emitting mode for iOS icons (or a
+  sibling script).
+
+**To stay iOS-friendly going forward:** keep decision logic in JS behind the
+plugin boundary; route every new entry point through the shared `lastglance://`
+router so only the native declaration is per-platform; keep the App Group as the
+single native shared store.


### PR DESCRIPTION
Docs-only. Independent of the v1.14.0 PR (#202).

## Android plan — reconciled with the tree

The `docs/android-native-features-plan.md` "RESUME HERE" banner was stale (dated 2026-06-26: "Phase 2 in progress", "Android not yet compiled/device-tested"), while the code shows the work finished and then some. Updates:

- **Banner refreshed** to reflect reality: Phases 0-3 all built; heatmap widget migrated from RemoteViews to Jetpack Glance (every widget is now Glance); remaining work is on-device verification of the last widgets/config flow plus the deferred-by-choice items.
- **Documented two as-built extras** that weren't in the plan: Quick Settings tiles (`tiles/AddChoreTileService`, `tiles/SoonTileService`) and the native broadcast intents bridge (`intents/IntentReceiver` + `IntentsBridgePlugin`, `app.lastglance.{CREATE,COMPLETE,OPEN,QUERY}`) exposing the shared `@glance-apps/intents` dispatcher to Tasker/automation.
- **Phase 0** RemoteViews-vs-Glance "OPEN DECISION" marked resolved (unified on Glance).
- **Phase 2 / Phase 3** headers flipped from "IN PROGRESS" to "BUILT".

## New: iOS plan

Adds `docs/ios-native-features-plan.md`, turning the Android plan's Section 8 (iOS portability) into a concrete phased checklist mirroring the Android doc. Contents:

- **Current state:** stock Capacitor shell only (default `AppDelegate`, SPM package; no widget extension, App Group, or custom Swift). All native JS is gated to `getPlatform() === 'android'` (12 guards, 0 iOS branches), so nothing native runs on iOS yet.
- **The App Group prerequisite** (`group.app.lastglance`) as the linchpin shared store.
- **What carries over unchanged:** snapshot contract, reminders model, completion/deep-link queues, the `lastglance://` router.
- **Phases:** (0) App Group + WidgetBridge Swift plugin, (1) notifications (~70-80% portable via `@capacitor/local-notifications`), (2) WidgetKit widgets + AppIntents tap-to-complete + Lucide-to-PNG icon pipeline, (3) deep links, shortcuts, and a share extension.
- iOS-specific risks (WidgetKit timeline budget, AppIntents iOS 17+, no exact-alarm timing, 64-notification cap) and a proposed file touch list.

No code changes; nothing to build or test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_