### PR TITLE
Release v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Part of the **GLANCE family**: focused, standalone apps connected through a shared intent protocol. See also [dayGLANCE](https://github.com/krelltunez/dayGLANCE) (today), lastGLANCE (recent upkeep), and [lifeGLANCE](https://github.com/krelltunez/lifeGLANCE) (your whole timeline).
 
-[![Version](https://img.shields.io/badge/version-1.14.0-green.svg)](../../releases)
+[![Version](https://img.shields.io/badge/version-2.0.0-green.svg)](../../releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "1.14.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "1.14.0",
+      "version": "2.0.0",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
         "@capacitor/core": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
-  "version": "1.14.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version stamp for the first public Play Store release: `package.json`, `package-lock.json`, and the README badge → **2.0.0**. Derived `versionCode`: **2000000** (monotonic above 1.14.0's 1140000, with the usual pre-release override headroom).

## Why 2.0.0 (not 1.14.1)

- Marks the public paid launch cleanly on the store listing.
- The Tasker automation-intents transport becoming **opt-in, off by default** (#208) is a genuine breaking behavior change for automation users, which justifies the major bump on engineering grounds too.
- Nothing depends on the old numbering; versionCode stays monotonic.

## In this release since v1.14.0

- Fix: disabling WebDAV sync now persists (no self re-enable, no credential wipe) (#206)
- Tasker automation intents now behind an opt-in toggle, off by default; enforced natively (#208)
- Credentials, sync keys, and app data excluded from Google cloud backups; device-to-device transfer unaffected (#209)
- Inter font bundled locally; wordmark/UI render offline with no Google Fonts CDN dependency (#207)

Tests green (181), lockfile updated, no dependency drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_