### PR TITLE
Billing follow-ups: correct product ids + committed-secret reviewer code

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -119,12 +119,10 @@ if $RELEASE; then
   cp "app/build/outputs/apk/release/lastglance.apk" "$OUT_DIR/lastglance.apk"
   echo "    APK (release, github channel) → outputs/lastglance.apk"
 
-  # The Play build must carry the reviewer bypass (@glance-apps/billing rule 9:
-  # store review needs a way past a hard gate).
-  if [ -z "$VITE_REVIEWER_SECRET" ]; then
-    echo "WARNING: VITE_REVIEWER_SECRET is not set — the Play build's reviewer"
-    echo "         bypass will be DISABLED. Set it before building a store AAB."
-  fi
+  # The reviewer bypass (@glance-apps/billing rule 9: store review needs a way
+  # past a hard gate) is compiled in from src/config/reviewerAccess.js — a
+  # committed secret, no env var to set. Run `npm run reviewer-code` to print
+  # the current month's code for the store review notes.
   echo "==> Building web assets (channel: play — gated AAB)..."
   cd "$SCRIPT_DIR"
   VITE_BUILD_CHANNEL=play npm run build:android

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "gen:icons": "node scripts/gen-lucide-drawables.mjs",
     "gen:screenshots": "node scripts/seed-demo-screenshots.mjs",
+    "reviewer-code": "node scripts/reviewer-code.mjs",
     "cap:sync": "npm run build && cap sync",
     "build:android": "npm run build && cap sync android",
     "build:ios": "npm run build && cap sync ios && node scripts/sync-ios-version.mjs",

--- a/scripts/reviewer-code.mjs
+++ b/scripts/reviewer-code.mjs
@@ -1,0 +1,29 @@
+// Prints the current month's reviewer bypass code to paste into the store
+// review notes (Play Console App access / App Store Connect App Review).
+//   npm run reviewer-code
+// Preview a future month before a store update near month-end:
+//   npm run reviewer-code -- 2026-08
+//
+// Imports the bound deriveReviewerCode() from src/config/reviewerAccess.js, so
+// the secret is never passed on the command line and the printed code always
+// matches what the running app will accept.
+import { deriveReviewerCode } from '../src/config/reviewerAccess.js'
+
+const arg = process.argv[2]
+if (arg && !/^\d{4}-\d{2}$/.test(arg)) {
+  console.error(`Invalid month "${arg}" — expected YYYY-MM (e.g. 2026-08).`)
+  process.exit(1)
+}
+
+let code
+if (arg) {
+  // Preview a different month by pinning the clock deriveReviewerCode() reads.
+  const real = Date.prototype.toISOString
+  Date.prototype.toISOString = function () { return `${arg}-01T00:00:00.000Z` }
+  try { code = await deriveReviewerCode() } finally { Date.prototype.toISOString = real }
+} else {
+  code = await deriveReviewerCode()
+}
+
+const period = arg || new Date().toISOString().slice(0, 7)
+console.log(`Reviewer code for ${period}: ${code}`)

--- a/src/billing/billing.ts
+++ b/src/billing/billing.ts
@@ -3,11 +3,13 @@ import { playManageSubscriptionUrl } from '@glance-apps/billing'
 import { createCapacitorAdapter, type CapacitorBillingPlugin } from '@glance-apps/billing/capacitor'
 import { useBilling, type UseBillingResult } from '@glance-apps/billing/react'
 
-// Play product ids, as created in the Play Console (docs/paywall-billing-plan.md):
-// the subscription product `pro` (base plan `annual`, $4.99/yr) queried as SUBS,
-// and the one-time INAPP product `pro_lifetime` ($19.99). Single source of truth
-// for the whole app — the gate UI and the native plugin both derive from here.
-export const PRODUCT_IDS = { yearly: 'pro', lifetime: 'pro_lifetime' }
+// Play product ids, as created in the Play Console. Following the GLANCE family
+// convention (dayGLANCE uses dayglance_pro_*): the subscription product
+// `lastglance_pro_annual` (base plan `annual`, $4.99/yr) queried as SUBS, and the
+// one-time INAPP product `lastglance_pro_lifetime` ($19.99). Permanent once
+// created. Single source of truth for the app — the gate UI and the native
+// plugin both derive from here.
+export const PRODUCT_IDS = { yearly: 'lastglance_pro_annual', lifetime: 'lastglance_pro_lifetime' }
 
 // Channel gating is structural (@glance-apps/billing README rule 10): only the
 // Play build constructs an adapter. The GitHub sideload APK and self-hosted

--- a/src/billing/billing.ts
+++ b/src/billing/billing.ts
@@ -2,6 +2,7 @@ import { Capacitor, registerPlugin } from '@capacitor/core'
 import { playManageSubscriptionUrl } from '@glance-apps/billing'
 import { createCapacitorAdapter, type CapacitorBillingPlugin } from '@glance-apps/billing/capacitor'
 import { useBilling, type UseBillingResult } from '@glance-apps/billing/react'
+import { REVIEWER_SECRET } from '@/config/reviewerAccess'
 
 // Play product ids, as created in the Play Console. Following the GLANCE family
 // convention (dayGLANCE uses dayglance_pro_*): the subscription product
@@ -29,11 +30,13 @@ const adapter = isGatedChannel
 export const MANAGE_SUBSCRIPTION_URL = playManageSubscriptionUrl('com.lastglance.app', PRODUCT_IDS.yearly)
 
 // The app-wide billing hook. Reviewer bypass (README rule 9: store review needs
-// a way past a hard gate) is derived from VITE_REVIEWER_SECRET, injected at
-// build time for the Play channel only — build-android.sh warns when unset.
+// a way past a hard gate) uses REVIEWER_SECRET from the committed config module
+// (dayGLANCE model) — the same constant the `npm run reviewer-code` CLI derives
+// from, so a printed code always matches. Only load-bearing on the gated Play
+// channel; on ungated builds the adapter is null and nothing is behind the gate.
 export function useSubscription(): UseBillingResult {
   return useBilling(() => ({
     adapter,
-    reviewerSecret: import.meta.env.VITE_REVIEWER_SECRET ?? null,
+    reviewerSecret: REVIEWER_SECRET,
   }))
 }

--- a/src/config/reviewerAccess.d.ts
+++ b/src/config/reviewerAccess.d.ts
@@ -1,0 +1,7 @@
+// Types for the plain-JS reviewer-access module. It is plain JS (not TS) so the
+// `npm run reviewer-code` CLI can import it under plain node with no loader; the
+// app side imports it as TypeScript through these declarations. See
+// reviewerAccess.js.
+export declare const REVIEWER_SECRET: string
+export declare function deriveReviewerCode(): Promise<string>
+export declare function sha256Hex(text: string): Promise<string>

--- a/src/config/reviewerAccess.js
+++ b/src/config/reviewerAccess.js
@@ -1,0 +1,29 @@
+// Reviewer bypass for Play Console App-access policy and Apple Guideline 2.1: a
+// hard-gated store build must give the reviewer a way past the paywall. This is
+// the ONE place lastGLANCE's secret appears. Both the running app (billing.ts,
+// as the engine's `reviewerSecret`) and the `npm run reviewer-code` CLI import
+// from here, so they can never disagree and the secret is never typed on a
+// command line. @glance-apps/billing does the HMAC math; this binds our secret
+// to it. Client-side gating is honor-system by design — this is light
+// obfuscation, not real security.
+import {
+  deriveReviewerCode as deriveWithSecret,
+  sha256Hex,
+} from '@glance-apps/billing'
+
+// lastGLANCE's OWN secret — deliberately different from dayGLANCE's so one
+// month's code never unlocks both apps. Split across a concat so it isn't a
+// single greppable string literal. Pick once and leave it: changing it after a
+// build reaches store review invalidates any code already pasted into the
+// review notes.
+const _S = 'lg-r3v13w-' + 'c6f3e6cca00a20393e2ed8702eb4a2d331f181e5'
+
+/** Passed into the billing engine config as `reviewerSecret`. */
+export const REVIEWER_SECRET = _S
+
+/** No-arg: HMAC-SHA256 over the current UTC month ("YYYY-MM"), 12-char hex. */
+export function deriveReviewerCode() {
+  return deriveWithSecret(_S)
+}
+
+export { sha256Hex }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,8 +6,6 @@ interface ImportMetaEnv {
   // Distribution channel, set per artifact by build-android.sh: 'play' (gated
   // AAB), 'github' (ungated sideload APK); unset/'web' for web/PWA builds.
   readonly VITE_BUILD_CHANNEL?: string
-  // Reviewer-bypass secret for the Play channel (@glance-apps/billing rule 9).
-  readonly VITE_REVIEWER_SECRET?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Two commits that landed on `claude/billing-integration` **after** #216 had already merged and closed, so they were never carried into `main`. #216 merged with a single commit (`eed1cf0`), leaving `main` with the placeholder product ids and the env-var reviewer model. This is the follow-up PR that finishes the billing work.

## What's here

- **`e845c3a` — correct product ids.** `PRODUCT_IDS` goes from the placeholder `{ yearly: 'pro', lifetime: 'pro_lifetime' }` to the GLANCE family convention `{ yearly: 'lastglance_pro_annual', lifetime: 'lastglance_pro_lifetime' }`, matching the products created in Play Console and dayGLANCE's `dayglance_pro_*` pattern. These ids are permanent and surface only on the settings entitlement line.
- **`0e4df8d` — committed-secret reviewer code (dayGLANCE model).** Replaces `VITE_REVIEWER_SECRET` env-injection with a single committed config module so the running app and the code-printing CLI can never disagree and the secret is never typed on a command line:
  - `src/config/reviewerAccess.js` (+ `.d.ts`) binds lastGLANCE's own secret (distinct from dayGLANCE's) to `@glance-apps/billing`'s `deriveReviewerCode`. Plain JS so the CLI imports it under plain node with no loader; the `.d.ts` types the app side.
  - `scripts/reviewer-code.mjs` + `npm run reviewer-code` prints the current UTC month's 12-char code (optional `YYYY-MM` arg previews a future month) for the store review notes.
  - `billing.ts` engine `reviewerSecret` now comes from `REVIEWER_SECRET` — the same constant the CLI derives from.
  - Drops `VITE_REVIEWER_SECRET` from `vite-env.d.ts` and the now-moot warning in `build-android.sh`.

## Verified

- `tsc -b` clean, lint clean, full `VITE_BUILD_CHANNEL=play` production build succeeds with the secret compiled in.
- Proved the invariant: the CLI's printed code is byte-identical to the engine-side derivation for the current month, so a code from `npm run reviewer-code` will unlock the running app.
- Clean three-way merge into `main` (the two commits touch `billing.ts` / `src/config` / `scripts` / build files; the only thing `main` gained since `eed1cf0` is `AndroidManifest.xml`, so no overlap).

## Note

The committed secret ships in every channel bundle, including the public GitHub sideload APK, so it's more extractable than the env-only model. Accepted tradeoff: the gate is honor-system by design (the AAB is decompilable on-device regardless), and it matches dayGLANCE. Server-side receipt validation is the future upgrade path and slots in behind the same engine without touching this flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_