### PR TITLE
Paywall: Privacy Policy and Terms of Use links on the gate

### DIFF
--- a/src/components/PaywallModal/PaywallModal.tsx
+++ b/src/components/PaywallModal/PaywallModal.tsx
@@ -226,6 +226,30 @@ export function PaywallModal({ billing, mode, onClose }: Props) {
             {codeError && (
               <p className="text-xs text-red-500 dark:text-red-400 mt-2">{t('paywall.codeInvalid')}</p>
             )}
+
+            {/* Legal links on the wall itself: Apple 3.1.2 requires a privacy
+                policy and Terms of Use link on the subscription paywall (the
+                Help-modal links alone don't satisfy it); harmless on Play.
+                Labels reuse the localized help.* strings. */}
+            <div className="flex items-center justify-center gap-3 mt-5 text-[11px] text-slate-400 dark:text-slate-500">
+              <a
+                href="https://www.glance-apps.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+              >
+                {t('help.privacyPolicy')}
+              </a>
+              <span aria-hidden="true">·</span>
+              <a
+                href="https://www.glance-apps.com/eula"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline underline-offset-2 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+              >
+                {t('help.termsOfUse')}
+              </a>
+            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
## What

Adds Privacy Policy and Terms of Use links to the bottom of the gate paywall — the final piece of App Store prep for the shared paywall. Apple 3.1.2 requires these links on the subscription paywall itself (the Help-modal links from #226 don't satisfy it); they're harmless on Play.

## Changes

- **`src/components/PaywallModal/PaywallModal.tsx`** (gate mode only): a subtle centered footer row with two external links — Privacy Policy → `https://www.glance-apps.com/privacy` and Terms of Use → `https://www.glance-apps.com/eula`. Labels reuse the already-localized `help.privacyPolicy` / `help.termsOfUse` strings (all six locales), so no locale changes needed.

## Testing

- `tsc -b` clean, lint clean, 243 tests pass.
- Rendered the gate with stubbed billing data: links appear beneath the restore/reviewer row, styled to match the wall's footer text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft9FNhX6JDiHjgnVRtXGXu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft9FNhX6JDiHjgnVRtXGXu)_