### PR TITLE
Harden GHCR publish for multi-arch (arm64) pulls

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -46,8 +49,11 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false


### PR DESCRIPTION
## Summary

Ports the dayGLANCE GHCR hardening (PRs #1258, #1259) to this repo. Note the honest finding below: the situation here is **not** the same as dayGLANCE.

## What the registry actually showed (verified before changing anything)

Queried the live `ghcr.io/krelltunez/lastglance:latest` manifest directly:

```
linux/amd64        image
unknown/unknown    attestation-manifest
```

**`linux/arm64` was genuinely missing.** Unlike dayGLANCE (where arm64 was present all along and the failure was purely pull-side/old-client), this repo's publish workflow had **no `platforms:` line at all**, so only the runner's native amd64 image was ever built. An arm64 client (Raspberry Pi / Apple Silicon) pulling this image would legitimately get `no matching manifest for linux/arm64/v8`, because there is no arm64 manifest.

The index also carried an `unknown/unknown` `attestation-manifest` (buildx provenance), which older Docker/containerd clients can mis-resolve.

## Changes (`.github/workflows/publish-ghcr.yml`)

- **Add `platforms: linux/amd64,linux/arm64`** — this is the change that actually builds arm64. It goes beyond the literal dayGLANCE port because dayGLANCE already had this line; here it was absent, which is why arm64 was missing.
- **Add a `Set up QEMU` step** (from #1258) before Buildx, so the arm64 cross-build has binfmt emulation instead of relying on the runner having it pre-registered.
- **Set `provenance: false` and `sbom: false`** (from #1259) so the attestation side-manifests are dropped, leaving a clean amd64 + arm64 image index that older clients resolve reliably.

No Dockerfile change is needed: the builder stage is `FROM node:20-alpine AS builder` (not pinned with `FROM --platform=linux/amd64`), so the `# check=skip=FromPlatformFlagConstDisallowed` parser directive from #1258 does not apply here.

## Notes

- **No version bump / tag needed.** `publish-ghcr.yml` has `workflow_dispatch`, so a Docker-only republish can be triggered manually. There is no desktop/Electron workflow and nothing triggers on `push: tags: ['v*']`, so the unwanted-desktop-build caveat does not apply to this repo.
- **Verify after merge + a build run** by re-checking the manifest — expect exactly `linux/amd64` and `linux/arm64` and no `unknown/unknown` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe8kipGuMFpSfJPfQyVM9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe8kipGuMFpSfJPfQyVM9u)_