### PR TITLE
Migrate Play channel to Play Billing Library 8

### DIFF
--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -14,6 +14,6 @@ ext {
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
     glanceVersion = '1.1.1'
-    playBillingVersion = '7.1.1'
+    playBillingVersion = '8.3.0'
     okhttpVersion = '4.12.0'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/share": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
-        "@glance-apps/billing": "0.1.1",
+        "@glance-apps/billing": "0.2.0",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.6.1",
         "dayjs": "^1.11.13",
@@ -2844,9 +2844,9 @@
       }
     },
     "node_modules/@glance-apps/billing": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.1.1.tgz",
-      "integrity": "sha512-7dayiwwDAEyhZbtwtg1GOj9uJixCIS2kI/qXx12S63ec+sbrgNlXFkJ+MpgV/pE04Mq5ndJo8DiYJmGnDfjI9Q==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.2.0.tgz",
+      "integrity": "sha512-LG+WTxGIIjJspqVbU3WfpIqys71I7JSTn60xe2vY7jbcLlRouxbX7UQt0In3bJfV0dzpLtqvFEzx1OhwUQmbTA==",
       "license": "MIT",
       "peerDependencies": {
         "electron": ">=28",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/share": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
-    "@glance-apps/billing": "0.1.1",
+    "@glance-apps/billing": "0.2.0",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.6.1",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
## Summary

Prepares the Play channel for Google's requirement that all app updates use Play Billing Library 8+ by August 31, 2026.

- `android/variables.gradle`: `playBillingVersion` 7.1.1 → **8.3.0** (latest stable 8.x). The `@glance-apps/billing` native plugin reads this override (`rootProject.ext.playBillingVersion`), so it drives the actual `com.android.billingclient:billing-ktx` version.
- `package.json` / `package-lock.json`: `@glance-apps/billing` 0.1.1 → **0.2.0**, the release carrying the Billing 8 `queryProductDetailsAsync` callback fix (`List<ProductDetails>` → `QueryProductDetailsResult`) and defaulting billing-ktx to 8.3.0.

Verified against the published 0.2.0 tarball: all three `queryProductDetailsAsync` call sites in `PlayBillingCore.kt` use the v8 `queryResult.productDetailsList` shape, so the Android build compiles against Billing 8, not just resolves.

## Impact

- Play channel only. GitHub sideload and web/PWA builds pass `adapter: null` and are unaffected.
- npm install resolves cleanly (Vercel build green as of the 0.2.0 publish).

## Remaining before release

- [ ] `./build-android.sh --release`
- [ ] Smoke-test the four callback-touched paths on the Play channel: price display, purchase, restore, trial-eligibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj)_