### PR TITLE
Version 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The release bundles Play Billing 8, Keystore-backed credential storage, and the paywall dismiss changes; that is a minor release, not a patch. versionCode derives to 2010000. In-app badge, Android versionName, and the README badge all follow package.json.


Claude-Session: https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj