### PR TITLE
Gate paywall: visible dismiss control + requirement line (Play Subscriptions policy)

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-app')
     implementation project(':capacitor-filesystem')
     implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-share')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
 include ':capacitor-filesystem'
 project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "lastglance",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",
+        "@capacitor/app": "^8.1.1",
         "@capacitor/core": "^8.4.0",
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/ios": "^8.4.0",
@@ -1658,6 +1659,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.1.tgz",
+      "integrity": "sha512-xM2ZTX5jK60tFtmjsmJv+Cdj1Qsb6NcavkqmdEnCPQBeya9oKhamZJxYOnQNj1ZvcJM7sWfG6BEtSLx42pisbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/assets": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.4.0",
+    "@capacitor/app": "^8.1.1",
     "@capacitor/core": "^8.4.0",
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/ios": "^8.4.0",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -381,6 +381,7 @@
   },
   "paywall": {
     "pitch": "Behalte im Blick, wann du alles Wichtige zuletzt erledigt hast. Einmal freischalten, alle Funktionen.",
+    "requiredNotice": "Für die Nutzung von lastGLANCE ist ein Abonnement oder eine einmalige Lifetime-Freischaltung erforderlich.",
     "featureWidgets": "Startbildschirm-Widgets & Schnellkacheln",
     "featureReminders": "Erinnerungen bei überfälligen Aufgaben",
     "featureSync": "Verschlüsselte Synchronisierung zwischen Geräten",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -407,6 +407,7 @@
   },
   "paywall": {
     "pitch": "Track when you last did everything that matters. One unlock, every feature.",
+    "requiredNotice": "A subscription or one-time lifetime unlock is required to use lastGLANCE.",
     "featureWidgets": "Home-screen widgets & quick tiles",
     "featureReminders": "Overdue reminders",
     "featureSync": "Encrypted sync across devices",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -381,6 +381,7 @@
   },
   "paywall": {
     "pitch": "Controla cuándo hiciste por última vez todo lo que importa. Un desbloqueo, todas las funciones.",
+    "requiredNotice": "Para usar lastGLANCE se requiere una suscripción o un desbloqueo vitalicio de pago único.",
     "featureWidgets": "Widgets de pantalla de inicio y mosaicos rápidos",
     "featureReminders": "Recordatorios de tareas atrasadas",
     "featureSync": "Sincronización cifrada entre dispositivos",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -381,6 +381,7 @@
   },
   "paywall": {
     "pitch": "Suivez quand vous avez fait tout ce qui compte pour la dernière fois. Un déblocage, toutes les fonctions.",
+    "requiredNotice": "Un abonnement ou un déblocage à vie en un seul paiement est requis pour utiliser lastGLANCE.",
     "featureWidgets": "Widgets d'écran d'accueil et tuiles rapides",
     "featureReminders": "Rappels de tâches en retard",
     "featureSync": "Synchronisation chiffrée entre appareils",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -381,6 +381,7 @@
   },
   "paywall": {
     "pitch": "Tieni traccia di quando hai fatto l'ultima volta tutto ciò che conta. Uno sblocco, tutte le funzioni.",
+    "requiredNotice": "Per usare lastGLANCE è necessario un abbonamento o uno sblocco a vita con pagamento unico.",
     "featureWidgets": "Widget della schermata Home e riquadri rapidi",
     "featureReminders": "Promemoria per attività in ritardo",
     "featureSync": "Sincronizzazione crittografata tra dispositivi",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -381,6 +381,7 @@
   },
   "paywall": {
     "pitch": "Acompanhe quando fez pela última vez tudo o que importa. Um desbloqueio, todas as funções.",
+    "requiredNotice": "Para usar o lastGLANCE, é necessária uma assinatura ou um desbloqueio vitalício de pagamento único.",
     "featureWidgets": "Widgets do ecrã inicial e mosaicos rápidos",
     "featureReminders": "Lembretes de tarefas atrasadas",
     "featureSync": "Sincronização encriptada entre dispositivos",

--- a/src/components/PaywallModal/PaywallModal.tsx
+++ b/src/components/PaywallModal/PaywallModal.tsx
@@ -1,9 +1,20 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { App as CapacitorApp } from '@capacitor/app'
 import { X, Check, Loader, BadgeCheck, KeyRound } from 'lucide-react'
 import type { UseBillingResult } from '@glance-apps/billing/react'
 import { PRODUCT_IDS, MANAGE_SUBSCRIPTION_URL, STORE_NAME } from '@/billing/billing'
 import { useTranslation } from 'react-i18next'
+
+// Dismissing the hard gate means leaving the app — there is nothing behind it
+// to show. That is exactly what the Android back button already did (Capacitor's
+// native default: no WebView history on the gate, so back left the app). The
+// visible X (Play Subscriptions policy: no unclear/invisible dismiss buttons)
+// and the back button both route through this one handler so they can never
+// diverge. No-op off native, where exitApp is unimplemented.
+function exitGate(): void {
+  CapacitorApp.exitApp().catch(() => {})
+}
 
 interface Props {
   billing: UseBillingResult
@@ -20,6 +31,16 @@ export function PaywallModal({ billing, mode, onClose }: Props) {
   const [showCode, setShowCode] = useState(false)
   const [code, setCode] = useState('')
   const [codeError, setCodeError] = useState(false)
+
+  // While the gate is mounted, own the hardware back button/gesture explicitly.
+  // Registering a listener replaces Capacitor's native default, and the handler
+  // reimplements exactly what that default did here (leave the app) — through
+  // the same function the X calls, keeping the two behaviors identical.
+  useEffect(() => {
+    if (mode !== 'gate') return
+    const handle = CapacitorApp.addListener('backButton', exitGate)
+    return () => { void handle.then(h => h.remove()).catch(() => {}) }
+  }, [mode])
 
   async function submitCode() {
     if (!code.trim()) return
@@ -75,9 +96,22 @@ export function PaywallModal({ billing, mode, onClose }: Props) {
           <h2 className="text-2xl font-black tracking-tight text-slate-900 dark:text-slate-100">
             last<span className="italic text-green-400">GLANCE</span>
           </h2>
-          {mode === 'status' && (
+          {mode === 'status' ? (
             <button onClick={onClose} className="p-1.5 rounded-lg text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors">
               <X size={16} />
+            </button>
+          ) : (
+            /* Gate dismiss control (Play Subscriptions policy). Deliberately the
+               body-copy color, not the muted footer token — it must be obvious
+               against the card. 22px glyph; the 12px padding makes a 46px hit
+               target; negative margins keep the glyph aligned with the wordmark
+               and the card's padding edge. Same handler as the back button. */
+            <button
+              onClick={exitGate}
+              aria-label="Close"
+              className="p-3 -mt-2 -mr-3 rounded-xl text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400"
+            >
+              <X size={22} strokeWidth={2} aria-hidden="true" />
             </button>
           )}
         </div>
@@ -116,6 +150,11 @@ export function PaywallModal({ billing, mode, onClose }: Props) {
         ) : (
           <>
             <p className="text-sm text-slate-500 dark:text-slate-400 mt-2">{t('paywall.pitch')}</p>
+
+            {/* Play policy: the purchase requirement must be stated plainly on
+                the gate. Body size and the body-copy color on purpose — this is
+                not fine print. */}
+            <p className="text-sm text-slate-600 dark:text-slate-300 mt-2">{t('paywall.requiredNotice')}</p>
 
             {/* Named benefits, not just scope: App Store review rejects paywalls
                 that don't describe what the price buys (Guideline 3.1.2 —


### PR DESCRIPTION
Addresses the Google Play Subscriptions-policy citation: "unclear or invisible dismiss button" on the hard-gate paywall.

## Step 1 findings (reported before changing anything)

**a. Component:** `PaywallModal` in `src/components/PaywallModal/PaywallModal.tsx`, rendered as the hard gate from `App.tsx` (`billing.gated && !billing.isUnlocked`, `mode="gate"`).

**b. Hardware back button on the gate (before this PR):** nothing in JS at all — no `@capacitor/app` dependency, no `backButton` listener, no router/`pushState` (so no WebView history). Behavior came entirely from Capacitor's native `BridgeActivity` default: WebView can't go back → `super.onBackPressed()` → the app exits to the launcher. So back *did* exit the app; there was just no named handler to share.

**c. Color tokens** (Tailwind defaults — `tailwind.config.ts` extends colors but does not override slate):
- Body copy (feature checklist): `text-slate-600` **#475569** / dark `text-slate-300` **#cbd5e1**
- Muted/tertiary ("Payment via Google Play", explainer, footer): `text-slate-400` **#94a3b8** / dark `text-slate-500` **#64748b**
- (Tagline sits between: `text-slate-500`/`400`.)

**d. Card padding:** `p-6` → **24px top, 24px horizontal** (uniform).

## Step 2 — close control

X in the card's top-right, vertically centered on the wordmark: 22px lucide `X`, 2px stroke, **46×46px hit target** via `p-3` padding (glyph size unchanged), body-copy color `text-slate-600 dark:text-slate-300` (not the muted token), `aria-label="Close"`, `focus-visible` green ring. Negative margins park the glyph at the card's padding edge.

Since back's behavior was the un-named native default, the "same handler" requirement is implemented by giving it a name: `exitGate()` → `App.exitApp()` (new `@capacitor/app@^8.1.1` dependency, native project files regenerated via `cap sync`). The X calls it, and while the gate is mounted a `backButton` listener routes the hardware back/gesture through the identical function. Listener is removed on unmount, so back behavior everywhere else is untouched. No confirmation dialog.

## Step 3 — requirement line

Directly under the tagline, above the checklist, body size/weight in the body-copy color:

> A subscription or one-time lifetime unlock is required to use lastGLANCE.

English is verbatim; localized in de/es/fr/it/pt (`paywall.requiredNotice`).

## Step 4 — verification at 360×640dp

Screenshotted via Chromium at exactly 360×640 (light + dark, attached in session). Computed layout:

| Element | Rect | Above fold |
|---|---|---|
| Close button | 46×46 @ top 81, right edge = card padding edge; center y=104 vs wordmark center y=105 | ✅ |
| Requirement line | 14px / weight 400 / `#475569`, top 183 | ✅ |

Both visible with zero scrolling; both pricing tiers also fit above the fold.

**versionCode:** 2.0.1 → 2.0.2 ⇒ derived `versionCode` **2000200**. Nothing else on the screen touched (status-mode paywall unchanged).

## Checks

- `tsc -b`, `eslint --max-warnings 0`, `vitest run` (254 passed), `vite build` all green
- Not run here (needs device): confirming `App.exitApp()` + back-gesture behavior on real Android; recommend one pass in the `--release` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj)_