### PR TITLE
Move sync credentials to Android Keystore-backed storage (#210)

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -21,6 +21,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(IntentsBridgePlugin.class);
         registerPlugin(BillingBridgePlugin.class);
         registerPlugin(WebDavHttpPlugin.class);
+        registerPlugin(SecureStorePlugin.class);
         super.onCreate(savedInstanceState);
         captureWidgetDeepLink(getIntent());
         captureSharedText(getIntent());

--- a/android/app/src/main/java/com/lastglance/app/SecureStorePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/SecureStorePlugin.java
@@ -1,0 +1,171 @@
+package com.lastglance.app;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.security.KeyStore;
+import java.security.SecureRandom;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+// Keystore-backed secret storage for sync/vault/intents credentials (issue
+// #210). Values are AES-GCM ciphertext in a private SharedPreferences file;
+// the AES key lives in the Android Keystore (non-exportable, hardware-backed
+// where the device supports it), so the ciphertext is useless off-device.
+// That failure mode is deliberate: prefs restored or transferred to another
+// device won't decrypt, get() reports the entry as absent, and the app asks
+// the user to re-enter credentials rather than failing cryptically.
+//
+// Registered in MainActivity; consumed by src/native/secureStore.ts, which
+// falls back to localStorage on non-Android platforms.
+@CapacitorPlugin(name = "SecureStore")
+public class SecureStorePlugin extends Plugin {
+
+    private static final String PREFS = "lastglance_secure_store";
+    private static final String KEY_ALIAS = "lastglance_secure_store";
+    private static final String ANDROID_KEYSTORE = "AndroidKeyStore";
+    // GCM: 12-byte IV, 128-bit tag. Stored value format is
+    // "v1:" + base64(iv) + ":" + base64(ciphertext).
+    private static final int GCM_IV_BYTES = 12;
+    private static final int GCM_TAG_BITS = 128;
+    private static final String FORMAT_PREFIX = "v1:";
+
+    @PluginMethod
+    public void get(PluginCall call) {
+        String key = call.getString("key");
+        if (key == null || key.isEmpty()) {
+            call.reject("missing key");
+            return;
+        }
+        String stored = prefs().getString(key, null);
+        JSObject ret = new JSObject();
+        if (stored == null) {
+            ret.put("value", (String) null);
+            call.resolve(ret);
+            return;
+        }
+        String plain = decrypt(stored);
+        if (plain == null) {
+            // Undecryptable (restored ciphertext, invalidated key). The Keystore
+            // key is non-exportable, so this can never recover — drop the entry
+            // so the caller sees a clean "absent" and a later set() starts fresh.
+            prefs().edit().remove(key).apply();
+        }
+        ret.put("value", plain);
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void set(PluginCall call) {
+        String key = call.getString("key");
+        String value = call.getString("value");
+        if (key == null || key.isEmpty() || value == null) {
+            call.reject("missing key or value");
+            return;
+        }
+        String stored = encrypt(value);
+        if (stored == null) {
+            // One retry with a fresh key covers the rare corrupted-alias state
+            // (e.g. a partially restored Keystore). Existing entries were already
+            // undecryptable in that state, so rotating the key loses nothing.
+            deleteKeyQuietly();
+            stored = encrypt(value);
+        }
+        if (stored == null) {
+            call.reject("encrypt failed");
+            return;
+        }
+        prefs().edit().putString(key, stored).apply();
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void delete(PluginCall call) {
+        String key = call.getString("key");
+        if (key == null || key.isEmpty()) {
+            call.reject("missing key");
+            return;
+        }
+        prefs().edit().remove(key).apply();
+        call.resolve();
+    }
+
+    private SharedPreferences prefs() {
+        return getContext().getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    // ── Keystore-backed AES-GCM ───────────────────────────────────────────────
+
+    private String encrypt(String plaintext) {
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            byte[] iv = new byte[GCM_IV_BYTES];
+            new SecureRandom().nextBytes(iv);
+            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] ct = cipher.doFinal(plaintext.getBytes("UTF-8"));
+            return FORMAT_PREFIX
+                + Base64.encodeToString(iv, Base64.NO_WRAP)
+                + ":"
+                + Base64.encodeToString(ct, Base64.NO_WRAP);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String decrypt(String stored) {
+        try {
+            if (!stored.startsWith(FORMAT_PREFIX)) return null;
+            String[] parts = stored.substring(FORMAT_PREFIX.length()).split(":", 2);
+            if (parts.length != 2) return null;
+            byte[] iv = Base64.decode(parts[0], Base64.NO_WRAP);
+            byte[] ct = Base64.decode(parts[1], Base64.NO_WRAP);
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            return new String(cipher.doFinal(ct), "UTF-8");
+        } catch (Exception e) {
+            // Bad tag / invalidated or missing key / malformed entry — all map to
+            // "absent" (see get()).
+            return null;
+        }
+    }
+
+    private SecretKey getOrCreateKey() throws Exception {
+        KeyStore ks = KeyStore.getInstance(ANDROID_KEYSTORE);
+        ks.load(null);
+        KeyStore.Entry entry = ks.getEntry(KEY_ALIAS, null);
+        if (entry instanceof KeyStore.SecretKeyEntry) {
+            return ((KeyStore.SecretKeyEntry) entry).getSecretKey();
+        }
+        KeyGenerator kg = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE);
+        kg.init(new KeyGenParameterSpec.Builder(KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            // No user-auth binding: these credentials are read at boot for
+            // background-capable sync, before any biometric prompt could show.
+            .build());
+        return kg.generateKey();
+    }
+
+    private void deleteKeyQuietly() {
+        try {
+            KeyStore ks = KeyStore.getInstance(ANDROID_KEYSTORE);
+            ks.load(null);
+            ks.deleteEntry(KEY_ALIAS);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import { useAndroidIntentBridge } from '@/hooks/useAndroidIntentBridge'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
-import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
+import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, DB_CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
 import { createDbEngine } from '@/sync/dbEngine'
 import { registerDbEngine } from '@/sync/dirtyTracker'
 import { isVaultEnabled } from '@/sync/vaultConfig'
@@ -221,7 +221,7 @@ function AppInner() {
         // via initDbRootKey, so the prompt is skipped. The in-memory hasDbRootKey
         // is always false at mount, so we attempt the restore before deciding.
         if (!isVaultEnabled()) return
-        const hasRoot = hasDbRootKey() || await initDbRootKey(CRYPTO_CONFIG)
+        const hasRoot = hasDbRootKey() || await initDbRootKey(DB_CRYPTO_CONFIG)
         if (!hasRoot && getSyncPassphrase() === null) setShowPassphrase(true)
       })
       .catch(() => {/* non-fatal */})

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { X, Loader, AlertTriangle, CheckCircle, XCircle, ShieldAlert } from 'lucide-react'
 import type { SyncEngine, DbSyncEngine, SyncErrorCode } from '@glance-apps/sync'
 import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, DEFAULT_SYNC_FOLDER, SYNC_FOLDER_KEY } from '@/sync/engine'
+import { flushSecureWrites } from '@/sync/secureConfigShim'
 import { syncErrorText } from '@/sync/syncErrorText'
 import { getVaultConfig, setVaultConfig } from '@/sync/vaultConfig'
 import { testVaultConnection } from '@/sync/testVaultConnection'
@@ -139,9 +140,12 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
       resetEnsuredFolder()
     }
     // A folder change or any vault change requires a reload so the engines are
-    // reconstructed with the new transport config on next mount.
+    // reconstructed with the new transport config on next mount. On Android the
+    // credential writes above are an async write-through to the SecureStore
+    // (issue #210) — wait for them, or the reload could tear the page down with
+    // the new credentials not yet persisted. Off Android this resolves at once.
     if (folderPath !== originalFolder.current || vaultChanged) {
-      window.location.reload()
+      flushSecureWrites().finally(() => window.location.reload())
     }
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { Capacitor } from '@capacitor/core'
 import './index.css'
 import './i18n'
 import App from './App'
+import { hydrateSecureConfig, installSecureConfigShim } from './sync/secureConfigShim'
 
 // crypto.randomUUID() is only available in secure contexts (HTTPS / localhost).
 // This polyfill covers HTTP access over a LAN IP (e.g. self-hosted Docker).
@@ -31,10 +32,21 @@ if (saved === 'dark' || (!saved && prefersDark)) {
   document.documentElement.classList.add('dark')
 }
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <Suspense fallback={null}>
-      <App />
-    </Suspense>
-  </StrictMode>,
-)
+const render = () =>
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <Suspense fallback={null}>
+        <App />
+      </Suspense>
+    </StrictMode>,
+  )
+
+// On Android, route credential-bearing config through the Keystore-backed
+// SecureStore (issue #210). Hydration must finish before the first render:
+// IntentsContext and the sync engines read these keys synchronously during
+// mount. Both calls are no-ops off Android, and a hydration failure still
+// renders — the app degrades to "sync not configured", never a blank screen.
+installSecureConfigShim()
+hydrateSecureConfig()
+  .catch(() => {})
+  .then(render)

--- a/src/native/secureStore.ts
+++ b/src/native/secureStore.ts
@@ -1,0 +1,33 @@
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+// Native bridge to Keystore-backed secret storage (issue #210). Values are
+// AES-GCM ciphertext in a private SharedPreferences file with the key in the
+// Android Keystore, so secrets are no longer plaintext-at-rest in WebView
+// storage. Ciphertext restored onto a different device cannot decrypt and
+// reads as absent — the app falls back to asking for credentials again.
+// Android-only; on web/PWA and iOS callers keep their existing storage.
+export interface SecureStorePlugin {
+  // Resolve the stored value, or null when absent or undecryptable.
+  get(options: { key: string }): Promise<{ value: string | null }>
+  set(options: { key: string; value: string }): Promise<void>
+  delete(options: { key: string }): Promise<void>
+}
+
+const SecureStore = registerPlugin<SecureStorePlugin>('SecureStore')
+
+// The shim and key hooks must only engage where the plugin exists — anywhere
+// else the fallback is the status quo (localStorage / IndexedDB).
+export const isSecureStoreAvailable = Capacitor.getPlatform() === 'android'
+
+export async function secureGet(key: string): Promise<string | null> {
+  const res = await SecureStore.get({ key })
+  return res.value ?? null
+}
+
+export async function secureSet(key: string, value: string): Promise<void> {
+  await SecureStore.set({ key, value })
+}
+
+export async function secureDelete(key: string): Promise<void> {
+  await SecureStore.delete({ key })
+}

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -19,6 +19,7 @@ import type { Category, Chore, CompletionEvent, User } from '@/types'
 import type { SyncCategory, SyncChore, SyncCompletionEvent, SyncUser } from './types'
 import { getVaultConfig, isVaultEnabled } from './vaultConfig'
 import { getDeviceId } from './deviceId'
+import { DB_ROOT_KEY_HOOKS } from './nativeKeyHooks'
 import { addDeferredChore, removeDeferredChore, getDeferredChores } from './deferredChores'
 import {
   addDeferredCompletion,
@@ -488,6 +489,9 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
     appId: APP_ID,
     vaultApp: APP_ID,
     cryptoDBName: CRYPTO_DB_NAME,
+    // Keystore-backed root-key storage on Android (issue #210) — must be the
+    // DB-tier pair; see the note on CRYPTO_CONFIG / DB_CRYPTO_CONFIG.
+    ...DB_ROOT_KEY_HOOKS,
     vaultUrl: cfg.vaultUrl,
     vaultToken: cfg.vaultToken,
     accountId: cfg.accountId,

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -12,10 +12,17 @@ import { db } from '@/db/client'
 import type { Category, Chore, CompletionEvent, User } from '@/types'
 import { buildAuthHeader, ensureFolder, forgetEnsuredFolders } from '@/intents/webdav'
 import { browserDirectFetch, isNativePlatform, nativeHttpFetch, webdavDirect } from './nativeHttp'
+import { DB_ROOT_KEY_HOOKS, FILE_SYNC_KEY_HOOKS } from './nativeKeyHooks'
 import type { SyncPayload, SyncSettings } from './types'
 import { getMultiUserEnabled, setMultiUserEnabled } from '@/multiuser/settings'
 
-export const CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto' }
+// On Android the spread hooks route key storage to the Keystore-backed
+// SecureStore instead of IndexedDB (issue #210); elsewhere they spread to
+// nothing and the package keeps its IndexedDB path. The two configs must stay
+// separate: the package uses the same hook names for the file-tier session
+// key and the vault root key, so sharing one pair would cross the tiers.
+export const CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto', ...FILE_SYNC_KEY_HOOKS }
+export const DB_CRYPTO_CONFIG = { cryptoDBName: 'lastglance-crypto', ...DB_ROOT_KEY_HOOKS }
 export const DEFAULT_SYNC_FOLDER = 'GLANCE/lastglance'
 export const SYNC_FOLDER_KEY = 'lastglance-cloud-sync-folder'
 
@@ -485,6 +492,7 @@ export function createEngine(proxyUrl: string | undefined, callbacks: EngineCall
   const engine = createSyncEngine({
     storageKeyPrefix: 'lastglance',
     cryptoDBName: 'lastglance-crypto',
+    ...FILE_SYNC_KEY_HOOKS,
     autoBackupDBName: 'lastglance-auto-backups',
     syncFilename: 'lastglance-sync.json',
     appFolderName,

--- a/src/sync/nativeKeyHooks.test.ts
+++ b/src/sync/nativeKeyHooks.test.ts
@@ -1,0 +1,111 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { IDBFactory } from 'fake-indexeddb'
+
+const nativeStore = new Map<string, string>()
+vi.mock('@/native/secureStore', () => ({
+  isSecureStoreAvailable: true,
+  secureGet: vi.fn(async (key: string) => (nativeStore.has(key) ? nativeStore.get(key)! : null)),
+  secureSet: vi.fn(async (key: string, value: string) => { nativeStore.set(key, value) }),
+  secureDelete: vi.fn(async (key: string) => { nativeStore.delete(key) }),
+}))
+
+import { FILE_SYNC_KEY_HOOKS, DB_ROOT_KEY_HOOKS } from './nativeKeyHooks'
+
+// Seed a legacy crypto DB the way @glance-apps/sync laid it out.
+function seedLegacyDb(dbName: string, storeName: string, record: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, 1)
+    req.onupgradeneeded = () => req.result.createObjectStore(storeName, { keyPath: 'id' })
+    req.onerror = () => reject(req.error)
+    req.onsuccess = () => {
+      const db = req.result
+      const tx = db.transaction(storeName, 'readwrite')
+      tx.objectStore(storeName).put(record)
+      tx.oncomplete = () => { db.close(); resolve() }
+      tx.onerror = () => { db.close(); reject(tx.error) }
+    }
+  })
+}
+
+function readLegacy(dbName: string, storeName: string, id: string): Promise<unknown> {
+  return new Promise((resolve) => {
+    const req = indexedDB.open(dbName)
+    req.onsuccess = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(storeName)) { db.close(); resolve(null); return }
+      const get = db.transaction(storeName, 'readonly').objectStore(storeName).get(id)
+      get.onsuccess = () => { db.close(); resolve(get.result ?? null) }
+      get.onerror = () => { db.close(); resolve(null) }
+    }
+    req.onerror = () => resolve(null)
+  })
+}
+
+describe('nativeKeyHooks', () => {
+  beforeEach(() => {
+    nativeStore.clear()
+    // Fresh IndexedDB universe per test.
+    globalThis.indexedDB = new IDBFactory()
+  })
+
+  it('returns null when neither store has a key', async () => {
+    expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey!()).toBeNull()
+  })
+
+  it('round-trips through the store hook', async () => {
+    const blob = btoa(JSON.stringify({ rawKey: [1, 2, 3], salt: [4, 5, 6] }))
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey!(blob)
+    await vi.waitFor(async () => {
+      expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey!()).toBe(blob)
+    })
+  })
+
+  it('store(null) clears the entry (package clear semantics)', async () => {
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey!(btoa('{"rawKey":[1],"salt":[2]}'))
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey!(null)
+    await vi.waitFor(async () => {
+      expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey!()).toBeNull()
+    })
+  })
+
+  it('migrates the legacy file-sync key record (ArrayBuffer rawKey) and deletes it', async () => {
+    const rawKey = new Uint8Array([9, 8, 7, 6]).buffer
+    await seedLegacyDb('lastglance-crypto', 'keys', { id: 'sync-key', rawKey, salt: [1, 2] })
+
+    const blob = await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey!()
+    expect(blob).not.toBeNull()
+    expect(JSON.parse(atob(blob!))).toEqual({ rawKey: [9, 8, 7, 6], salt: [1, 2] })
+    // Migrated into the secure store, wiped from IndexedDB (risk note: the
+    // legacy record is extractable raw bytes — it must not survive).
+    expect(nativeStore.get('crypto.sync-key')).toBe(blob)
+    expect(await readLegacy('lastglance-crypto', 'keys', 'sync-key')).toBeNull()
+  })
+
+  it('migrates the legacy vault root key record and deletes it', async () => {
+    await seedLegacyDb('lastglance-crypto-db', 'db-root-keys', { id: 'db-root-key', rootBytes: [5, 5], salt: [6, 6] })
+
+    const blob = await DB_ROOT_KEY_HOOKS.nativeGetSyncKey!()
+    expect(JSON.parse(atob(blob!))).toEqual({ rootBytes: [5, 5], salt: [6, 6] })
+    expect(nativeStore.get('crypto.db-root-key')).toBe(blob)
+    expect(await readLegacy('lastglance-crypto-db', 'db-root-keys', 'db-root-key')).toBeNull()
+  })
+
+  it('file and db tiers use distinct secure-store entries', async () => {
+    FILE_SYNC_KEY_HOOKS.nativeStoreSyncKey!(btoa(JSON.stringify({ rawKey: [1], salt: [1] })))
+    DB_ROOT_KEY_HOOKS.nativeStoreSyncKey!(btoa(JSON.stringify({ rootBytes: [2], salt: [2] })))
+    await vi.waitFor(() => {
+      expect(nativeStore.size).toBe(2)
+    })
+    const file = JSON.parse(atob((await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey!())!))
+    const dbRoot = JSON.parse(atob((await DB_ROOT_KEY_HOOKS.nativeGetSyncKey!())!))
+    expect(file.rawKey).toEqual([1])
+    expect(dbRoot.rootBytes).toEqual([2])
+  })
+
+  it('a malformed legacy record reads as absent (fail-safe)', async () => {
+    await seedLegacyDb('lastglance-crypto', 'keys', { id: 'sync-key', wrongField: true })
+    expect(await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey!()).toBeNull()
+    expect(nativeStore.size).toBe(0)
+  })
+})

--- a/src/sync/nativeKeyHooks.ts
+++ b/src/sync/nativeKeyHooks.ts
@@ -1,0 +1,140 @@
+import { isSecureStoreAvailable, secureDelete, secureGet, secureSet } from '@/native/secureStore'
+
+// SecureStore-backed implementations of the `nativeGetSyncKey` /
+// `nativeStoreSyncKey` hooks that `@glance-apps/sync` ships for exactly this
+// purpose (issue #210) and that the app has so far passed as null. With the
+// hooks present the package stops using its `lastglance-crypto*` IndexedDB
+// databases — the two records it kept there are extractable raw key bytes
+// (`rawKey` for the file-sync key, `rootBytes` for the vault HKDF root), the
+// most sensitive artifacts in WebView storage.
+//
+// The package treats the hooks as either/or with IndexedDB (no fallback), so
+// each getter carries its own one-time legacy migration: read the old record,
+// re-encode it as the exact base64 blob the package's native path expects,
+// store it in the SecureStore, then delete the IndexedDB copy (leaving it
+// would defeat the point — the bytes are extractable where they sit).
+//
+// Two separately-bound hook pairs are required. The file tier and the DB tier
+// use the SAME hook names in the package (`initSessionKey` vs `initDbRootKey`
+// both call `nativeGetSyncKey`), so a single shared pair would make both
+// tiers read and clobber one SecureStore entry. FILE_SYNC_KEY_HOOKS binds to
+// 'crypto.sync-key', DB_ROOT_KEY_HOOKS to 'crypto.db-root-key'.
+//
+// On non-Android platforms both exports are empty objects: spread into a
+// config they contribute nothing, the package sees no hooks, and IndexedDB
+// behavior is unchanged.
+
+interface NativeKeyHooks {
+  nativeGetSyncKey?: () => Promise<string | null>
+  nativeStoreSyncKey?: (b64: string | null) => void
+}
+
+// Read one record from a legacy crypto DB without creating stores. Opening
+// versionless never triggers an upgrade, so a missing store just reads null.
+function readLegacyRecord(dbName: string, storeName: string, id: string): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    try {
+      const req = indexedDB.open(dbName)
+      req.onerror = () => resolve(null)
+      req.onsuccess = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.close()
+          resolve(null)
+          return
+        }
+        const get = db.transaction(storeName, 'readonly').objectStore(storeName).get(id)
+        get.onerror = () => { db.close(); resolve(null) }
+        get.onsuccess = () => { db.close(); resolve(get.result ?? null) }
+      }
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+function deleteLegacyRecord(dbName: string, storeName: string, id: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const req = indexedDB.open(dbName)
+      req.onerror = () => resolve()
+      req.onsuccess = () => {
+        const db = req.result
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.close()
+          resolve()
+          return
+        }
+        const tx = db.transaction(storeName, 'readwrite')
+        tx.objectStore(storeName).delete(id)
+        tx.oncomplete = () => { db.close(); resolve() }
+        tx.onerror = () => { db.close(); resolve() }
+      }
+    } catch {
+      resolve()
+    }
+  })
+}
+
+// number[] | ArrayBuffer | TypedArray → plain number[] for the JSON blob.
+function toByteArray(v: unknown): number[] {
+  if (Array.isArray(v)) return v
+  if (v instanceof ArrayBuffer) return Array.from(new Uint8Array(v))
+  if (ArrayBuffer.isView(v)) return Array.from(new Uint8Array(v.buffer, v.byteOffset, v.byteLength))
+  return []
+}
+
+function makeHooks(
+  storeKey: string,
+  legacy: { dbName: string; storeName: string; id: string },
+  // Re-encode the legacy IndexedDB record into the package's native blob shape.
+  // Returns null when the record is malformed — treated as absent.
+  recordToBlob: (record: Record<string, unknown>) => Record<string, unknown> | null,
+): NativeKeyHooks {
+  if (!isSecureStoreAvailable) return {}
+  return {
+    nativeGetSyncKey: async () => {
+      const existing = await secureGet(storeKey)
+      if (existing !== null) return existing
+      const record = await readLegacyRecord(legacy.dbName, legacy.storeName, legacy.id)
+      if (!record) return null
+      const blob = recordToBlob(record)
+      if (!blob) return null
+      const b64 = btoa(JSON.stringify(blob))
+      await secureSet(storeKey, b64)
+      await deleteLegacyRecord(legacy.dbName, legacy.storeName, legacy.id)
+      return b64
+    },
+    nativeStoreSyncKey: (b64: string | null) => {
+      // The package calls this fire-and-forget (null means "clear").
+      void (b64 === null ? secureDelete(storeKey) : secureSet(storeKey, b64)).catch(() => {
+        // Failed persist: the in-memory session key still works; next boot
+        // falls back to the passphrase prompt (fail-safe).
+      })
+    },
+  }
+}
+
+// File-tier sync key: record { rawKey: ArrayBuffer, salt: number[] } in
+// lastglance-crypto/keys, blob shape { rawKey: number[], salt: number[] }.
+export const FILE_SYNC_KEY_HOOKS: NativeKeyHooks = makeHooks(
+  'crypto.sync-key',
+  { dbName: 'lastglance-crypto', storeName: 'keys', id: 'sync-key' },
+  (record) => {
+    const rawKey = toByteArray(record.rawKey)
+    const salt = toByteArray(record.salt)
+    return rawKey.length && salt.length ? { rawKey, salt } : null
+  },
+)
+
+// Vault root key: record { rootBytes: number[], salt: number[] } in
+// lastglance-crypto-db/db-root-keys, blob shape { rootBytes, salt }.
+export const DB_ROOT_KEY_HOOKS: NativeKeyHooks = makeHooks(
+  'crypto.db-root-key',
+  { dbName: 'lastglance-crypto-db', storeName: 'db-root-keys', id: 'db-root-key' },
+  (record) => {
+    const rootBytes = toByteArray(record.rootBytes)
+    const salt = toByteArray(record.salt)
+    return rootBytes.length && salt.length ? { rootBytes, salt } : null
+  },
+)

--- a/src/sync/secureConfigShim.test.ts
+++ b/src/sync/secureConfigShim.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// In-memory stand-in for the native SecureStore plugin. `available` is
+// mutable so individual tests can exercise the non-Android no-op path.
+const nativeStore = new Map<string, string>()
+const availability = { value: true }
+vi.mock('@/native/secureStore', () => ({
+  get isSecureStoreAvailable() { return availability.value },
+  secureGet: vi.fn(async (key: string) => (nativeStore.has(key) ? nativeStore.get(key)! : null)),
+  secureSet: vi.fn(async (key: string, value: string) => { nativeStore.set(key, value) }),
+  secureDelete: vi.fn(async (key: string) => { nativeStore.delete(key) }),
+}))
+
+// The vitest environment is node: no Storage / window / localStorage. The shim
+// patches Storage.prototype and distinguishes localStorage from sessionStorage
+// by identity, so the fixture must model both on a real prototype chain.
+class FakeStorage {
+  private store = new Map<string, string>()
+  getItem(k: string): string | null { return this.store.has(k) ? this.store.get(k)! : null }
+  setItem(k: string, v: string): void { this.store.set(k, String(v)) }
+  removeItem(k: string): void { this.store.delete(k) }
+  clear(): void { this.store.clear() }
+  key(i: number): string | null { return Array.from(this.store.keys())[i] ?? null }
+  get length(): number { return this.store.size }
+}
+
+const SECRET_KEY = 'lastglance-cloud-sync-config'
+
+type ShimModule = typeof import('./secureConfigShim')
+let shim: ShimModule
+
+describe('secureConfigShim', () => {
+  beforeEach(async () => {
+    const g = globalThis as Record<string, unknown>
+    g.Storage = FakeStorage
+    g.localStorage = new FakeStorage()
+    g.sessionStorage = new FakeStorage()
+    g.window = globalThis
+    nativeStore.clear()
+    availability.value = true
+    vi.resetModules()
+    shim = await import('./secureConfigShim')
+  })
+
+  afterEach(() => {
+    shim.uninstallSecureConfigShimForTests()
+  })
+
+  it('passes non-secret keys through to real localStorage', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    localStorage.setItem('theme', 'dark')
+    expect(localStorage.getItem('theme')).toBe('dark')
+    expect(nativeStore.size).toBe(0)
+  })
+
+  it('serves secret keys from the cache and writes through to the native store', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    const cfg = JSON.stringify({ enabled: true, appPassword: 'hunter2' })
+    localStorage.setItem(SECRET_KEY, cfg)
+    // Synchronous read-back straight from the cache — this is the contract the
+    // sync engine's synchronous getConfig() depends on.
+    expect(localStorage.getItem(SECRET_KEY)).toBe(cfg)
+    await shim.flushSecureWrites()
+    expect(nativeStore.get(SECRET_KEY)).toBe(cfg)
+    // The real localStorage must never have seen the value.
+    shim.uninstallSecureConfigShimForTests()
+    expect(localStorage.getItem(SECRET_KEY)).toBeNull()
+  })
+
+  it('removeItem clears both cache and native store', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    localStorage.setItem(SECRET_KEY, 'v')
+    localStorage.removeItem(SECRET_KEY)
+    expect(localStorage.getItem(SECRET_KEY)).toBeNull()
+    await shim.flushSecureWrites()
+    expect(nativeStore.has(SECRET_KEY)).toBe(false)
+  })
+
+  it('migrates legacy plaintext out of localStorage on hydrate', async () => {
+    const legacy = JSON.stringify({ vaultToken: 'tok_legacy' })
+    localStorage.setItem('lastglance-vault-config', legacy)
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    // Served from the cache, present in the native store, gone from disk.
+    expect(localStorage.getItem('lastglance-vault-config')).toBe(legacy)
+    expect(nativeStore.get('lastglance-vault-config')).toBe(legacy)
+    shim.uninstallSecureConfigShimForTests()
+    expect(localStorage.getItem('lastglance-vault-config')).toBeNull()
+  })
+
+  it('hydrates previously stored secrets from the native store', async () => {
+    nativeStore.set('lg_intents_config', '{"webdavPassword":"pw"}')
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    expect(localStorage.getItem('lg_intents_config')).toBe('{"webdavPassword":"pw"}')
+  })
+
+  it('a wiped native store (device transfer) reads as absent', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    expect(localStorage.getItem(SECRET_KEY)).toBeNull()
+  })
+
+  it('does not touch sessionStorage', async () => {
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    sessionStorage.setItem(SECRET_KEY, 'session-value')
+    expect(sessionStorage.getItem(SECRET_KEY)).toBe('session-value')
+    await shim.flushSecureWrites()
+    expect(nativeStore.size).toBe(0)
+  })
+
+  it('is a no-op when the secure store is unavailable (web / iOS)', async () => {
+    availability.value = false
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    localStorage.setItem(SECRET_KEY, 'plain')
+    // Without the shim installed, behavior is the status quo: plain localStorage.
+    expect(localStorage.getItem(SECRET_KEY)).toBe('plain')
+    expect(nativeStore.size).toBe(0)
+  })
+})

--- a/src/sync/secureConfigShim.ts
+++ b/src/sync/secureConfigShim.ts
@@ -1,0 +1,135 @@
+import { isSecureStoreAvailable, secureDelete, secureGet, secureSet } from '@/native/secureStore'
+
+// Keeps credential-bearing config out of localStorage on Android (issue #210)
+// without touching any of the ~20 call sites that read it synchronously —
+// including `@glance-apps/sync`, whose engine hard-codes
+// `localStorage.getItem(...)` for its config key with no storage injection
+// point. The only way its reads can hit a secure backend is to interpose on
+// Storage itself, so that is exactly (and only) what this does:
+//
+// - `installSecureConfigShim()` patches Storage.prototype get/set/removeItem.
+//   For an allow-list of secret keys on `window.localStorage`, reads are served
+//   from an in-memory session cache and writes go to the cache plus a
+//   write-through to the native SecureStore. Every other key, and everything on
+//   sessionStorage, passes through untouched.
+// - `hydrateSecureConfig()` runs once at boot, before React renders (and
+//   therefore before the sync engine's first read): it migrates any legacy
+//   plaintext value out of real localStorage into the SecureStore (one-time,
+//   idempotent), then seeds the cache from the SecureStore.
+//
+// Known limits, deliberate: property-style access (`localStorage['k']`),
+// enumeration (`length`/`key(i)`) and `clear()` are not intercepted — no
+// consumer of these keys uses them (engine and app code use the method API
+// throughout). On non-Android platforms neither function does anything, so
+// behavior there is byte-for-byte the status quo.
+
+// Every localStorage key whose value contains a credential. The engine-owned
+// names are `${storageKeyPrefix}-cloud-sync-config` / `-db-sync-config` with
+// prefix 'lastglance' (see createEngine); they exist nowhere as importable
+// constants, so they are spelled out here.
+const SECRET_KEYS = new Set([
+  'lastglance-cloud-sync-config', // WebDAV appPassword (file sync engine)
+  'lastglance-db-sync-config', // engine-owned twin, normally empty — covered so it can never leak
+  'lastglance-vault-config', // GLANCEvault device bearer token
+  'lg_intents_config', // WebDAV password, second copy (intents transport)
+])
+
+const cache = new Map<string, string>()
+let installed = false
+
+// In-flight write-throughs, so a caller that is about to tear the page down
+// (SyncSettingsModal reloads after a config change) can wait for the native
+// side to actually have the credentials. See flushSecureWrites().
+const pending = new Set<Promise<void>>()
+
+function track(p: Promise<void>): void {
+  const guarded = p.catch(() => {
+    // Native write failed: the cache still serves this session, and the worst
+    // case on next boot is the fail-safe — the user re-enters credentials.
+  })
+  pending.add(guarded)
+  void guarded.finally(() => pending.delete(guarded))
+}
+
+export function flushSecureWrites(): Promise<void> {
+  return Promise.all([...pending]).then(() => undefined)
+}
+
+// Original Storage.prototype methods, captured at install time. Hydration uses
+// these to reach the real localStorage beneath the shim.
+let origGetItem: typeof Storage.prototype.getItem
+let origSetItem: typeof Storage.prototype.setItem
+let origRemoveItem: typeof Storage.prototype.removeItem
+
+export function installSecureConfigShim(): void {
+  if (!isSecureStoreAvailable || installed) return
+  installed = true
+
+  const proto = Storage.prototype
+  origGetItem = proto.getItem
+  origSetItem = proto.setItem
+  origRemoveItem = proto.removeItem
+
+  proto.getItem = function (key: string): string | null {
+    if (this === window.localStorage && SECRET_KEYS.has(key)) {
+      return cache.has(key) ? cache.get(key)! : null
+    }
+    return origGetItem.call(this, key)
+  }
+
+  proto.setItem = function (key: string, value: string): void {
+    if (this === window.localStorage && SECRET_KEYS.has(key)) {
+      const str = String(value)
+      cache.set(key, str)
+      track(secureSet(key, str))
+      return
+    }
+    origSetItem.call(this, key, value)
+  }
+
+  proto.removeItem = function (key: string): void {
+    if (this === window.localStorage && SECRET_KEYS.has(key)) {
+      cache.delete(key)
+      track(secureDelete(key))
+      return
+    }
+    origRemoveItem.call(this, key)
+  }
+}
+
+// Boot-time hydration. Must complete before the first render (main.tsx awaits
+// it): IntentsContext and the sync engines read these keys synchronously
+// during mount, and a miss would present as "sync not configured".
+export async function hydrateSecureConfig(): Promise<void> {
+  if (!installed) return
+  for (const key of SECRET_KEYS) {
+    try {
+      // Migrate legacy plaintext first. If a plaintext copy exists it is the
+      // newest write (pre-shim builds wrote here), so it wins over any secure
+      // copy; removal makes the migration one-time.
+      const legacy = origGetItem.call(window.localStorage, key)
+      if (legacy !== null) {
+        await secureSet(key, legacy)
+        origRemoveItem.call(window.localStorage, key)
+        cache.set(key, legacy)
+        continue
+      }
+      const value = await secureGet(key)
+      if (value !== null) cache.set(key, value)
+    } catch {
+      // SecureStore unavailable for this key — the app degrades to "not
+      // configured" for that credential rather than failing to boot.
+    }
+  }
+}
+
+// Test-only: undo the prototype patch and clear module state.
+export function uninstallSecureConfigShimForTests(): void {
+  if (!installed) return
+  Storage.prototype.getItem = origGetItem
+  Storage.prototype.setItem = origSetItem
+  Storage.prototype.removeItem = origRemoveItem
+  cache.clear()
+  pending.clear()
+  installed = false
+}


### PR DESCRIPTION
Closes #210.

## What moves where

| Secret | Was | Now (Android) |
|---|---|---|
| WebDAV `appPassword` (`lastglance-cloud-sync-config`) | localStorage plaintext | SecureStore (Keystore AES-GCM) |
| Vault bearer token (`lastglance-vault-config`) | localStorage plaintext | SecureStore |
| WebDAV password, 2nd copy (`lg_intents_config`) | localStorage plaintext | SecureStore |
| Engine's `lastglance-db-sync-config` twin | localStorage (normally empty) | SecureStore (covered so it can never leak) |
| File-sync AES key (`lastglance-crypto` → `rawKey`, **extractable raw bytes**) | IndexedDB | SecureStore, legacy record deleted after transfer |
| Vault HKDF root (`lastglance-crypto-db` → `rootBytes`) | IndexedDB | SecureStore, legacy record deleted after transfer |

## How

**Native (`SecureStorePlugin.java`):** `get`/`set`/`delete` over AES-256-GCM ciphertext in a private SharedPreferences file; the key lives in the Android Keystore (non-exportable, hardware-backed where available). Undecryptable entries — restored ciphertext on another device, invalidated key — read as absent and are dropped, so the fail-safe is re-entering credentials, exactly as the issue specifies. Not `EncryptedSharedPreferences` (deprecated); the Keystore is used directly.

**Config keys (`secureConfigShim.ts`):** `@glance-apps/sync` reads its config synchronously via a hard-coded `localStorage.getItem` — no injection point. So the shim patches `Storage.prototype` for an **allow-list of 4 keys only**: reads served from an in-memory session cache, writes go to cache + SecureStore write-through. Hydration (with one-time migration of legacy plaintext out of localStorage) completes in `main.tsx` before first render, ahead of every synchronous read. All ~20 existing call sites — engine internals, both settings modals (including the raw `getItem` at `IntegrationSettingsModal.tsx:39`), `sharedUsers` — work unchanged. Off Android the shim never installs; web/PWA and iOS behavior is byte-for-byte the status quo.

**Crypto keys (`nativeKeyHooks.ts`):** implements the `nativeGetSyncKey`/`nativeStoreSyncKey` hooks the sync package already ships (previously passed as `null`). The package's file tier and DB tier use the *same hook names*, so the two tiers get **separately bound pairs** (`CRYPTO_CONFIG` vs new `DB_CRYPTO_CONFIG`, distinct SecureStore entries) — one shared pair would cross-clobber. The hooks are either/or with IndexedDB in the package, so each getter carries its own one-time legacy-IDB migration and deletes the old extractable record after transfer.

**Race fix:** `SyncSettingsModal`'s post-save `window.location.reload()` now awaits `flushSecureWrites()` so a credential save can't be torn down mid-write-through.

## Acceptance criteria from the issue

- ✅ No credential in localStorage after migration (migrated + removed at hydrate; interposer prevents re-introduction)
- ✅ Raw key material out of IndexedDB (both extractable records migrated + deleted)
- ✅ Sync (file + vault), intents transports, encryption unlock unchanged — all reads still synchronous via the pre-hydrated cache
- ✅ Fresh restore on a new device: ciphertext undecryptable → reads absent → credential/passphrase prompt, not a cryptic failure
- ⚠️ **One scoped exception:** the intents root keys (`lastglance-intents-crypto`, `lastglance-vault-intents-crypto`) are stored as **non-extractable `CryptoKey` objects** — `exportKey` is impossible by design, so they cannot be migrated without regenerating keys and re-running intents encryption setup. Left in place as a follow-up; the browser never exposes their bytes to JS, which is a materially better resting state than the raw-bytes records this PR removes.

## Verification

- `vitest run`: 269 passed (15 new — shim passthrough/intercept/migration/no-op paths, hook round-trip/migration/tier separation/fail-safe)
- `tsc -b` clean, `eslint --max-warnings 0` clean, `vite build` (Vercel path) green
- Not run (no device here): on-device flows — configure sync → kill/relaunch → verify sync works and `localStorage` shows no `appPassword`; passphrase unlock across restart; vault tier; a legacy-data upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj)_