### PR TITLE
Make the MIT-source / paid-store-builds relationship explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,11 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to run
 
 ## License
 
-[MIT](LICENSE): free to use, self-host, modify, and distribute.
+The source code is [MIT-licensed](LICENSE): free to build, self-host, modify, and distribute. Free builds (including the sideload APK) are on the [releases page](../../releases).
+
+The paid Google Play / App Store builds are a convenience distribution that funds development: you're paying for the packaged, signed, auto-updating binary, not the code.
+
+The lastGLANCE name, logo, and app icon are trademarks and are not covered by the MIT license.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "lastglance",
   "private": true,
+  "license": "MIT",
   "version": "2.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- package.json: add "license": "MIT" so the manifest matches the LICENSE file ("private": true stays — it only blocks npm publish and is unrelated to app licensing).
- README License section: spell out the model — the source is MIT (free to build, self-host, modify, distribute), free builds live on the releases page, and the paid Play / App Store builds are a convenience distribution funding development (you pay for the packaged, signed, auto-updating binary, not the code).
- Trademark note: the lastGLANCE name, logo, and app icon are not covered by the MIT license. MIT is silent on trademarks so they were never granted, but a README that invites free distribution should say so explicitly.


Claude-Session: https://claude.ai/code/session_01Ft9FNhX6JDiHjgnVRtXGXu