### PR TITLE
Integrate @glance-apps/billing: Play-channel paywall (annual + lifetime)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,6 +100,8 @@ dependencies {
     implementation project(':capacitor-android')
     // Jetpack Glance home-screen widgets (Compose-based).
     implementation "androidx.glance:glance-appwidget:$glanceVersion"
+    // Play Billing bridge bundled with @glance-apps/billing (see settings.gradle).
+    implementation project(':glance-apps-billing')
     implementation "androidx.glance:glance-material3:$glanceVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 
 import com.getcapacitor.BridgeActivity;
 
+import com.glanceapps.billing.BillingBridgePlugin;
+
 import com.lastglance.app.intents.IntentReceiver;
 import com.lastglance.app.intents.IntentsBridgePlugin;
 
@@ -17,6 +19,7 @@ public class MainActivity extends BridgeActivity {
         // Register app-local plugins before the bridge starts.
         registerPlugin(WidgetBridgePlugin.class);
         registerPlugin(IntentsBridgePlugin.class);
+        registerPlugin(BillingBridgePlugin.class);
         super.onCreate(savedInstanceState);
         captureWidgetDeepLink(getIntent());
         captureSharedText(getIntent());

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -2,4 +2,9 @@ include ':app'
 include ':capacitor-cordova-android-plugins'
 project(':capacitor-cordova-android-plugins').projectDir = new File('./capacitor-cordova-android-plugins/')
 
+// @glance-apps/billing ships its BillingBridge Capacitor plugin as a Gradle
+// module inside the npm package (see the package README, "Capacitor apps").
+include ':glance-apps-billing'
+project(':glance-apps-billing').projectDir = new File('../node_modules/@glance-apps/billing/android')
+
 apply from: 'capacitor.settings.gradle'

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -14,4 +14,5 @@ ext {
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
     glanceVersion = '1.1.1'
+    playBillingVersion = '7.1.1'
 }

--- a/build-android.sh
+++ b/build-android.sh
@@ -105,29 +105,36 @@ if $RELEASE; then
     echo "         be UNSIGNED and not installable. See keystore.properties.example."
   fi
 
-  echo "==> Building web assets..."
+  # Channel-split release builds (docs/paywall-billing-plan.md): the sideload
+  # APK is UNGATED (github channel) and the Play AAB is GATED (play channel),
+  # so each artifact needs its own web build — VITE_BUILD_CHANNEL is baked in
+  # at Vite build time. APP_VERSION_CODE, when set, overrides the derived
+  # versionCode for both artifacts (see build.gradle).
+
+  echo "==> Building web assets (channel: github — ungated sideload APK)..."
   cd "$SCRIPT_DIR"
-  npm run build:android
-
-  # Build the release APK (for sideloading/testing) and the AAB (App Bundle)
-  # that the Play Store requires for uploads, in a single Gradle invocation.
-  # APP_VERSION_CODE, when set, overrides the package.json-derived versionCode
-  # (see build.gradle); otherwise the gradle property is simply not passed.
-  if [ -n "$APP_VERSION_CODE" ]; then
-    echo "==> Building release APK + AAB (versionCode override: $APP_VERSION_CODE)..."
-  else
-    echo "==> Building release APK + AAB..."
-  fi
+  VITE_BUILD_CHANNEL=github npm run build:android
   cd "$ANDROID_DIR"
-  ./gradlew assembleRelease bundleRelease ${APP_VERSION_CODE:+-PappVersionCode="$APP_VERSION_CODE"}
-
+  ./gradlew assembleRelease ${APP_VERSION_CODE:+-PappVersionCode="$APP_VERSION_CODE"}
   cp "app/build/outputs/apk/release/lastglance.apk" "$OUT_DIR/lastglance.apk"
-  echo "    APK (release) → outputs/lastglance.apk"
+  echo "    APK (release, github channel) → outputs/lastglance.apk"
+
+  # The Play build must carry the reviewer bypass (@glance-apps/billing rule 9:
+  # store review needs a way past a hard gate).
+  if [ -z "$VITE_REVIEWER_SECRET" ]; then
+    echo "WARNING: VITE_REVIEWER_SECRET is not set — the Play build's reviewer"
+    echo "         bypass will be DISABLED. Set it before building a store AAB."
+  fi
+  echo "==> Building web assets (channel: play — gated AAB)..."
+  cd "$SCRIPT_DIR"
+  VITE_BUILD_CHANNEL=play npm run build:android
+  cd "$ANDROID_DIR"
+  ./gradlew bundleRelease ${APP_VERSION_CODE:+-PappVersionCode="$APP_VERSION_CODE"}
 
   # The bundle task ignores the APK outputFileName rename in build.gradle, so
   # the .aab keeps its default name (app-release.aab); copy it to a stable path.
   cp "app/build/outputs/bundle/release/app-release.aab" "$OUT_DIR/lastglance.aab"
-  echo "    AAB (release) → outputs/lastglance.aab"
+  echo "    AAB (release, play channel) → outputs/lastglance.aab"
 
   # Verify the APK carries a valid signature (catches a misconfigured or
   # missing keystore.properties that would otherwise ship an unsigned APK/AAB).

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/ios": "^8.4.0",
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/status-bar": "^8.0.2",
+        "@glance-apps/billing": "0.1.0",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.0",
         "dayjs": "^1.11.13",
@@ -2810,6 +2811,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@glance-apps/billing": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.0.tgz",
+      "integrity": "sha512-HmrIf7ZuqRKDz/4kPG02qf2CGBzaWAO7wEYhfuN8au/oo2mPDPxge5BmLqqVrdEf/swo7MiBdZ2pURmXTRsjxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "electron": ">=28",
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "electron": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@glance-apps/intents": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@capacitor/ios": "^8.4.0",
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/status-bar": "^8.0.2",
+    "@glance-apps/billing": "0.1.0",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.0",
     "dayjs": "^1.11.13",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -19,7 +19,8 @@
     "all": "Alle",
     "done": "Fertig",
     "edit": "Bearbeiten",
-    "settings": "Einstellungen"
+    "settings": "Einstellungen",
+    "subscription": "Abo"
   },
   "activityLog": {
     "title": "Aktivitätsprotokoll",
@@ -373,5 +374,27 @@
     "sendLabel": "→ dG",
     "done": "Erledigt",
     "details": "Details"
+  },
+  "paywall": {
+    "pitch": "Behalte im Blick, wann du alles Wichtige zuletzt erledigt hast. Einmal freischalten, alle Funktionen.",
+    "annualTitle": "Jährlich",
+    "annualPer": "{{price}}/Jahr",
+    "lifetimeTitle": "Lebenslang",
+    "lifetimeOnce": "{{price}} einmalig",
+    "lifetimeHint": "Einmal zahlen, für immer behalten.",
+    "trialDays_one": "{{count}} Tag kostenlos testen",
+    "trialDays_other": "{{count}} Tage kostenlos testen",
+    "trialGeneric": "Kostenlose Testphase inklusive",
+    "restore": "Kauf wiederherstellen",
+    "nothingToRestore": "Kein früherer Kauf gefunden.",
+    "haveCode": "Code vorhanden?",
+    "codePlaceholder": "Zugangscode",
+    "codeSubmit": "Einlösen",
+    "codeInvalid": "Dieser Code ist ungültig.",
+    "manage": "Abo verwalten",
+    "sourceLifetime": "Lebenslange Freischaltung aktiv",
+    "sourceSubscription": "Jahresabo aktiv",
+    "sourceReviewer": "Prüfzugang aktiv",
+    "sourceNone": "Nicht freigeschaltet"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -19,7 +19,8 @@
     "all": "All",
     "done": "Done",
     "edit": "Edit",
-    "settings": "Settings"
+    "settings": "Settings",
+    "subscription": "Subscription"
   },
   "activityLog": {
     "title": "Activity Log",
@@ -399,5 +400,27 @@
     "sendLabel": "→ dG",
     "done": "Done",
     "details": "Details"
+  },
+  "paywall": {
+    "pitch": "Track when you last did everything that matters. One unlock, every feature.",
+    "annualTitle": "Annual",
+    "annualPer": "{{price}}/year",
+    "lifetimeTitle": "Lifetime",
+    "lifetimeOnce": "{{price}} once",
+    "lifetimeHint": "Pay once, keep it forever.",
+    "trialDays_one": "{{count}}-day free trial",
+    "trialDays_other": "{{count}}-day free trial",
+    "trialGeneric": "Free trial included",
+    "restore": "Restore purchase",
+    "nothingToRestore": "No previous purchase found.",
+    "haveCode": "Have a code?",
+    "codePlaceholder": "Access code",
+    "codeSubmit": "Apply",
+    "codeInvalid": "That code is not valid.",
+    "manage": "Manage subscription",
+    "sourceLifetime": "Lifetime unlock active",
+    "sourceSubscription": "Annual subscription active",
+    "sourceReviewer": "Review access active",
+    "sourceNone": "Not unlocked"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -19,7 +19,8 @@
     "all": "Todas",
     "done": "Listo",
     "edit": "Editar",
-    "settings": "Ajustes"
+    "settings": "Ajustes",
+    "subscription": "Suscripción"
   },
   "activityLog": {
     "title": "Registro de actividad",
@@ -373,5 +374,27 @@
     "sendLabel": "→ dG",
     "done": "Hecho",
     "details": "Detalles"
+  },
+  "paywall": {
+    "pitch": "Controla cuándo hiciste por última vez todo lo que importa. Un desbloqueo, todas las funciones.",
+    "annualTitle": "Anual",
+    "annualPer": "{{price}}/año",
+    "lifetimeTitle": "De por vida",
+    "lifetimeOnce": "{{price}} una vez",
+    "lifetimeHint": "Paga una vez y quédatelo para siempre.",
+    "trialDays_one": "Prueba gratis de {{count}} día",
+    "trialDays_other": "Prueba gratis de {{count}} días",
+    "trialGeneric": "Prueba gratis incluida",
+    "restore": "Restaurar compra",
+    "nothingToRestore": "No se encontró ninguna compra anterior.",
+    "haveCode": "¿Tienes un código?",
+    "codePlaceholder": "Código de acceso",
+    "codeSubmit": "Aplicar",
+    "codeInvalid": "Ese código no es válido.",
+    "manage": "Gestionar suscripción",
+    "sourceLifetime": "Desbloqueo de por vida activo",
+    "sourceSubscription": "Suscripción anual activa",
+    "sourceReviewer": "Acceso de revisión activo",
+    "sourceNone": "No desbloqueado"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -19,7 +19,8 @@
     "all": "Toutes",
     "done": "Terminer",
     "edit": "Modifier",
-    "settings": "Paramètres"
+    "settings": "Paramètres",
+    "subscription": "Abonnement"
   },
   "activityLog": {
     "title": "Journal d'activité",
@@ -373,5 +374,27 @@
     "sendLabel": "→ dG",
     "done": "Fait",
     "details": "Détails"
+  },
+  "paywall": {
+    "pitch": "Suivez quand vous avez fait tout ce qui compte pour la dernière fois. Un déblocage, toutes les fonctions.",
+    "annualTitle": "Annuel",
+    "annualPer": "{{price}}/an",
+    "lifetimeTitle": "À vie",
+    "lifetimeOnce": "{{price}} une fois",
+    "lifetimeHint": "Payez une fois, gardez-le pour toujours.",
+    "trialDays_one": "Essai gratuit de {{count}} jour",
+    "trialDays_other": "Essai gratuit de {{count}} jours",
+    "trialGeneric": "Essai gratuit inclus",
+    "restore": "Restaurer l'achat",
+    "nothingToRestore": "Aucun achat antérieur trouvé.",
+    "haveCode": "Un code ?",
+    "codePlaceholder": "Code d'accès",
+    "codeSubmit": "Valider",
+    "codeInvalid": "Ce code n'est pas valide.",
+    "manage": "Gérer l'abonnement",
+    "sourceLifetime": "Déblocage à vie actif",
+    "sourceSubscription": "Abonnement annuel actif",
+    "sourceReviewer": "Accès de test actif",
+    "sourceNone": "Non débloqué"
   }
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -19,7 +19,8 @@
     "all": "Tutte",
     "done": "Fine",
     "edit": "Modifica",
-    "settings": "Impostazioni"
+    "settings": "Impostazioni",
+    "subscription": "Abbonamento"
   },
   "activityLog": {
     "title": "Registro attività",
@@ -373,5 +374,27 @@
     "sendLabel": "→ dG",
     "done": "Fatto",
     "details": "Dettagli"
+  },
+  "paywall": {
+    "pitch": "Tieni traccia di quando hai fatto l'ultima volta tutto ciò che conta. Uno sblocco, tutte le funzioni.",
+    "annualTitle": "Annuale",
+    "annualPer": "{{price}}/anno",
+    "lifetimeTitle": "A vita",
+    "lifetimeOnce": "{{price}} una tantum",
+    "lifetimeHint": "Paghi una volta, è tuo per sempre.",
+    "trialDays_one": "Prova gratuita di {{count}} giorno",
+    "trialDays_other": "Prova gratuita di {{count}} giorni",
+    "trialGeneric": "Prova gratuita inclusa",
+    "restore": "Ripristina acquisto",
+    "nothingToRestore": "Nessun acquisto precedente trovato.",
+    "haveCode": "Hai un codice?",
+    "codePlaceholder": "Codice di accesso",
+    "codeSubmit": "Applica",
+    "codeInvalid": "Codice non valido.",
+    "manage": "Gestisci abbonamento",
+    "sourceLifetime": "Sblocco a vita attivo",
+    "sourceSubscription": "Abbonamento annuale attivo",
+    "sourceReviewer": "Accesso di revisione attivo",
+    "sourceNone": "Non sbloccato"
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -19,7 +19,8 @@
     "all": "Todas",
     "done": "Concluído",
     "edit": "Editar",
-    "settings": "Definições"
+    "settings": "Definições",
+    "subscription": "Subscrição"
   },
   "activityLog": {
     "title": "Registo de atividade",
@@ -373,5 +374,27 @@
     "sendLabel": "→ dG",
     "done": "Feito",
     "details": "Detalhes"
+  },
+  "paywall": {
+    "pitch": "Acompanhe quando fez pela última vez tudo o que importa. Um desbloqueio, todas as funções.",
+    "annualTitle": "Anual",
+    "annualPer": "{{price}}/ano",
+    "lifetimeTitle": "Vitalício",
+    "lifetimeOnce": "{{price}} uma vez",
+    "lifetimeHint": "Pague uma vez, fique com ele para sempre.",
+    "trialDays_one": "Teste grátis de {{count}} dia",
+    "trialDays_other": "Teste grátis de {{count}} dias",
+    "trialGeneric": "Teste grátis incluído",
+    "restore": "Restaurar compra",
+    "nothingToRestore": "Nenhuma compra anterior encontrada.",
+    "haveCode": "Tem um código?",
+    "codePlaceholder": "Código de acesso",
+    "codeSubmit": "Aplicar",
+    "codeInvalid": "Esse código não é válido.",
+    "manage": "Gerir subscrição",
+    "sourceLifetime": "Desbloqueio vitalício ativo",
+    "sourceSubscription": "Subscrição anual ativa",
+    "sourceReviewer": "Acesso de revisão ativo",
+    "sourceNone": "Não desbloqueado"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Pencil, Check, Sun, Moon, Archive, Plug, Cloud, CloudOff, RefreshCw, HelpCircle, Users, Settings, UserCircle, Clock } from 'lucide-react'
+import { Pencil, Check, Sun, Moon, Archive, Plug, Cloud, CloudOff, RefreshCw, HelpCircle, Users, Settings, UserCircle, Clock, BadgeCheck } from 'lucide-react'
 import { Ribbon } from '@/components/Ribbon/Ribbon'
 import { BackupModal } from '@/components/BackupModal/BackupModal'
 import { WelcomeModal } from '@/components/WelcomeModal/WelcomeModal'
@@ -12,6 +12,8 @@ import { ShortcutsModal } from '@/components/ShortcutsModal/ShortcutsModal'
 import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal'
 import { ToastProvider, useToast } from '@/components/Toast/Toast'
 import { UsersModal } from '@/components/UsersModal/UsersModal'
+import { PaywallModal } from '@/components/PaywallModal/PaywallModal'
+import { useSubscription } from '@/billing/billing'
 import { UsersContext } from '@/multiuser/UsersContext'
 import { useUsers } from '@/multiuser/useUsers'
 import { useNotifications } from '@/hooks/useNotifications'
@@ -133,6 +135,10 @@ function AppInner() {
   const usersCtx = useUsers()
   const reloadUsers = usersCtx.reload
   const { multiUserEnabled, meId, filter, setFilter, attentionOnly, setAttentionOnly } = usersCtx
+  // Billing/paywall — inert off the Play channel (adapter is null there, so
+  // gated stays false and the hard gate below never renders).
+  const billing = useSubscription()
+  const [showBillingStatus, setShowBillingStatus] = useState(false)
   const [editMode, setEditMode] = useState(false)
   const [showWelcome, setShowWelcome] = useState(() => !localStorage.getItem('lg-welcome-dismissed'))
   const [welcomeClearing, setWelcomeClearing] = useState(false)
@@ -432,6 +438,8 @@ function AppInner() {
     { label: isDark ? t('app.lightMode') : t('app.darkMode'), icon: isDark ? <Sun size={15} /> : <Moon size={15} />, onClick: () => { toggleTheme(); setShowSettingsSheet(false) } },
     { label: t('app.backupRestore'), icon: <Archive size={15} />, onClick: () => { setShowBackup(true); setShowSettingsSheet(false) } },
     { label: t('app.helpFeedback'), icon: <HelpCircle size={15} />, onClick: () => { setShowHelp(true); setShowSettingsSheet(false) } },
+    // Entitlement surface, Play builds only (gated is false on github/web).
+    ...(billing.gated ? [{ label: t('app.subscription'), icon: <BadgeCheck size={15} />, onClick: () => { setShowBillingStatus(true); setShowSettingsSheet(false) } }] : []),
   ]
 
   return (
@@ -678,6 +686,18 @@ function AppInner() {
           onUserMutated={runSharedUserSync}
           onClose={() => { setShowUsers(false); usersCtx.reload() }}
         />
+      )}
+
+      {/* Entitlement status (settings surface, unlocked installs). */}
+      {showBillingStatus && (
+        <PaywallModal billing={billing} mode="status" onClose={() => setShowBillingStatus(false)} />
+      )}
+
+      {/* Hard paywall — last in the tree and z-[80], above every other surface.
+          Only ever true on the Play channel; the engine's provisional unlock
+          keeps previously-entitled installs from ever flashing this. */}
+      {billing.gated && !billing.isUnlocked && (
+        <PaywallModal billing={billing} mode="gate" />
       )}
     </div>
     </UsersContext.Provider>

--- a/src/billing/billing.ts
+++ b/src/billing/billing.ts
@@ -1,0 +1,37 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+import { playManageSubscriptionUrl } from '@glance-apps/billing'
+import { createCapacitorAdapter, type CapacitorBillingPlugin } from '@glance-apps/billing/capacitor'
+import { useBilling, type UseBillingResult } from '@glance-apps/billing/react'
+
+// Play product ids, as created in the Play Console (docs/paywall-billing-plan.md):
+// the subscription product `pro` (base plan `annual`, $4.99/yr) queried as SUBS,
+// and the one-time INAPP product `pro_lifetime` ($19.99). Single source of truth
+// for the whole app — the gate UI and the native plugin both derive from here.
+export const PRODUCT_IDS = { yearly: 'pro', lifetime: 'pro_lifetime' }
+
+// Channel gating is structural (@glance-apps/billing README rule 10): only the
+// Play build constructs an adapter. The GitHub sideload APK and self-hosted
+// web/PWA builds pass adapter: null and are ungated by design — no debug flags,
+// nothing to strip. VITE_BUILD_CHANNEL is set by build-android.sh per artifact.
+const CHANNEL = import.meta.env.VITE_BUILD_CHANNEL ?? 'web'
+const isGatedChannel = CHANNEL === 'play' && Capacitor.getPlatform() === 'android'
+
+// Safe to register unconditionally: on non-Android the proxy is simply never
+// called because the adapter below is null.
+const BillingBridge = registerPlugin<CapacitorBillingPlugin>('BillingBridge')
+
+const adapter = isGatedChannel
+  ? createCapacitorAdapter({ plugin: BillingBridge, products: PRODUCT_IDS })
+  : null
+
+export const MANAGE_SUBSCRIPTION_URL = playManageSubscriptionUrl('com.lastglance.app', PRODUCT_IDS.yearly)
+
+// The app-wide billing hook. Reviewer bypass (README rule 9: store review needs
+// a way past a hard gate) is derived from VITE_REVIEWER_SECRET, injected at
+// build time for the Play channel only — build-android.sh warns when unset.
+export function useSubscription(): UseBillingResult {
+  return useBilling(() => ({
+    adapter,
+    reviewerSecret: import.meta.env.VITE_REVIEWER_SECRET ?? null,
+  }))
+}

--- a/src/components/PaywallModal/PaywallModal.tsx
+++ b/src/components/PaywallModal/PaywallModal.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react'
+import { createPortal } from 'react-dom'
+import { X, Loader, BadgeCheck, KeyRound } from 'lucide-react'
+import type { UseBillingResult } from '@glance-apps/billing/react'
+import { PRODUCT_IDS, MANAGE_SUBSCRIPTION_URL } from '@/billing/billing'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  billing: UseBillingResult
+  // 'gate': the hard paywall on a locked Play install — fullscreen, not
+  // dismissible (store review passes it via the reviewer code, rule 9).
+  // 'status': the settings surface on an unlocked install — dismissible,
+  // shows the entitlement and manage/restore actions.
+  mode: 'gate' | 'status'
+  onClose?: () => void
+}
+
+export function PaywallModal({ billing, mode, onClose }: Props) {
+  const { t } = useTranslation()
+  const [showCode, setShowCode] = useState(false)
+  const [code, setCode] = useState('')
+  const [codeError, setCodeError] = useState(false)
+
+  async function submitCode() {
+    if (!code.trim()) return
+    const ok = await billing.setReviewerUnlocked(code.trim())
+    if (!ok) setCodeError(true)
+  }
+
+  const isError = billing.billingEvent?.status === 'error'
+  const restored = billing.billingEvent?.message === 'restore_complete'
+
+  // Prices come from the store or not at all (no hardcoded strings — package
+  // README rule 8). Null renders a quiet placeholder until the store answers.
+  const yearlyPrice = billing.prices.yearly
+  const lifetimePrice = billing.prices.lifetime
+
+  const body = (
+    <div className={`fixed inset-0 z-[80] flex items-end sm:items-center justify-center app-safe-bottom ${mode === 'gate' ? 'bg-slate-50 dark:bg-slate-950' : 'bg-black/40 dark:bg-black/60 backdrop-blur-sm'}`}
+      onClick={mode === 'status' ? e => { if (e.target === e.currentTarget) onClose?.() } : undefined}
+    >
+      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl border border-slate-200 dark:border-slate-700/50 max-h-[90svh] overflow-y-auto">
+        <div className="flex items-start justify-between mb-1">
+          <h2 className="text-2xl font-black tracking-tight text-slate-900 dark:text-slate-100">
+            last<span className="italic text-green-400">GLANCE</span>
+          </h2>
+          {mode === 'status' && (
+            <button onClick={onClose} className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors">
+              <X size={16} />
+            </button>
+          )}
+        </div>
+
+        {mode === 'status' ? (
+          <>
+            <div className="flex items-center gap-2 mt-4 mb-1">
+              <BadgeCheck size={16} className="text-green-400 shrink-0" />
+              <p className="text-sm font-medium text-slate-800 dark:text-slate-200">
+                {billing.entitlementSource === 'lifetime' ? t('paywall.sourceLifetime')
+                  : billing.entitlementSource === 'subscription' ? t('paywall.sourceSubscription')
+                  : billing.entitlementSource === 'reviewer' ? t('paywall.sourceReviewer')
+                  : t('paywall.sourceNone')}
+              </p>
+            </div>
+            {billing.productId && (
+              <p className="text-xs text-slate-400 dark:text-slate-500 ml-6 mb-4">{billing.productId}</p>
+            )}
+            <div className="space-y-2 mt-4">
+              {billing.entitlementSource === 'subscription' && (
+                <button
+                  onClick={() => window.open(MANAGE_SUBSCRIPTION_URL, '_blank')}
+                  className="w-full py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+                >
+                  {t('paywall.manage')}
+                </button>
+              )}
+              <button
+                onClick={() => billing.restore()}
+                className="w-full py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+              >
+                {t('paywall.restore')}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mt-2 mb-5">{t('paywall.pitch')}</p>
+
+            <div className="space-y-3">
+              {/* Annual */}
+              <button
+                onClick={() => { billing.clearBillingEvent(); billing.subscribe(PRODUCT_IDS.yearly) }}
+                disabled={billing.isLoading}
+                className="w-full text-left p-4 rounded-xl border-2 border-green-400/60 hover:border-green-400 bg-green-400/5 hover:bg-green-400/10 transition-colors disabled:opacity-50"
+              >
+                <div className="flex items-baseline justify-between">
+                  <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">{t('paywall.annualTitle')}</span>
+                  <span className="text-sm font-bold text-slate-900 dark:text-slate-50 tabular-nums">
+                    {yearlyPrice ? t('paywall.annualPer', { price: yearlyPrice }) : '…'}
+                  </span>
+                </div>
+                {billing.trialEligible && (
+                  <p className="text-xs text-green-500 dark:text-green-400 mt-1">
+                    {billing.trialDays != null ? t('paywall.trialDays', { count: billing.trialDays }) : t('paywall.trialGeneric')}
+                  </p>
+                )}
+              </button>
+
+              {/* Lifetime */}
+              <button
+                onClick={() => { billing.clearBillingEvent(); billing.subscribe(PRODUCT_IDS.lifetime) }}
+                disabled={billing.isLoading}
+                className="w-full text-left p-4 rounded-xl border border-slate-200 dark:border-slate-600 hover:border-slate-300 dark:hover:border-slate-500 bg-slate-50 dark:bg-slate-700/40 transition-colors disabled:opacity-50"
+              >
+                <div className="flex items-baseline justify-between">
+                  <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">{t('paywall.lifetimeTitle')}</span>
+                  <span className="text-sm font-bold text-slate-900 dark:text-slate-50 tabular-nums">
+                    {lifetimePrice ? t('paywall.lifetimeOnce', { price: lifetimePrice }) : '…'}
+                  </span>
+                </div>
+                <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">{t('paywall.lifetimeHint')}</p>
+              </button>
+            </div>
+
+            {isError && billing.billingEvent && (
+              <p className="text-xs text-red-500 dark:text-red-400 mt-3">
+                {billing.billingErrorMessage(billing.billingEvent.code)}
+              </p>
+            )}
+            {restored && (
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-3">{t('paywall.nothingToRestore')}</p>
+            )}
+
+            <div className="flex items-center justify-between mt-5">
+              <button
+                onClick={() => billing.restore()}
+                className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors inline-flex items-center gap-1.5"
+              >
+                {billing.isLoading && <Loader size={11} className="animate-spin" />}
+                {t('paywall.restore')}
+              </button>
+              <button
+                onClick={() => setShowCode(s => !s)}
+                className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors inline-flex items-center gap-1.5"
+              >
+                <KeyRound size={11} />
+                {t('paywall.haveCode')}
+              </button>
+            </div>
+
+            {showCode && (
+              <div className="flex items-center gap-2 mt-3">
+                <input
+                  type="text"
+                  value={code}
+                  onChange={e => { setCode(e.target.value); setCodeError(false) }}
+                  onKeyDown={e => { if (e.key === 'Enter') submitCode() }}
+                  placeholder={t('paywall.codePlaceholder')}
+                  className="flex-1 bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
+                />
+                <button onClick={submitCode} className="text-xs font-medium text-green-500 hover:text-green-400 shrink-0">
+                  {t('paywall.codeSubmit')}
+                </button>
+              </div>
+            )}
+            {codeError && (
+              <p className="text-xs text-red-500 dark:text-red-400 mt-2">{t('paywall.codeInvalid')}</p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+
+  return createPortal(body, document.body)
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,11 @@
 interface ImportMetaEnv {
   readonly VITE_WEBDAV_PROXY_URL?: string
   readonly VITE_WEBDAV_DIRECT?: string
+  // Distribution channel, set per artifact by build-android.sh: 'play' (gated
+  // AAB), 'github' (ungated sideload APK); unset/'web' for web/PWA builds.
+  readonly VITE_BUILD_CHANNEL?: string
+  // Reviewer-bypass secret for the Play channel (@glance-apps/billing rule 9).
+  readonly VITE_REVIEWER_SECRET?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Consumes `@glance-apps/billing@0.1.0` (pinned, family convention) per `docs/paywall-billing-plan.md`. The Play listing is locked free; this is the in-app gate that monetizes it. The package shipped more complete than the plan assumed — the Capacitor adapter and the native `BillingBridge` plugin are bundled — so this PR is pure consumption plus the app-side pieces the package README leaves to us.

## What's here

- **`src/billing/billing.ts`** — channel-structural gating (package rule 10): only `VITE_BUILD_CHANNEL=play` on native Android constructs the adapter; github/web builds pass `adapter: null` and are ungated by design. Product ids centralized: subscription **`pro`**, one-time **`pro_lifetime`**. Reviewer bypass (rule 9) wired to `VITE_REVIEWER_SECRET`.
- **`PaywallModal`** — hard gate: annual card (store-reported price + trial copy, rule 8: no hardcoded prices), lifetime card, restore, and a "Have a code?" reviewer-code entry for store review. Second mode = the settings entitlement surface (source, manage subscription via `playManageSubscriptionUrl`, restore). All six locales.
- **`App.tsx`** — `useSubscription()` at the root; gate renders last in the tree at `z-[80]` when `gated && !isUnlocked` (the engine's provisional cold-launch unlock prevents paid-user flash); settings sheet gains a Subscription row on gated builds only.
- **Android wiring** — `settings.gradle` includes the plugin module from `node_modules/@glance-apps/billing/android`; `app/build.gradle` depends on it; `playBillingVersion = '7.1.1'` pinned in `variables.gradle`; `BillingBridgePlugin` registered in `MainActivity`. The module's own manifest merges the `BILLING` permission (making #215 redundant if still unmerged — harmless either way).
- **`build-android.sh`** — the channel split from the plan: github-channel web build → `assembleRelease` APK (ungated), play-channel web build → `bundleRelease` AAB (gated). Warns when `VITE_REVIEWER_SECRET` is unset for the Play pass.

## Verified / not verified

- ✅ Web: `tsc`, lint, 181 tests, and a full `VITE_BUILD_CHANNEL=play` production build.
- ⚠️ The package README explicitly marks the Capacitor adapter + `android/` module as **unverified scaffolding** — "treat the first integration as their verification pass." That's this PR. First Android Studio build may surface compile fixes (paste errors back and I'll iterate), and the real verification is a license-tester purchase pass on the internal track: buy annual, buy lifetime, restore after reinstall, cancel flow, reviewer code, and airplane-mode launch on an entitled install.

## Needs confirming

1. **Product ids**: code assumes `pro` (subscription) / `pro_lifetime` (INAPP) per the plan doc and PR #215's console instructions. If the console SKUs differ, change `PRODUCT_IDS` in `src/billing/billing.ts` only.
2. **`VITE_REVIEWER_SECRET`**: pick a value, keep it out of the repo (env/CI secret), set it for every Play build. Reviewer codes rotate monthly via `deriveReviewerCode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)