### PR TITLE
Fix: classify lifetime unlock correctly (pass products to the engine)

### DIFF
--- a/src/billing/billing.ts
+++ b/src/billing/billing.ts
@@ -44,6 +44,11 @@ export const STORE_NAME = Capacitor.getPlatform() === 'ios' ? 'App Store' : 'Goo
 export function useSubscription(): UseBillingResult {
   return useBilling(() => ({
     adapter,
+    // Engine-side product hints for entitlementSource classification. The
+    // adapter's `products` (for querying) do NOT feed this — without passing it
+    // here too, an active lifetime unlock misreports as 'subscription' (shows
+    // "Annual subscription active" + a Manage-subscription button).
+    products: PRODUCT_IDS,
     reviewerSecret: REVIEWER_SECRET,
   }))
 }


### PR DESCRIPTION
Bug found during on-device Play Billing testing (buy-lifetime step): after purchasing the lifetime unlock, the settings status sheet showed **"Annual subscription active"** and a **Manage subscription** button, even though the owned product was correctly `lastglance_pro_lifetime`.

## Root cause

The engine derives `entitlementSource` ('lifetime' vs 'subscription') from its **own** `products` hint in `EngineConfig`:

```js
isPro ? (this.products?.lifetime && productId === this.products.lifetime ? 'lifetime' : 'subscription')
```

That is separate from the `products` we pass to `createCapacitorAdapter` (which is only used for querying). We never passed `products` into the engine config, so `this.products` was undefined and — per the package's documented behavior ("without them, any active entitlement classifies as 'subscription'") — every entitlement, including lifetime, fell back to `subscription`.

## Fix

Pass `products: PRODUCT_IDS` into the `useBilling` engine config. Now:
- An owned lifetime product classifies as `lifetime` -> status reads **"Lifetime unlock active"**.
- The Manage-subscription button (rendered only when `entitlementSource === 'subscription'`) correctly hides for a lifetime unlock.

Subscription classification is unaffected (annual still reads "Annual subscription active" with Manage subscription).

## Verified

- `tsc -b` and lint clean.
- Traced the two affected UI branches in PaywallModal (status text + Manage button gating) to confirm both symptoms are resolved.
- Real device re-test to follow (requires a new build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhW3YVwiQyTcqrew9yRQhL)_