### PR TITLE
Gate the Tasker automation-intents transport behind an opt-in toggle

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -51,6 +51,11 @@ public class MainActivity extends BridgeActivity {
             return;
         }
 
+        // User opt-in gate (off by default), mirroring IntentReceiver: while the
+        // automation-intents toggle is off, an Activity-target intent may still
+        // launch the app (that can't be prevented) but its payload is dropped.
+        if (!SharedDataStore.isAutomationIntentsEnabled(this)) return;
+
         JSONObject payloadObj;
         try {
             String raw = intent.getStringExtra("payload");

--- a/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
+++ b/android/app/src/main/java/com/lastglance/app/SharedDataStore.java
@@ -98,4 +98,25 @@ public final class SharedDataStore {
         if (value != null) prefs(context).edit().remove(KEY_PENDING_INTENT).apply();
         return value;
     }
+
+    // Master switch for the Android/Tasker automation-intents transport. OFF by
+    // default: the app.lastglance.* surface is open to every installed app (an
+    // exported receiver in, unrestricted RESULT/NOTIFY broadcasts out), so it
+    // only runs once the user opts in from the dayGLANCE Integration settings.
+    // While disabled, inbound intents are dropped without being stored and no
+    // outbound broadcasts are emitted — enforced natively in IntentReceiver,
+    // MainActivity, and IntentsBridgePlugin, not just ignored by the WebView.
+    private static final String KEY_AUTOMATION_INTENTS = "automation_intents_enabled";
+
+    public static boolean isAutomationIntentsEnabled(Context context) {
+        return prefs(context).getBoolean(KEY_AUTOMATION_INTENTS, false);
+    }
+
+    public static void setAutomationIntentsEnabled(Context context, boolean enabled) {
+        SharedPreferences.Editor edit = prefs(context).edit().putBoolean(KEY_AUTOMATION_INTENTS, enabled);
+        // Turning the transport off also drops any intent stored while it was on,
+        // so a stale payload can't be processed after the user opted out.
+        if (!enabled) edit.remove(KEY_PENDING_INTENT);
+        edit.apply();
+    }
 }

--- a/android/app/src/main/java/com/lastglance/app/intents/IntentReceiver.java
+++ b/android/app/src/main/java/com/lastglance/app/intents/IntentReceiver.java
@@ -29,6 +29,11 @@ public class IntentReceiver extends BroadcastReceiver {
         String action = intent.getAction();
         if (action == null) return;
 
+        // User opt-in gate (off by default): this receiver is exported to every
+        // installed app, so while the toggle is off, drop the intent without
+        // storing or waking anything.
+        if (!SharedDataStore.isAutomationIntentsEnabled(context)) return;
+
         // Re-serialize the payload through JSONObject rather than trusting the raw
         // extra: a crafted `payload` string can't inject structure this way.
         JSONObject payloadObj;

--- a/android/app/src/main/java/com/lastglance/app/intents/IntentsBridgePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/intents/IntentsBridgePlugin.java
@@ -62,14 +62,23 @@ public class IntentsBridgePlugin extends Plugin {
 
     @PluginMethod
     public void getPendingIntent(PluginCall call) {
+        // Opt-in gate: while disabled, drain-and-drop so a payload stored before
+        // the user opted out can never be processed.
         String json = SharedDataStore.readAndClearPendingIntent(getContext());
+        boolean enabled = SharedDataStore.isAutomationIntentsEnabled(getContext());
         JSObject ret = new JSObject();
-        ret.put("value", json != null ? json : "");
+        ret.put("value", enabled && json != null ? json : "");
         call.resolve(ret);
     }
 
     @PluginMethod
     public void reportIntentResult(PluginCall call) {
+        // Opt-in gate: RESULT is an unrestricted broadcast (any app can listen),
+        // so it only fires when the user has enabled automation intents.
+        if (!SharedDataStore.isAutomationIntentsEnabled(getContext())) {
+            call.resolve();
+            return;
+        }
         String action = call.getString("action");
         String result = call.getString("result");
         Intent intent = new Intent(ACTION_RESULT);
@@ -81,10 +90,33 @@ public class IntentsBridgePlugin extends Plugin {
 
     @PluginMethod
     public void sendNotifyBroadcast(PluginCall call) {
+        // Opt-in gate: NOTIFY carries chore data (names, timestamps) as an
+        // unrestricted broadcast, so it only fires when the user has opted in.
+        if (!SharedDataStore.isAutomationIntentsEnabled(getContext())) {
+            call.resolve();
+            return;
+        }
         String payload = call.getString("payload");
         Intent intent = new Intent(ACTION_NOTIFY);
         intent.putExtra("payload", payload);
         getContext().sendBroadcast(intent);
+        call.resolve();
+    }
+
+    // The user-facing toggle (dayGLANCE Integration settings). Persisted in
+    // SharedPreferences so the manifest IntentReceiver can enforce it even when
+    // the app process is dead.
+    @PluginMethod
+    public void getAutomationIntentsEnabled(PluginCall call) {
+        JSObject ret = new JSObject();
+        ret.put("value", SharedDataStore.isAutomationIntentsEnabled(getContext()));
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void setAutomationIntentsEnabled(PluginCall call) {
+        Boolean enabled = call.getBoolean("enabled", false);
+        SharedDataStore.setAutomationIntentsEnabled(getContext(), Boolean.TRUE.equals(enabled));
         call.resolve();
     }
 }

--- a/docs/tasker-intents-architecture.md
+++ b/docs/tasker-intents-architecture.md
@@ -13,6 +13,18 @@ This is Android-only. iOS has no equivalent broadcast mechanism; for cross-platf
 
 ## 1. What it does
 
+> **Opt-in gate (lastGLANCE, added post-port; mirrors dayGLANCE's toggle).**
+> The whole transport is gated behind a user toggle — "Enable automation
+> intents" in the dayGLANCE Integration settings — **off by default**, because
+> the surface is open to every installed app (exported receiver in,
+> unrestricted RESULT/NOTIFY broadcasts out). The flag lives in native
+> `SharedPreferences` (`SharedDataStore.isAutomationIntentsEnabled`) so it is
+> enforced natively even when the app process is dead: `IntentReceiver` and
+> `MainActivity` drop inbound intents without storing them, the plugin's
+> `getPendingIntent` drains-and-drops anything stored pre-opt-out, and
+> `reportIntentResult` / `sendNotifyBroadcast` are suppressed. Disabling also
+> clears the pending-intent slot.
+
 Let another Android app (Tasker, MacroDroid, Automate, …) drive the app by sending Android intents:
 
 | Inbound action | Meaning |

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -159,6 +159,10 @@
   },
   "integration": {
     "title": "dayGLANCE-Integration",
+    "automationSection": "Automatisierungs-Intents (Tasker)",
+    "automationDescription": "Erlaubt Tasker und anderen Automatisierungs-Apps, Aufgaben per Android-Intents zu erstellen, abzuschließen, zu öffnen und abzufragen.",
+    "enableAutomation": "Automatisierungs-Intents aktivieren",
+    "enableAutomationHint": "Standardmäßig aus. Wenn aktiviert, kann jede auf diesem Gerät installierte App deine Aufgaben erstellen, abschließen und lesen sowie Aufgabendaten (Namen und Zeiten) per Broadcast empfangen.",
     "connectionSection": "Verbindung",
     "enableIntegration": "WebDAV-Intents aktivieren",
     "enableIntegrationHint": "Steuert nur den WebDAV-Intents-Transport — GLANCEvault-Intents werden unten festgelegt.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -164,6 +164,10 @@
   },
   "integration": {
     "title": "dayGLANCE Integration",
+    "automationSection": "Automation intents (Tasker)",
+    "automationDescription": "Let Tasker and other automation apps create, complete, open, and query chores by sending Android intents.",
+    "enableAutomation": "Enable automation intents",
+    "enableAutomationHint": "Off by default. When on, any app installed on this device can create, complete, and read your chores, and receive chore data (names and times) via broadcasts.",
     "connectionSection": "Connection",
     "enableIntegration": "Enable WebDAV intents",
     "enableIntegrationHint": "Controls the WebDAV intents transport only — GLANCEvault intents are set below.",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -159,6 +159,10 @@
   },
   "integration": {
     "title": "Integración con dayGLANCE",
+    "automationSection": "Intents de automatización (Tasker)",
+    "automationDescription": "Permite que Tasker y otras apps de automatización creen, completen, abran y consulten tareas mediante intents de Android.",
+    "enableAutomation": "Activar intents de automatización",
+    "enableAutomationHint": "Desactivado por defecto. Al activarlo, cualquier app instalada en este dispositivo puede crear, completar y leer tus tareas, y recibir datos de tareas (nombres y horas) por broadcast.",
     "connectionSection": "Conexión",
     "enableIntegration": "Activar intents por WebDAV",
     "enableIntegrationHint": "Controla solo el transporte de intents por WebDAV — los intents por GLANCEvault se configuran abajo.",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -159,6 +159,10 @@
   },
   "integration": {
     "title": "Intégration dayGLANCE",
+    "automationSection": "Intents d'automatisation (Tasker)",
+    "automationDescription": "Permet à Tasker et à d'autres applis d'automatisation de créer, terminer, ouvrir et interroger des tâches via des intents Android.",
+    "enableAutomation": "Activer les intents d'automatisation",
+    "enableAutomationHint": "Désactivé par défaut. Une fois activé, toute appli installée sur cet appareil peut créer, terminer et lire vos tâches, et recevoir des données de tâches (noms et horaires) par broadcast.",
     "connectionSection": "Connexion",
     "enableIntegration": "Activer les intents WebDAV",
     "enableIntegrationHint": "Contrôle uniquement le transport des intents WebDAV — les intents GLANCEvault se configurent ci-dessous.",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -159,6 +159,10 @@
   },
   "integration": {
     "title": "Integrazione dayGLANCE",
+    "automationSection": "Intent di automazione (Tasker)",
+    "automationDescription": "Consente a Tasker e ad altre app di automazione di creare, completare, aprire e interrogare le attività tramite intent Android.",
+    "enableAutomation": "Abilita intent di automazione",
+    "enableAutomationHint": "Disattivato per impostazione predefinita. Se attivo, qualsiasi app installata su questo dispositivo può creare, completare e leggere le tue attività e ricevere i dati delle attività (nomi e orari) via broadcast.",
     "connectionSection": "Connessione",
     "enableIntegration": "Abilita intent via WebDAV",
     "enableIntegrationHint": "Controlla solo il trasporto degli intent via WebDAV — gli intent via GLANCEvault si configurano sotto.",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -159,6 +159,10 @@
   },
   "integration": {
     "title": "Integração dayGLANCE",
+    "automationSection": "Intents de automação (Tasker)",
+    "automationDescription": "Permite que o Tasker e outras apps de automação criem, concluam, abram e consultem tarefas através de intents Android.",
+    "enableAutomation": "Ativar intents de automação",
+    "enableAutomationHint": "Desativado por predefinição. Quando ativo, qualquer app instalada neste dispositivo pode criar, concluir e ler as suas tarefas, e receber dados de tarefas (nomes e horas) por broadcast.",
     "connectionSection": "Ligação",
     "enableIntegration": "Ativar intents via WebDAV",
     "enableIntegrationHint": "Controla apenas o transporte de intents via WebDAV — os intents via GLANCEvault são configurados abaixo.",

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -19,6 +19,7 @@ import { loadVaultIntentsRootKey } from '@/intents/vaultIntentsKeyStore'
 import { setupIntentsEncryption } from '@/intents/setupIntentsEncryption'
 import { setupVaultIntentsEncryption, ensureVaultIntentsKey, VaultConnMissingError, VaultSaltMissingError } from '@/intents/setupVaultIntentsEncryption'
 import { flushIntents } from '@/intents/flushIntents'
+import { isAndroid, nativeGetAutomationIntentsEnabled, nativeSetAutomationIntentsEnabled } from '@/native/intentsBridge'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from 'react-i18next'
 
@@ -52,6 +53,21 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
   const [passphraseInput, setPassphraseInput] = useState('')
   const [setupError, setSetupError] = useState('')
   const [saving, setSaving] = useState(false)
+
+  // Android/Tasker automation-intents opt-in (off by default). The flag lives in
+  // native SharedPreferences — the manifest receiver enforces it even when the
+  // app is dead — so this toggle reads/writes through the plugin and applies
+  // immediately rather than riding the Save button.
+  const [automationEnabled, setAutomationEnabled] = useState(false)
+  useEffect(() => {
+    if (!isAndroid()) return
+    nativeGetAutomationIntentsEnabled().then(setAutomationEnabled)
+  }, [])
+  function toggleAutomation() {
+    const next = !automationEnabled
+    setAutomationEnabled(next)
+    void nativeSetAutomationIntentsEnabled(next)
+  }
 
   // GLANCEvault DB intents transport (beta). Independent of the WebDAV intents
   // config above and of the vault SYNC toggle: this only flips the `enabled`
@@ -216,6 +232,34 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
 
         {/* Scrollable body */}
         <div className="overflow-y-auto flex-1 px-6 pb-4 space-y-5">
+          {/* Automation intents (Tasker) — Android only. Native opt-in gate for
+              the app.lastglance.* broadcast surface; applies immediately. */}
+          {isAndroid() && (
+            <div className="space-y-3">
+              <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                {t('integration.automationSection')}
+              </h3>
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                {t('integration.automationDescription')}
+              </p>
+              <div className="flex items-start justify-between py-1">
+                <div className="min-w-0">
+                  <p className="text-sm text-slate-700 dark:text-slate-300">{t('integration.enableAutomation')}</p>
+                  <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{t('integration.enableAutomationHint')}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={toggleAutomation}
+                  className={`relative shrink-0 mt-0.5 w-10 h-6 rounded-full transition-colors ${automationEnabled ? 'bg-green-400' : 'bg-slate-300 dark:bg-slate-600'}`}
+                  aria-checked={automationEnabled}
+                  role="switch"
+                >
+                  <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${automationEnabled ? 'translate-x-4' : ''}`} />
+                </button>
+              </div>
+            </div>
+          )}
+
           {/* Connection section */}
           <div className="space-y-3">
             <h3 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide">

--- a/src/native/intentsBridge.ts
+++ b/src/native/intentsBridge.ts
@@ -19,6 +19,11 @@ export interface IntentsBridgePlugin {
   // Emit the NOTIFY broadcast (a chore changed state), plaintext, for a local
   // listener like Tasker to react to.
   sendNotifyBroadcast(options: { payload: string }): Promise<void>
+  // The user-facing opt-in for the whole transport (off by default). Persisted
+  // natively (SharedPreferences) so the manifest receiver enforces it even when
+  // the app process is dead.
+  getAutomationIntentsEnabled(): Promise<{ value: boolean }>
+  setAutomationIntentsEnabled(options: { enabled: boolean }): Promise<void>
   // Fired by native when a new intent lands while the app is running, so the web
   // app drains immediately rather than waiting for the next visibility/focus.
   addListener(eventName: 'pendingIntent', listenerFunc: () => void): Promise<PluginListenerHandle>
@@ -70,6 +75,27 @@ export async function nativeSendNotifyBroadcast(payloadJson: string): Promise<vo
     await IntentsBridge.sendNotifyBroadcast({ payload: payloadJson })
   } catch {
     // Best-effort; a dropped NOTIFY just means a local listener misses one event.
+  }
+}
+
+// Reads the automation-intents opt-in. False off Android or on any error, so
+// the settings UI defaults to the safe (disabled) state.
+export async function nativeGetAutomationIntentsEnabled(): Promise<boolean> {
+  if (!isAndroid()) return false
+  try {
+    const res = await IntentsBridge.getAutomationIntentsEnabled()
+    return res?.value === true
+  } catch {
+    return false
+  }
+}
+
+export async function nativeSetAutomationIntentsEnabled(enabled: boolean): Promise<void> {
+  if (!isAndroid()) return
+  try {
+    await IntentsBridge.setAutomationIntentsEnabled({ enabled })
+  } catch {
+    // Best-effort; the native default (disabled) is the safe state.
   }
 }
 


### PR DESCRIPTION
Mirrors dayGLANCE's "Enable automation intents" toggle for consistency and safety (flagged in the Play Store readiness audit).

## Why

The `app.lastglance.*` surface is open to every installed app: the manifest `IntentReceiver` is exported without a permission (any app can inject CREATE/COMPLETE/OPEN/QUERY), and the RESULT/NOTIFY replies are unrestricted broadcasts (any app can listen for chore names/times). That's inherent to Tasker-style integration, but it shouldn't be on by default.

## What

**"Enable automation intents" toggle — off by default** — in the dayGLANCE Integration settings, Android-only, with the same honest warning copy as dayGLANCE ("When on, any app installed on this device can create, complete, and read your chores, and receive chore data (names and times) via broadcasts."). Localized in all six languages.

**Enforcement is native**, so it holds even when the app process is dead:
- Flag persisted in `SharedDataStore` (SharedPreferences), default `false`
- `IntentReceiver.onReceive` and `MainActivity.captureTaskerIntent` drop inbound intents without storing or waking anything while disabled
- `IntentsBridgePlugin.getPendingIntent` drains-and-drops any payload stored before opt-out
- `reportIntentResult` / `sendNotifyBroadcast` are suppressed while disabled (no data leaves via broadcast)
- Disabling also clears the pending-intent slot

The plugin exposes `getAutomationIntentsEnabled` / `setAutomationIntentsEnabled` for the settings UI; the toggle applies immediately (it's a native safety switch, not part of the save-on-close config). Architecture doc updated.

## Behavior change

Existing Tasker users must flip the toggle on once — the transport previously ran unconditionally. Worth a line in the next release notes.

## Verification

- Web: clean `tsc -b`, lint, full suite green (181 tests).
- **Java is compile-unverified in this environment (no Android SDK)** — the changes are mechanical (a boolean pref + early returns; all imports pre-existing), but please run a device build before release and sanity-check: toggle off → Tasker broadcast does nothing and no NOTIFY fires on completion; toggle on → CREATE/COMPLETE/QUERY round-trip works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_