### PR TITLE
Restore hardware back button (regression from #241's @capacitor/app)

### DIFF
--- a/src/components/PaywallModal/PaywallModal.tsx
+++ b/src/components/PaywallModal/PaywallModal.tsx
@@ -1,20 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
-import { App as CapacitorApp } from '@capacitor/app'
 import { X, Check, Loader, BadgeCheck, KeyRound } from 'lucide-react'
 import type { UseBillingResult } from '@glance-apps/billing/react'
 import { PRODUCT_IDS, MANAGE_SUBSCRIPTION_URL, STORE_NAME } from '@/billing/billing'
+import { leaveApp } from '@/native/backButton'
 import { useTranslation } from 'react-i18next'
-
-// Dismissing the hard gate means leaving the app — there is nothing behind it
-// to show. That is exactly what the Android back button already did (Capacitor's
-// native default: no WebView history on the gate, so back left the app). The
-// visible X (Play Subscriptions policy: no unclear/invisible dismiss buttons)
-// and the back button both route through this one handler so they can never
-// diverge. No-op off native, where exitApp is unimplemented.
-function exitGate(): void {
-  CapacitorApp.exitApp().catch(() => {})
-}
 
 interface Props {
   billing: UseBillingResult
@@ -31,16 +21,6 @@ export function PaywallModal({ billing, mode, onClose }: Props) {
   const [showCode, setShowCode] = useState(false)
   const [code, setCode] = useState('')
   const [codeError, setCodeError] = useState(false)
-
-  // While the gate is mounted, own the hardware back button/gesture explicitly.
-  // Registering a listener replaces Capacitor's native default, and the handler
-  // reimplements exactly what that default did here (leave the app) — through
-  // the same function the X calls, keeping the two behaviors identical.
-  useEffect(() => {
-    if (mode !== 'gate') return
-    const handle = CapacitorApp.addListener('backButton', exitGate)
-    return () => { void handle.then(h => h.remove()).catch(() => {}) }
-  }, [mode])
 
   async function submitCode() {
     if (!code.trim()) return
@@ -105,9 +85,11 @@ export function PaywallModal({ billing, mode, onClose }: Props) {
                body-copy color, not the muted footer token — it must be obvious
                against the card. 22px glyph; the 12px padding makes a 46px hit
                target; negative margins keep the glyph aligned with the wordmark
-               and the card's padding edge. Same handler as the back button. */
+               and the card's padding edge. leaveApp is the same function the
+               app-wide backButton listener lands on here (the gate has no
+               WebView history), so X and back are identical by construction. */
             <button
-              onClick={exitGate}
+              onClick={leaveApp}
               aria-label="Close"
               className="p-3 -mt-2 -mr-3 rounded-xl text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400"
             >

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css'
 import './i18n'
 import App from './App'
 import { hydrateSecureConfig, installSecureConfigShim } from './sync/secureConfigShim'
+import { initHardwareBackButton } from './native/backButton'
 
 // crypto.randomUUID() is only available in secure contexts (HTTPS / localhost).
 // This polyfill covers HTTP access over a LAN IP (e.g. self-hosted Docker).
@@ -47,6 +48,10 @@ const render = () =>
 // mount. Both calls are no-ops off Android, and a hydration failure still
 // renders — the app degrades to "sync not configured", never a blank screen.
 installSecureConfigShim()
+// The @capacitor/app plugin (added for the paywall dismiss control) swallows
+// the hardware back button unless a JS listener owns it — this restores the
+// stock behavior app-wide. No-op off Android.
+initHardwareBackButton()
 hydrateSecureConfig()
   .catch(() => {})
   .then(render)

--- a/src/native/backButton.ts
+++ b/src/native/backButton.ts
@@ -1,0 +1,27 @@
+import { App as CapacitorApp } from '@capacitor/app'
+import { Capacitor } from '@capacitor/core'
+
+// Restores the hardware back button that adding @capacitor/app silently broke.
+// The plugin registers an always-enabled OnBackPressedDispatcher callback on
+// load, and its no-JS-listener branch does NOTHING when the WebView has no
+// history (AppPlugin.handleOnBackPressed) — so merely installing the plugin
+// swallowed every back press in this no-router SPA. With a listener registered,
+// the plugin hands the press to us instead; this one app-wide handler
+// reimplements what the system default did before the plugin existed:
+// WebView history → go back; otherwise → move the task to the background.
+
+// Leave the app the way the pre-@capacitor/app system default did:
+// moveTaskToBack, i.e. background the task (warm resume), not finish() it.
+// Shared by the hardware back button (below) and the paywall gate's X, so the
+// two can never diverge (Play Subscriptions-policy dismiss control).
+export function leaveApp(): void {
+  CapacitorApp.minimizeApp().catch(() => {})
+}
+
+export function initHardwareBackButton(): void {
+  if (Capacitor.getPlatform() !== 'android') return
+  void CapacitorApp.addListener('backButton', ({ canGoBack }) => {
+    if (canGoBack) window.history.back()
+    else leaveApp()
+  })
+}


### PR DESCRIPTION
Fixes the regression from #241 where the hardware back button/gesture stopped doing anything in the app.

## Root cause

Adding `@capacitor/app` changed back-button semantics *by its mere presence*. On load the plugin registers an always-enabled `OnBackPressedDispatcher` callback, and its no-JS-listener branch does nothing when the WebView has no history (`AppPlugin.java:48-59`). lastGLANCE is a no-router SPA, so `canGoBack` is always false — and because the dispatcher callback is registered, the system default (background the task) never runs. Back did nothing anywhere except the mounted gate.

## Fix

- **`src/native/backButton.ts`** — one app-wide `backButton` listener, registered at boot in `main.tsx`, reimplementing the stock default: WebView history → `history.back()`, otherwise `leaveApp()` → `App.minimizeApp()` (`moveTaskToBack`, matching the pre-plugin system default).
- **`PaywallModal`** — the gate's per-mount listener removed as redundant; the X calls the same `leaveApp()`, so the Play-policy requirement that X and back behave identically holds by construction.

Also in this PR: README version badge switched to the dynamic `github/package-json/v` endpoint (was a static URL stuck at 2.0.0).

*Post-merge note: the `@glance-apps/billing` 0.2.1 pin and the 2.1.0 version bump were committed to this branch but merged separately via #243 and #244. The critical Keystore encrypt fix found in device testing landed after this merge, via #245.*

## Checks

- `tsc -b`, `eslint --max-warnings 0`, `vitest run` (269 passed), `vite build` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj