### PR TITLE
Fix WebDAV sync re-enabling itself after disable (#204)

### DIFF
--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -10,6 +10,7 @@ import { cloudSyncProviders } from '@/utils/cloudSyncProviders'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from 'react-i18next'
 import { isWebCryptoAvailable } from '@/utils/secureContext'
+import { buildSyncConfigToSave } from './buildSyncConfig'
 
 interface Props {
   engine: SyncEngine | null
@@ -127,7 +128,13 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
       (prevVault?.accountId ?? '') !== (nextVault?.accountId ?? '')
 
     if (engine) {
-      engine.setConfig(requiredFieldsFilled ? { provider, ...formData, syncFolder: folderPath, enabled: syncEnabled, encryptionEnabled: encEnabled } : null)
+      // Persist enabled:false (and keep credentials) when disabling; only clear the
+      // config when every field is blank. Never drop it just because a required
+      // field is empty — that reset the toggle back to on and wiped creds (#204).
+      engine.setConfig(buildSyncConfigToSave({
+        provider, formData, configFields: activeProvider?.configFields ?? [],
+        folderPath, syncEnabled, encEnabled,
+      }))
       localStorage.setItem(SYNC_FOLDER_KEY, folderPath)
       resetEnsuredFolder()
     }

--- a/src/components/SyncSettingsModal/buildSyncConfig.test.ts
+++ b/src/components/SyncSettingsModal/buildSyncConfig.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { buildSyncConfigToSave } from './buildSyncConfig'
+
+// Mirrors the WebDAV provider's required fields.
+const WEBDAV_FIELDS = [{ key: 'webdavUrl' }, { key: 'username' }, { key: 'appPassword' }]
+
+const filled = { webdavUrl: 'https://dav.example.com', username: 'user', appPassword: 'pass' }
+
+describe('buildSyncConfigToSave (issue #204: cannot disable WebDAV sync)', () => {
+  it('persists enabled:false when disabling with all fields filled (does not drop the config)', () => {
+    const cfg = buildSyncConfigToSave({
+      provider: 'webdav', formData: filled, configFields: WEBDAV_FIELDS,
+      folderPath: 'GLANCE/lastglance', syncEnabled: false, encEnabled: false,
+    })
+    expect(cfg).not.toBeNull()
+    expect(cfg!.enabled).toBe(false)
+    expect(cfg!.appPassword).toBe('pass') // credentials preserved
+  })
+
+  it('keeps the config (enabled:false) when disabling even if a required field is blank', () => {
+    // The exact bug: a blank required field used to null the whole config, which
+    // reset the toggle back to on and wiped credentials on the next open.
+    const cfg = buildSyncConfigToSave({
+      provider: 'webdav', formData: { ...filled, appPassword: '' }, configFields: WEBDAV_FIELDS,
+      folderPath: 'GLANCE/lastglance', syncEnabled: false, encEnabled: false,
+    })
+    expect(cfg).not.toBeNull()
+    expect(cfg!.enabled).toBe(false)
+    expect(cfg!.webdavUrl).toBe('https://dav.example.com')
+  })
+
+  it('saves enabled:true with the full config when sync is on and fields are filled', () => {
+    const cfg = buildSyncConfigToSave({
+      provider: 'webdav', formData: filled, configFields: WEBDAV_FIELDS,
+      folderPath: 'GLANCE/lastglance', syncEnabled: true, encEnabled: true,
+    })
+    expect(cfg).toMatchObject({
+      provider: 'webdav', webdavUrl: 'https://dav.example.com', username: 'user',
+      appPassword: 'pass', syncFolder: 'GLANCE/lastglance', enabled: true, encryptionEnabled: true,
+    })
+  })
+
+  it('clears the config (null) only when every field is blank', () => {
+    const cfg = buildSyncConfigToSave({
+      provider: 'webdav', formData: { webdavUrl: '', username: '', appPassword: '' }, configFields: WEBDAV_FIELDS,
+      folderPath: 'GLANCE/lastglance', syncEnabled: false, encEnabled: false,
+    })
+    expect(cfg).toBeNull()
+  })
+
+  it('treats whitespace-only fields as empty', () => {
+    const cfg = buildSyncConfigToSave({
+      provider: 'webdav', formData: { webdavUrl: '   ', username: '', appPassword: '' }, configFields: WEBDAV_FIELDS,
+      folderPath: 'GLANCE/lastglance', syncEnabled: true, encEnabled: false,
+    })
+    expect(cfg).toBeNull()
+  })
+})

--- a/src/components/SyncSettingsModal/buildSyncConfig.ts
+++ b/src/components/SyncSettingsModal/buildSyncConfig.ts
@@ -1,0 +1,41 @@
+// Decides what WebDAV sync config to persist when the settings modal saves.
+//
+// Extracted from SyncSettingsModal so it can be unit-tested. The important
+// invariant (issue #204): turning sync OFF — or saving while some connection
+// field is blank — must NOT discard the config. The old code passed `null` to
+// setConfig whenever the required fields weren't all filled, which deleted the
+// config (wiping credentials) and made the enabled toggle spring back to its
+// default (on) the next time the modal opened, i.e. "WebDAV re-enables itself".
+//
+// Rule now: keep the config whenever the user has entered *anything* for the
+// active provider, persisting `enabled` as chosen. Only clear the config (null)
+// when every field for the active provider is empty — a genuinely blank setup.
+
+export interface SyncConfigField {
+  key: string
+}
+
+export interface BuildSyncConfigInput {
+  provider: string
+  formData: Record<string, string>
+  configFields: readonly SyncConfigField[]
+  folderPath: string
+  syncEnabled: boolean
+  encEnabled: boolean
+}
+
+export function buildSyncConfigToSave(
+  input: BuildSyncConfigInput,
+): Record<string, unknown> | null {
+  const hasAnyField = input.configFields.some(
+    (f) => (input.formData[f.key] ?? '').trim() !== '',
+  )
+  if (!hasAnyField) return null
+  return {
+    provider: input.provider,
+    ...input.formData,
+    syncFolder: input.folderPath,
+    enabled: input.syncEnabled,
+    encryptionEnabled: input.encEnabled,
+  }
+}


### PR DESCRIPTION
Fixes #204.

## Problem

`SyncSettingsModal.saveConfig()` passed `null` to `engine.setConfig` whenever the active provider's required fields weren't **all** filled:

```js
engine.setConfig(requiredFieldsFilled ? { …, enabled: syncEnabled, … } : null)
```

So turning sync off while any connection field was blank (e.g. after clearing the password) **deleted the entire sync config**. Two consequences:
- stored credentials were wiped, and
- because the enabled toggle initializes from `existingConfig?.enabled ?? true`, the next time Settings opened it defaulted back to **on** — the "WebDAV re-enables itself" the issue describes.

The plain toggle-off (all fields present) always worked; the bug needed a blank required field — most likely a user clearing their credentials while turning sync off.

## Fix

Extracted the decision into a pure, unit-tested helper `buildSyncConfigToSave`:

- Persist the config with the chosen `enabled` value whenever the user has entered **anything** for the active provider.
- Only clear the config (`null`) when **every** field is blank.

Disabling now reliably saves `enabled:false` and keeps credentials, so the toggle stays off.

## Verification

- **Reproduced the bug** first (clear password → disable → reopen): config became `null`, toggle sprang back to on.
- **After the fix** (same steps): config persists with `enabled:false`, toggle stays off across modal reopen and a full app reload.
- 5 new unit tests for `buildSyncConfigToSave` (disable-with-filled, disable-with-blank-field, enable-full, all-blank→null, whitespace-only→null). Full suite green (181), clean `tsc` and lint.

No behavior change for a fully-configured, enabled sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_