### PR TITLE
Pin @glance-apps/billing to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/ios": "^8.4.0",
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/status-bar": "^8.0.2",
-        "@glance-apps/billing": "0.1.0",
+        "@glance-apps/billing": "0.1.1",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.0",
         "dayjs": "^1.11.13",
@@ -2814,9 +2814,9 @@
       }
     },
     "node_modules/@glance-apps/billing": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.0.tgz",
-      "integrity": "sha512-HmrIf7ZuqRKDz/4kPG02qf2CGBzaWAO7wEYhfuN8au/oo2mPDPxge5BmLqqVrdEf/swo7MiBdZ2pURmXTRsjxw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.1.tgz",
+      "integrity": "sha512-7dayiwwDAEyhZbtwtg1GOj9uJixCIS2kI/qXx12S63ec+sbrgNlXFkJ+MpgV/pE04Mq5ndJo8DiYJmGnDfjI9Q==",
       "license": "MIT",
       "peerDependencies": {
         "electron": ">=28",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@capacitor/ios": "^8.4.0",
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/status-bar": "^8.0.2",
-    "@glance-apps/billing": "0.1.0",
+    "@glance-apps/billing": "0.1.1",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.0",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
Bumps `@glance-apps/billing` from `0.1.0` to the latest published `0.1.1` (exact pin, family convention).

This is the pin that was intended for the pre-test build — it originally landed on the paywall branch after #218 had already merged and closed, so it never made it into `main`. Re-applied here on a fresh branch off the current `main`.

## No integration changes required

- Imported surface unchanged: `playManageSubscriptionUrl`, `deriveReviewerCode` / `sha256Hex`, `createCapacitorAdapter` + `CapacitorBillingPlugin`, `useBilling` / `UseBillingResult`.
- `UseBillingResult` hook shape unchanged (`trialEligible`, `trialDays`, `prices`, `setReviewerUnlocked`, `entitlementSource`, `isUnlocked`, `gated`).
- Android module unchanged: still namespaces `com.glanceapps.billing` (so `MainActivity`'s plugin import holds) and defaults `playBillingVersion` to `7.1.1`, matching `variables.gradle`.

## Verified

- `tsc -b`, lint, and a `VITE_BUILD_CHANNEL=play` production build all pass against 0.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_