### PR TITLE
WebDAV proxy: resolve-and-pin SSRF validation on the hosted deployment

### DIFF
--- a/api/webdav-proxy.js
+++ b/api/webdav-proxy.js
@@ -1,6 +1,7 @@
 import https from 'https'
 import http from 'http'
 import { URL } from 'url'
+import { lookup } from 'dns/promises'
 
 // Disable Vercel's default body parser so we can forward raw request bodies
 export const config = {
@@ -9,7 +10,89 @@ export const config = {
   },
 };
 
-function validateProxyUrl(urlString) {
+// The address checks below run on RESOLVED addresses, not hostname strings.
+// A string blocklist alone is bypassable with a public DNS name whose record
+// points at a private IP (and rebindable between check and connect); resolving
+// first, validating every returned address, and pinning the connection to a
+// validated address closes both. Literal-IP URLs still land here — dns.lookup
+// parses them (including WHATWG-URL-normalized decimal/octal forms) without a
+// network query. Exported for tests.
+
+export function isPrivateIPv4(address) {
+  const parts = address.split('.').map(Number);
+  if (parts.length !== 4 || parts.some(n => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return true; // unparseable — refuse rather than guess
+  }
+  const [a, b] = parts;
+  return (
+    a === 0 ||                            // "this network"
+    a === 10 ||                           // private
+    a === 127 ||                          // loopback
+    (a === 100 && b >= 64 && b <= 127) || // CGNAT 100.64/10
+    (a === 169 && b === 254) ||           // link-local (cloud metadata)
+    (a === 172 && b >= 16 && b <= 31) ||  // private
+    (a === 192 && b === 168) ||           // private
+    (a === 198 && (b === 18 || b === 19)) || // benchmarking 198.18/15
+    a >= 224                              // multicast, reserved, broadcast
+  );
+}
+
+export function isPrivateIPv6(address) {
+  const addr = address.toLowerCase().replace(/%.*$/, ''); // strip zone id
+  if (addr === '::' || addr === '::1') return true;
+  const mapped = addr.match(/^::ffff:(.+)$/);
+  if (mapped) {
+    // IPv4-mapped — judge the embedded IPv4. dns.lookup renders the dotted
+    // form; URL-normalized literals arrive as two hex groups.
+    const tail = mapped[1];
+    if (tail.includes('.')) return isPrivateIPv4(tail);
+    const groups = tail.split(':');
+    if (groups.length !== 2) return true;
+    const hi = parseInt(groups[0], 16);
+    const lo = parseInt(groups[1], 16);
+    if (Number.isNaN(hi) || Number.isNaN(lo)) return true;
+    return isPrivateIPv4(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`);
+  }
+  const first = parseInt(addr.split(':')[0] || '0', 16);
+  return (
+    Number.isNaN(first) ||
+    first === 0 ||                          // ::/16 — reserved, v4-compatible
+    (first >= 0xfe80 && first <= 0xfebf) || // link-local fe80::/10
+    (first >= 0xfc00 && first <= 0xfdff) || // ULA fc00::/7
+    first >= 0xff00                         // multicast ff00::/8
+  );
+}
+
+// Resolve the hostname, reject if ANY returned address is private/reserved,
+// and return one validated address for the connection to pin. IPv4 preferred:
+// hand-picking an address forgoes Node's family fallback, and a host with a
+// broken-but-advertised AAAA record must not lose the IPv4 path it uses today.
+async function resolvePinnedAddress(hostname) {
+  let addresses;
+  try {
+    addresses = await lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new Error('Could not resolve hostname');
+  }
+  if (!addresses || addresses.length === 0) {
+    throw new Error('Could not resolve hostname');
+  }
+  for (const { address, family } of addresses) {
+    if (family === 4 ? isPrivateIPv4(address) : isPrivateIPv6(address)) {
+      throw new Error('Private/reserved addresses are not allowed');
+    }
+  }
+  return addresses.find(a => a.family === 4) ?? addresses[0];
+}
+
+// Returns { parsed, pinned }. pinned is null when not enforcing; otherwise the
+// validated { address, family } the socket must connect to.
+//
+// Only enforce private-address restrictions on Vercel (SSRF protection for the
+// cloud-hosted deployment). Self-hosted instances run on the user's own
+// network where private addresses are legitimate WebDAV targets — no
+// resolution happens there at all, so their behavior is unchanged.
+export async function validateProxyUrl(urlString, enforce = !!process.env.VERCEL) {
   let parsed;
   try {
     parsed = new URL(urlString);
@@ -21,48 +104,14 @@ function validateProxyUrl(urlString) {
     throw new Error('Only http and https URLs are allowed');
   }
 
-  const hostname = parsed.hostname.toLowerCase();
+  if (!enforce) return { parsed, pinned: null };
 
-  // Only enforce private IP restrictions on Vercel (SSRF protection for the
-  // cloud-hosted deployment). Self-hosted instances run on the user's own
-  // network where private addresses are legitimate WebDAV targets.
-  if (process.env.VERCEL) {
-    if (hostname === 'localhost' || hostname === '0.0.0.0') {
-      throw new Error('Private/reserved addresses are not allowed');
-    }
-
-    const ipv4 = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-    if (ipv4) {
-      const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
-      if (
-        a === 10 ||
-        (a === 172 && b >= 16 && b <= 31) ||
-        (a === 192 && b === 168) ||
-        a === 127 ||
-        (a === 169 && b === 254) ||
-        a === 0 ||
-        (a === 100 && b >= 64 && b <= 127)
-      ) {
-        throw new Error('Private/reserved addresses are not allowed');
-      }
-    }
-
-    if (
-      hostname === '::1' ||
-      hostname === '::' ||
-      /^::ffff:/i.test(hostname) ||
-      /^fe80:/i.test(hostname) ||
-      /^fc/i.test(hostname) ||
-      /^fd/i.test(hostname)
-    ) {
-      throw new Error('Private/reserved addresses are not allowed');
-    }
-  }
-
-  return parsed;
+  // URL.hostname wraps IPv6 literals in brackets; dns.lookup wants them bare.
+  const pinned = await resolvePinnedAddress(parsed.hostname.replace(/^\[|\]$/g, ''));
+  return { parsed, pinned };
 }
 
-function proxyRequest(method, targetUrl, headers, body) {
+function proxyRequest(method, targetUrl, headers, body, pinned = null) {
   return new Promise((resolve, reject) => {
     const parsed = new URL(targetUrl);
     const transport = parsed.protocol === 'https:' ? https : http;
@@ -86,6 +135,20 @@ function proxyRequest(method, targetUrl, headers, body) {
       // Force HTTP/1.1 — avoid undici HTTP/2 negotiation issues with WebDAV
       agent: new transport.Agent({ keepAlive: false }),
     };
+
+    // Pin the socket to the address that passed validation, via a lookup
+    // override rather than by rewriting the URL: hostname above keeps driving
+    // SNI, certificate identity, and the Host header (an IP in the URL would
+    // break TLS against any virtual-hosted server), while a DNS answer that
+    // changes between validation and connect (rebinding) never reaches the
+    // socket. Node may call lookup in `all` mode (happy-eyeballs) or not —
+    // serve both shapes.
+    if (pinned) {
+      options.lookup = (host, opts, cb) => {
+        if (opts && opts.all) cb(null, [{ address: pinned.address, family: pinned.family }]);
+        else cb(null, pinned.address, pinned.family);
+      };
+    }
 
     const proxyReq = transport.request(options, (proxyRes) => {
       const chunks = [];
@@ -132,8 +195,9 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Missing url parameter' });
   }
 
+  let pinned = null;
   try {
-    validateProxyUrl(url);
+    ({ pinned } = await validateProxyUrl(url));
   } catch (err) {
     return res.status(400).json({ error: err.message });
   }
@@ -174,7 +238,7 @@ export default async function handler(req, res) {
       }
     }
 
-    const response = await proxyRequest(req.method, url, headers, body);
+    const response = await proxyRequest(req.method, url, headers, body, pinned);
 
     // Some WebDAV servers answer a GET for a missing/empty resource with a 2xx
     // whose body isn't the JSON the sync library expects — an HTML/XML error

--- a/api/webdav-proxy.test.js
+++ b/api/webdav-proxy.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock DNS so hostname-based cases are deterministic and offline. Literal IPs
+// bypass the mock's table and use the same literal-parse behavior as the real
+// getaddrinfo (no network query for literals either way).
+const dnsTable = {
+  localhost: [{ address: '127.0.0.1', family: 4 }],
+  'nas.rebind.example': [{ address: '10.0.0.5', family: 4 }],
+  'metadata.rebind.example': [{ address: '93.184.216.34', family: 4 }, { address: '169.254.169.254', family: 4 }],
+  'dav.example.com': [{ address: '93.184.216.34', family: 4 }],
+  'dual.example.com': [{ address: '2606:4700::1111', family: 6 }, { address: '93.184.216.34', family: 4 }],
+}
+vi.mock('dns/promises', async importOriginal => {
+  const real = await importOriginal()
+  return {
+    ...real,
+    lookup: async (hostname, opts) => {
+      if (dnsTable[hostname]) return dnsTable[hostname]
+      return real.lookup(hostname, opts)
+    },
+  }
+})
+
+const { validateProxyUrl, isPrivateIPv4, isPrivateIPv6 } = await import('./webdav-proxy.js')
+
+const PRIVATE_ERR = 'Private/reserved addresses are not allowed'
+
+describe('isPrivateIPv4', () => {
+  it.each([
+    '0.1.2.3', '10.0.0.1', '10.255.255.255', '100.64.0.1', '100.127.255.255',
+    '127.0.0.1', '169.254.169.254', '172.16.0.1', '172.31.255.255',
+    '192.168.0.1', '198.18.0.1', '198.19.255.255', '224.0.0.1', '255.255.255.255',
+  ])('blocks %s', ip => {
+    expect(isPrivateIPv4(ip)).toBe(true)
+  })
+
+  it.each([
+    '8.8.8.8', '93.184.216.34', '100.63.255.255', '100.128.0.1', '172.15.0.1',
+    '172.32.0.1', '192.167.0.1', '192.169.0.1', '198.17.0.1', '198.20.0.1', '223.255.255.255',
+  ])('allows %s', ip => {
+    expect(isPrivateIPv4(ip)).toBe(false)
+  })
+
+  it('refuses unparseable input rather than allowing it', () => {
+    expect(isPrivateIPv4('not-an-ip')).toBe(true)
+    expect(isPrivateIPv4('1.2.3')).toBe(true)
+    expect(isPrivateIPv4('1.2.3.999')).toBe(true)
+  })
+})
+
+describe('isPrivateIPv6', () => {
+  it.each([
+    '::', '::1', 'fe80::1', 'febf::1', 'fc00::1', 'fd12:3456::1', 'ff02::1',
+    // IPv4-mapped, both renderings: dns.lookup's dotted form and the
+    // WHATWG-URL-normalized hex form of ::ffff:127.0.0.1
+    '::ffff:127.0.0.1', '::ffff:7f00:1', '::ffff:192.168.1.5', '::ffff:c0a8:105',
+    'fe80::1%eth0', // zone id stripped, still link-local
+  ])('blocks %s', ip => {
+    expect(isPrivateIPv6(ip)).toBe(true)
+  })
+
+  it.each([
+    '2606:4700::1111', '2001:4860:4860::8888',
+    '::ffff:8.8.8.8', '::ffff:808:808', // mapped PUBLIC v4 is fine
+  ])('allows %s', ip => {
+    expect(isPrivateIPv6(ip)).toBe(false)
+  })
+})
+
+describe('validateProxyUrl', () => {
+  it('rejects non-http(s) schemes regardless of enforcement', async () => {
+    await expect(validateProxyUrl('ftp://example.com/x', false)).rejects.toThrow('Only http and https')
+    await expect(validateProxyUrl('file:///etc/passwd', true)).rejects.toThrow('Only http and https')
+  })
+
+  it('rejects malformed URLs', async () => {
+    await expect(validateProxyUrl('not a url', false)).rejects.toThrow('Invalid URL')
+  })
+
+  it('skips resolution entirely when not enforcing (self-hosted)', async () => {
+    const { pinned } = await validateProxyUrl('http://192.168.1.5/dav/', false)
+    expect(pinned).toBeNull()
+  })
+
+  it.each([
+    'http://10.0.0.1/dav/',
+    'http://192.168.1.5/dav/',
+    'http://172.16.0.1/dav/',
+    'http://127.0.0.1/dav/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://localhost/dav/',
+    'http://[::1]/dav/',
+    'http://[fe80::1]/dav/',
+    'http://[::ffff:127.0.0.1]/dav/', // URL normalizes to [::ffff:7f00:1]
+  ])('blocks %s when enforcing', async url => {
+    await expect(validateProxyUrl(url, true)).rejects.toThrow(PRIVATE_ERR)
+  })
+
+  it.each([
+    // WHATWG URL canonicalizes exotic IPv4 encodings before validation ever
+    // runs; these all become 127.0.0.1 and must stay blocked.
+    'http://2130706433/',
+    'http://0177.0.0.1/',
+    'http://0x7f000001/',
+  ])('blocks encoded-loopback %s when enforcing', async url => {
+    await expect(validateProxyUrl(url, true)).rejects.toThrow(PRIVATE_ERR)
+  })
+
+  it('blocks a public hostname whose DNS answer is a private address', async () => {
+    await expect(validateProxyUrl('https://nas.rebind.example/dav/', true)).rejects.toThrow(PRIVATE_ERR)
+  })
+
+  it('blocks when ANY resolved address is private, even alongside public ones', async () => {
+    await expect(validateProxyUrl('https://metadata.rebind.example/dav/', true)).rejects.toThrow(PRIVATE_ERR)
+  })
+
+  it('pins a public hostname to its validated address', async () => {
+    const { pinned } = await validateProxyUrl('https://dav.example.com/dav/', true)
+    expect(pinned).toEqual({ address: '93.184.216.34', family: 4 })
+  })
+
+  it('prefers IPv4 when a dual-stack host lists AAAA first', async () => {
+    const { pinned } = await validateProxyUrl('https://dual.example.com/dav/', true)
+    expect(pinned).toEqual({ address: '93.184.216.34', family: 4 })
+  })
+
+  it('pins public IP literals without a DNS query', async () => {
+    const v4 = await validateProxyUrl('https://93.184.216.34/dav/', true)
+    expect(v4.pinned).toEqual({ address: '93.184.216.34', family: 4 })
+    const v6 = await validateProxyUrl('https://[2606:4700::1111]/dav/', true)
+    expect(v6.pinned.family).toBe(6)
+  })
+})


### PR DESCRIPTION
## What

Hardens the hosted (Vercel) deployment's SSRF protection in `api/webdav-proxy.js`. The private-address blocklist previously ran against the URL's hostname string, which misses DNS-based bypasses: a public hostname whose A record points at a private address passes the string check, and even a correctly validated hostname can be rebound between the check and the connect (TOCTOU).

## Changes

- **Resolve first, validate every answer**: when enforcing (`VERCEL` set), the hostname is resolved via `dns.lookup` and the request is rejected if *any* returned address falls in a private/reserved range (mixed public+private answers are rejected too).
- **Pin the connection**: the socket connects to the exact address that passed validation, via a `lookup` override on `http(s).request` — a changed DNS answer never reaches the socket. The pin does not rewrite the URL: the original hostname still drives SNI, certificate identity, and the Host header, so TLS against virtual-hosted servers (Let's Encrypt etc.) is unaffected.
- **IPv4 preferred** among validated addresses, so a dual-stack host with a broken-but-advertised AAAA record keeps the IPv4 path it works over today.
- **Range checks are numeric** on resolved addresses: previous set plus benchmarking (`198.18/15`), multicast, reserved space, and both renderings of IPv4-mapped IPv6; unparseable input is refused rather than allowed.
- **Self-hosted unchanged, structurally**: with `VERCEL` unset there is no DNS lookup and no pin at all — private WebDAV targets (NAS on the LAN) keep working exactly as before.

## User impact

None for working hosted setups — "reachable from Vercel" already implies a public address. Targets that resolve privately (and therefore already failed at connect with a generic 502) now fail validation with a clear 400. Exotic IPv4 encodings (decimal/octal/hex) were already neutralized by WHATWG URL canonicalization before this change; they now have regression tests.

## Testing

- 62 new test cases in `api/webdav-proxy.test.js` (DNS mocked, fully offline): range validators, blocked/allowed URLs, DNS-rebind scenarios, pin selection. Full suite 243 passing (24 files), lint clean.
- Live verification: real handler run with `VERCEL=1` blocks `localhost` and `169.254.169.254` (400); same targets proxy fine with `VERCEL` unset; the lookup-override pin provably connects to the pinned IP while preserving the Host header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft9FNhX6JDiHjgnVRtXGXu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft9FNhX6JDiHjgnVRtXGXu)_