### PR TITLE
Bump version to 2.0.1 for multi-arch Docker re-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Version-only bump (`2.0.0` -> `2.0.1`) to republish the GHCR container image now that the multi-arch hardening (PR #237) has landed on `main`.

## Why

The `v2.0.0` image was built and pushed **before** #237 merged, so the published tags are amd64-only:

```
ghcr.io/krelltunez/lastglance:latest   -> linux/amd64 + unknown/unknown (attestation)
ghcr.io/krelltunez/lastglance:2.0.0    -> linux/amd64 + unknown/unknown (attestation)
```

ARM64 users (Raspberry Pi, Apple Silicon) pulling these get `no matching manifest for linux/arm64/v8` because no arm64 manifest exists. Verified against the live registry. (For reference, the `:main` tag, built after #237, already resolves cleanly to `linux/amd64` + `linux/arm64` with no attestation entries.)

Publishing a `v2.0.1` release re-runs the hardened `publish-ghcr.yml` workflow, which:
- builds `linux/amd64` + `linux/arm64`, and
- moves `:latest` onto that clean multi-arch index automatically (docker/metadata-action `latest=auto`), and
- publishes a `:2.0.1` / `:2.0` multi-arch tag.

## Changes

- `package.json` / `package-lock.json`: root `version` `2.0.0` -> `2.0.1`. No dependency or product changes.

Android `versionName`/`versionCode` derive from `package.json` (see `android/app/build.gradle`), so this also sets versionCode `2000100` automatically. No Android/Play artifact is produced by this change; releasing the tag only triggers the GHCR publish and the Vercel site-rebuild hook.

## After merge

Publish a `v2.0.1` GitHub release to trigger the workflow, then verify:

```
ghcr.io/krelltunez/lastglance:latest -> linux/amd64 + linux/arm64, no unknown/unknown
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe8kipGuMFpSfJPfQyVM9u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe8kipGuMFpSfJPfQyVM9u)_