### PR TITLE
Refresh the chore list after an intent-created chore

### DIFF
--- a/src/intents/intentContext.ts
+++ b/src/intents/intentContext.ts
@@ -124,6 +124,10 @@ export function buildIntentContext(onChanged?: () => void): IntentContext {
     createChore: async (input) => {
       const created = await createChore(input)
       addActivityEntry({ type: 'received', message: `Created "${input.name}" via Tasker` })
+      // Mirror the COMPLETE path and the poller transports: lg:chore-logged is
+      // what makes the Ribbon reload its data. Without it, an intent-created
+      // chore lands in the DB but stays invisible until the next app restart.
+      window.dispatchEvent(new CustomEvent('lg:chore-logged'))
       onChanged?.()
       return created
     },


### PR DESCRIPTION
Found while device-testing the automation-intents toggle (#208): a chore created via an inbound Android/Tasker intent lands in the database but never appears in the UI until the next app restart.

## Root cause

`buildIntentContext().createChore` only calls `onChanged` — which App wires to `loadHeatmap` — so the heatmap refreshes but the Ribbon's chore list never reloads. Every other mutating path already dispatches `lg:chore-logged` (the event the Ribbon's reload listener is keyed on): the bridge's own COMPLETE path, the WebDAV intents poller, the vault DB poller, and notification actions. CREATE was the one gap, and it made the device test look like the transport was dead when the chore was being created invisibly.

## Fix

Dispatch `lg:chore-logged` in the CREATE wrapper, mirroring the COMPLETE path two lines below it.

Tests green (181), tsc/lint clean. Device re-test: with the toggle on and the app open, `adb shell "am broadcast -a app.lastglance.CREATE -p com.lastglance.app --es payload '{\"title\":\"toggletest\"}'"` should now surface the chore live, without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_