### PR TITLE
Declare the Play Billing permission ahead of the paywall integration

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -148,6 +148,14 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Play Billing, declared ahead of the paywall integration: the Play Console
+         only allows creating in-app products/subscriptions once an uploaded
+         artifact carries this permission, so declaring it now lets the SKUs be
+         created (and start propagating) while @glance-apps/paywall is extracted.
+         Harmless at runtime — nothing queries billing until the paywall lands;
+         the Play Billing library will merge this same permission when added.
+         See docs/paywall-billing-plan.md. -->
+    <uses-permission android:name="com.android.vending.BILLING" />
     <!-- Exact alarms for Doze-proof overdue reminders (Android 12+). The plugin
          already declares POST_NOTIFICATIONS and RECEIVE_BOOT_COMPLETED. -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />


### PR DESCRIPTION
Unblocks the Play Console jump-start: product/subscription creation is gated on an uploaded artifact carrying `com.android.vending.BILLING` (the "Upload a new APK" wall on the One-time products page). This declares the permission now — one manifest line, zero runtime effect, nothing queries billing — so the console work can run in parallel with the `@glance-apps/paywall` extraction instead of serially after it.

The Play Billing library merges this same permission when the real integration lands, at which point this explicit declaration is redundant but harmless.

## After merging

1. `./build-android.sh --release` → upload `lastglance.aab` (versionCode 2000000) to **internal testing only** — do not submit to production; that remains the one-shot with the actual paywall under managed publishing.
2. The Monetize sections unlock. Create per `docs/paywall-billing-plan.md`:
   - Subscription `pro`, base plan `annual` — $4.99/year
   - One-time product `pro_lifetime` — $19.99
   - (IDs are effectively permanent; if you pick different ones, note them so the paywall config matches.)
3. Activate both; expect **hours of propagation** before they're purchasable — which is exactly why creating them early is worth it.
4. Setup → License testing: add tester emails so purchase testing is free when the billing build arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_