### PR TITLE
Exclude WebView storage and widget prefs from cloud backup

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/app/src/main/res/xml/backup_rules.xml
+++ b/android/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Auto Backup rules for Android 11 and below (API ≤ 30), referenced by
+     android:fullBackupContent in the manifest. Mirrors the cloud-backup section
+     of data_extraction_rules.xml — see the rationale there. (Pre-31 has no
+     separate device-transfer concept, so this governs cloud backup only.) -->
+<full-backup-content>
+    <exclude domain="root" path="app_webview/" />
+    <exclude domain="sharedpref" path="lastglance_shared.xml" />
+</full-backup-content>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Backup/transfer rules for Android 12+ (API 31), referenced by
+     android:dataExtractionRules in the manifest.
+
+     Cloud backup excludes:
+     - app_webview/: the WebView profile holding ALL web-app storage — IndexedDB
+       (chore data + the sync crypto keys in lastglance-crypto) and localStorage
+       (WebDAV credentials, vault token, intents config). Keeps secrets and user
+       content out of Google cloud backups; WebView data restore is also known to
+       be unreliable (partial LevelDB restores). Sync or the in-app export is the
+       sanctioned recovery path.
+     - lastglance_shared.xml: the widget hand-off prefs. The snapshot inside
+       carries chore names/dates (same content excluded above), and it is derived
+       data the app regenerates on first open — restoring it would only show
+       stale widget content until then.
+
+     Device-to-device transfer is intentionally UNRESTRICTED: it is a direct,
+     encrypted phone-to-phone copy that never lands on a server, and keeping it
+     preserves seamless migration for users who don't use sync. -->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="app_webview/" />
+        <exclude domain="sharedpref" path="lastglance_shared.xml" />
+    </cloud-backup>
+</data-extraction-rules>


### PR DESCRIPTION
Hardening item from the Play Store readiness audit. Keystore-backed credential storage is deferred as a separate follow-up (requires async-config plumbing in the sync engine).

## Problem

`allowBackup="true"` with no backup rules means Android Auto Backup ships the entire app data directory to Google cloud backups — including `app_webview/`, which holds **all** web storage:

- WebDAV credentials and the GLANCEvault token (localStorage)
- the sync encryption keys (`lastglance-crypto` IndexedDB)
- the chore database itself

## Change

Adds `android:dataExtractionRules` (API 31+) and `android:fullBackupContent` (API ≤30), both excluding from **cloud backup**:

- `app_webview/` — secrets, keys, and user content; WebView data restore is also notoriously unreliable (partial LevelDB restores), so excluding it removes a corruption failure mode too
- `shared_prefs/lastglance_shared.xml` — the widget hand-off prefs; the snapshot inside carries chore names/dates (the same content in derived form), and the app regenerates it on first open anyway

**Device-to-device transfer stays unrestricted** — it's a direct, encrypted phone-to-phone copy that never lands on a server, so new-phone migration keeps working seamlessly for users who don't use sync.

Recovery after a cloud restore is the sanctioned paths: cloud sync, or the in-app manual export/import.

## Notes

- Config-only: manifest (2 attributes) + 2 XML resource files. No code changes.
- XML validated; **not device-tested here** (no Android SDK in this environment). Before release, worth one pass on a device: `adb shell bmgr backupnow com.lastglance.app`, uninstall/reinstall with restore, and confirm the app comes up clean (no credentials, seeds fresh) while D2D transfer still migrates data.
- Post-restore quirk to expect: nothing — since the widget prefs are excluded too, a restored install starts fully clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_