### PR TITLE
Add opt-in WebView debugging flag for internal test builds

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -41,9 +41,18 @@ while [ $# -gt 0 ]; do
       if [ $# -lt 2 ]; then echo "Error: --build needs a number, e.g. --build 3" >&2; exit 1; fi
       BUILD_NUM="$2"; shift 2 ;;
     --build=*) BUILD_NUM="${1#--build=}"; shift ;;
-    *) echo "Unknown flag: $1 (valid flags: --clean, --release, --build N)" >&2; exit 1 ;;
+    # Enable chrome://inspect WebView debugging for THIS build only (read by
+    # capacitor.config.ts at cap sync time). For a throwaway internal test AAB —
+    # never promote a --webview-debug build to production.
+    --webview-debug) export CAP_WEBVIEW_DEBUG=1; shift ;;
+    *) echo "Unknown flag: $1 (valid flags: --clean, --release, --build N, --webview-debug)" >&2; exit 1 ;;
   esac
 done
+
+if [ "${CAP_WEBVIEW_DEBUG:-}" = "1" ]; then
+  echo "WARNING: WebView remote debugging is ENABLED (chrome://inspect) for this"
+  echo "         build. Internal testing ONLY — do NOT promote it to production."
+fi
 
 # --build N derives a pre-release versionCode (base + N) from package.json, so an
 # internal/closed-test upload gets a strictly higher code than the last without

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -8,6 +8,15 @@ const config: CapacitorConfig = {
   // Vite emits the production build here; `cap sync` copies it into the
   // native projects' web assets.
   webDir: 'dist',
+  android: {
+    // WebView remote debugging (chrome://inspect). OFF by default so shipped
+    // builds are not inspectable — an inspectable production WebView would let
+    // anyone with a USB cable read localStorage (sync credentials, passphrase
+    // material). Enable ONLY for a throwaway internal test build via
+    // `./build-android.sh --release --webview-debug` (sets CAP_WEBVIEW_DEBUG=1);
+    // never promote such a build to production.
+    webContentsDebuggingEnabled: process.env.CAP_WEBVIEW_DEBUG === '1',
+  },
   plugins: {
     // Route fetch/XHR through the native HTTP stack so WebDAV/Nextcloud sync
     // works without a CORS proxy inside the native WebView.


### PR DESCRIPTION
Testing Play Billing requires the Play-signed release build, whose WebView is not inspectable via `chrome://inspect`. That makes clearing local-only state during testing (e.g. the reviewer-unlock `localStorage` key) otherwise require wiping all app data. This adds an explicit, default-off way to enable remote debugging for a throwaway internal test build.

## What's here

- **`capacitor.config.ts`** — `android.webContentsDebuggingEnabled` now reads `process.env.CAP_WEBVIEW_DEBUG` (off unless `'1'`). Shipped/production builds stay non-inspectable by default, so no one with a USB cable can read localStorage (sync credentials, passphrase material).
- **`build-android.sh`** — new `--webview-debug` flag sets `CAP_WEBVIEW_DEBUG=1` for that build and prints a loud "internal testing only, do NOT promote to production" warning.

## Verified

- `cap copy` emits `webContentsDebuggingEnabled: false` by default and `true` only with the flag set. Repo left in the safe default state.

## Usage / safety

Build a throwaway internal AAB with a pre-release versionCode:

```
./build-android.sh --release --build 3 --webview-debug
```

Upload that to the internal track only. Do NOT promote a `--webview-debug` build to production — build the production bundle with a plain `./build-android.sh --release` (flag off) for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_