### PR TITLE
Add CLAUDE.md (maintainer context + release conventions)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md
+
+Working notes for AI-assisted sessions in this repo.
+
+## Maintainer context
+
+- **Timezone: America/Denver (Mountain Time).** Phrase all time-of-day
+  references ("today", "tonight", deadlines) in Mountain Time, not UTC.
+- Release notes must contain **no em dashes**.
+
+## Conventions
+
+- Versioning: `versionName` from package.json; Android `versionCode` is derived
+  as `major*1000000 + minor*10000 + patch*100` (see android/app/build.gradle),
+  leaving +100 headroom per patch for pre-release `APP_VERSION_CODE` overrides.
+- Release builds: `./build-android.sh --release` produces both the sideload APK
+  and the Play `.aab`. Upload the bundle once, then promote it between tracks;
+  do not rebuild per track.
+- Play listing is FREE (locked by Google; cannot become paid). Monetization is
+  in-app via Play Billing. The GitHub sideload APK ships without the paywall
+  (dayGLANCE-style split).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,17 @@ Working notes for AI-assisted sessions in this repo.
 - Play listing is FREE (locked by Google; cannot become paid). Monetization is
   in-app via Play Billing. The GitHub sideload APK ships without the paywall
   (dayGLANCE-style split).
+
+## Google Play (learned the hard way, 2026-07)
+
+- **NEVER create a Play app entry as Free unless it will stay free forever.**
+  Free→paid is impossible once the app has been published to ANY track — even
+  internal testing counts. Paid→free is allowed (also one-way). New GLANCE app
+  entries must be created as PAID; testers install paid apps free via
+  Setup → License testing.
+- The closed-testing requirement (12 testers opted in for 14 days) is per-app
+  and restarts for any new app entry / package name.
+- lastGLANCE (`com.lastglance.app`) is locked FREE on Play; monetization is an
+  in-app Play Billing unlock. lifeGLANCE reported locked free as well (verify:
+  the lock only applies once published to a track). dayGLANCE is free by
+  design with its own in-app paywall.


### PR DESCRIPTION
One-file addition so AI sessions carry the right context: maintainer timezone (Mountain Time), release-notes style (no em dashes), the versionCode scheme, the promote-don't-rebuild flow, and the free-listing/Play-Billing monetization reality. One-click merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_