### PR TITLE
Port dayGLANCE's reviewer banner ("Exit & view plans")

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -412,6 +412,8 @@
     "paymentVia": "Zahlung über {{store}}.",
     "reviewerAccess": "Prüfzugang",
     "reviewerHint": "Nur für App-Store-Prüfer. Kein Gutscheincode.",
+    "bannerActive": "Prüfzugang aktiv — die App ist ohne Kauf freigeschaltet.",
+    "bannerExit": "Beenden & Tarife ansehen",
     "bestValue": "Bester Wert"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -438,6 +438,8 @@
     "paymentVia": "Payment via {{store}}.",
     "reviewerAccess": "Reviewer access",
     "reviewerHint": "For app-store reviewers only. Not a promo code.",
+    "bannerActive": "Reviewer access active — the app is unlocked without a purchase.",
+    "bannerExit": "Exit & view plans",
     "bestValue": "Best value"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -412,6 +412,8 @@
     "paymentVia": "Pago a través de {{store}}.",
     "reviewerAccess": "Acceso de revisión",
     "reviewerHint": "Solo para revisores de la tienda. No es un código promocional.",
+    "bannerActive": "Acceso de revisión activo — la aplicación está desbloqueada sin compra.",
+    "bannerExit": "Salir y ver planes",
     "bestValue": "Mejor valor"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -412,6 +412,8 @@
     "paymentVia": "Paiement via {{store}}.",
     "reviewerAccess": "Accès évaluateur",
     "reviewerHint": "Réservé aux évaluateurs de la boutique. Ce n'est pas un code promo.",
+    "bannerActive": "Accès évaluateur actif — l'application est déverrouillée sans achat.",
+    "bannerExit": "Quitter et voir les offres",
     "bestValue": "Meilleure offre"
   }
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -412,6 +412,8 @@
     "paymentVia": "Pagamento tramite {{store}}.",
     "reviewerAccess": "Accesso revisori",
     "reviewerHint": "Solo per i revisori dello store. Non è un codice promozionale.",
+    "bannerActive": "Accesso revisori attivo — l'app è sbloccata senza acquisto.",
+    "bannerExit": "Esci e vedi i piani",
     "bestValue": "Miglior valore"
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -412,6 +412,8 @@
     "paymentVia": "Pagamento através da {{store}}.",
     "reviewerAccess": "Acesso de revisão",
     "reviewerHint": "Apenas para revisores da loja. Não é um código promocional.",
+    "bannerActive": "Acesso de revisão ativo — a aplicação está desbloqueada sem compra.",
+    "bannerExit": "Sair e ver planos",
     "bestValue": "Melhor valor"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,8 @@ import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal
 import { ToastProvider, useToast } from '@/components/Toast/Toast'
 import { UsersModal } from '@/components/UsersModal/UsersModal'
 import { PaywallModal } from '@/components/PaywallModal/PaywallModal'
-import { useSubscription } from '@/billing/billing'
+import { ReviewerBanner } from '@/components/ReviewerBanner/ReviewerBanner'
+import { useSubscription, exitReviewerMode } from '@/billing/billing'
 import { UsersContext } from '@/multiuser/UsersContext'
 import { useUsers } from '@/multiuser/useUsers'
 import { useNotifications } from '@/hooks/useNotifications'
@@ -691,6 +692,16 @@ function AppInner() {
       {/* Entitlement status (settings surface, unlocked installs). */}
       {showBillingStatus && (
         <PaywallModal billing={billing} mode="status" onClose={() => setShowBillingStatus(false)} />
+      )}
+
+      {/* Reviewer-mode banner — shown while unlocked via the store-review
+          bypass code (never for paying customers). Its exit action is the
+          reviewer's way back to the wall to test the IAPs; without it the
+          review gets rejected for unlocatable purchases (learned on
+          dayGLANCE, see docs/reviewer-access-flow.md). Never visible with
+          the gate below: isReviewerUnlocked implies isUnlocked. */}
+      {billing.isReviewerUnlocked && (
+        <ReviewerBanner onExit={exitReviewerMode} />
       )}
 
       {/* Hard paywall — last in the tree and z-[80], above every other surface.

--- a/src/billing/billing.ts
+++ b/src/billing/billing.ts
@@ -1,5 +1,5 @@
 import { Capacitor, registerPlugin } from '@capacitor/core'
-import { playManageSubscriptionUrl } from '@glance-apps/billing'
+import { DEFAULT_STORAGE_KEYS, playManageSubscriptionUrl } from '@glance-apps/billing'
 import { createCapacitorAdapter, type CapacitorBillingPlugin } from '@glance-apps/billing/capacitor'
 import { useBilling, type UseBillingResult } from '@glance-apps/billing/react'
 import { REVIEWER_SECRET } from '@/config/reviewerAccess'
@@ -51,4 +51,21 @@ export function useSubscription(): UseBillingResult {
     products: PRODUCT_IDS,
     reviewerSecret: REVIEWER_SECRET,
   }))
+}
+
+// Leave reviewer mode (the ReviewerBanner's "Exit & view plans" action): the
+// engine exposes no revoke, so clear the persisted unlock directly and reload —
+// the engine re-reads the now-absent key at start and, with no entitlement, the
+// hard gate (and its IAPs) returns. That way back is what App Review requires
+// (see docs/reviewer-access-flow.md). The key is read from DEFAULT_STORAGE_KEYS
+// because useSubscription passes no storageKeys override; deriving it from the
+// same constant the engine falls back to means the cleared key can never drift
+// from the one the engine wrote — the #1 porting bug the doc warns about.
+export function exitReviewerMode(): void {
+  try {
+    localStorage.removeItem(DEFAULT_STORAGE_KEYS.reviewerUnlock)
+  } catch {
+    // Storage unavailable — nothing was persisted, so nothing to clear.
+  }
+  window.location.reload()
 }

--- a/src/components/ReviewerBanner/ReviewerBanner.tsx
+++ b/src/components/ReviewerBanner/ReviewerBanner.tsx
@@ -1,0 +1,39 @@
+import { ShieldCheck } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  onExit: () => void
+}
+
+// Shown while the install is reviewer-unlocked (store-review bypass code —
+// never a paying customer, who is entitled via Play/StoreKit instead). Ported
+// from dayGLANCE (docs/reviewer-access-flow.md): the launch paywall is the only
+// IAP surface, so once the bypass code hides it the reviewer needs a way BACK
+// to locate and test the purchases (Guideline 2.1(b) / Play app-access).
+// "Exit & view plans" revokes the unlock and returns to the wall.
+//
+// Differences from the dayGLANCE original: theme comes from Tailwind's class
+// strategy (dark: variants) rather than a darkMode prop, the copy is localized,
+// and the top padding honors the safe-area inset because this app draws under
+// the transparent Android status bar (StatusBar.overlaysWebView).
+export function ReviewerBanner({ onExit }: Props) {
+  const { t } = useTranslation()
+  return (
+    <div
+      role="status"
+      className="fixed top-0 inset-x-0 z-[90] flex flex-wrap items-center justify-center gap-x-3 gap-y-1 px-4 pb-2 text-xs bg-amber-100 text-amber-900 border-b border-amber-300 dark:bg-amber-500/15 dark:text-amber-200 dark:border-amber-500/30"
+      style={{ paddingTop: 'max(0.5rem, env(safe-area-inset-top))' }}
+    >
+      <span className="flex items-center gap-1.5 font-medium">
+        <ShieldCheck size={14} className="shrink-0" />
+        {t('paywall.bannerActive')}
+      </span>
+      <button
+        onClick={onExit}
+        className="rounded-full px-3 py-1 font-semibold transition-colors bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-400 dark:text-amber-950 dark:hover:bg-amber-300"
+      >
+        {t('paywall.bannerExit')}
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Ports the reviewer-access banner from dayGLANCE per `docs/reviewer-access-flow.md`. While an install is unlocked via the store-review bypass code, a persistent amber banner shows at the top with an **"Exit & view plans"** button that revokes the unlock and returns to the paywall, so a reviewer can always get back to locate and test the IAPs (the Guideline 2.1(b) rejection dayGLANCE hit).

## Changes

- **`src/components/ReviewerBanner/ReviewerBanner.tsx`** (new): the doc's `ReviewerBanner.jsx` adapted to this repo, TypeScript with a folder + named export, Tailwind `dark:` class strategy instead of a `darkMode` prop, localized copy, and safe-area top padding since the app draws under the transparent Android status bar (`StatusBar.overlaysWebView`).
- **`src/billing/billing.ts`**: `exitReviewerMode()` clears the persisted unlock and reloads (the engine has no revoke method). The key comes from `DEFAULT_STORAGE_KEYS.reviewerUnlock` imported from `@glance-apps/billing`, the same constant the engine falls back to since `useSubscription` passes no `storageKeys` override, making the doc's "#1 porting bug" (clearing a key that doesn't match what the engine wrote) structurally impossible.
- **`src/App.tsx`**: renders the banner on `billing.isReviewerUnlocked`, next to the hard gate. The two can never coexist: `isUnlocked` includes `reviewerUnlocked`, so the gate's `!isUnlocked` condition excludes reviewer mode.
- **Locales (all 6)**: new `paywall.bannerActive` / `paywall.bannerExit` strings.

Already in place from earlier work, per the doc's porting checklist: lastGLANCE's own `REVIEWER_SECRET`, `reviewerSecret` wired into the engine, the paywall's "Reviewer access" field calling `setReviewerUnlocked`, and the `npm run reviewer-code` CLI.

## Testing

- `npm run lint` clean, `tsc -b` clean, 181 tests pass (23 files), production build (incl. PWA precache) succeeds.
- Dev-server check for the banner itself: plant a valid unlock (`sha256` of the current month's `npm run reviewer-code` output under `glance-billing.reviewer-unlock`), reload, banner appears; "Exit & view plans" clears the key and the banner is gone after reload. The full wall → code → banner → exit → wall loop is only observable on a play-channel Android build (the gate is structural off that channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft9FNhX6JDiHjgnVRtXGXu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft9FNhX6JDiHjgnVRtXGXu)_