### PR TITLE
Fix Keystore encrypt failure that presented as wiped sync settings

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/SecureStorePlugin.java
+++ b/android/app/src/main/java/com/lastglance/app/SecureStorePlugin.java
@@ -13,7 +13,6 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
 import java.security.KeyStore;
-import java.security.SecureRandom;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
@@ -36,9 +35,8 @@ public class SecureStorePlugin extends Plugin {
     private static final String PREFS = "lastglance_secure_store";
     private static final String KEY_ALIAS = "lastglance_secure_store";
     private static final String ANDROID_KEYSTORE = "AndroidKeyStore";
-    // GCM: 12-byte IV, 128-bit tag. Stored value format is
+    // GCM with the Keystore-generated IV, 128-bit tag. Stored value format is
     // "v1:" + base64(iv) + ":" + base64(ciphertext).
-    private static final int GCM_IV_BYTES = 12;
     private static final int GCM_TAG_BITS = 128;
     private static final String FORMAT_PREFIX = "v1:";
 
@@ -111,9 +109,14 @@ public class SecureStorePlugin extends Plugin {
     private String encrypt(String plaintext) {
         try {
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-            byte[] iv = new byte[GCM_IV_BYTES];
-            new SecureRandom().nextBytes(iv);
-            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            // The Keystore must generate the IV: keys are created with
+            // randomized encryption required (the secure default), and passing
+            // a caller-provided IV at encrypt time throws
+            // InvalidAlgorithmParameterException ("Caller-provided IV not
+            // permitted") — which made every set() fail and presented as wiped
+            // sync settings in the 2.1.0 release candidate.
+            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey());
+            byte[] iv = cipher.getIV();
             byte[] ct = cipher.doFinal(plaintext.getBytes("UTF-8"));
             return FORMAT_PREFIX
                 + Base64.encodeToString(iv, Base64.NO_WRAP)

--- a/src/sync/nativeKeyHooks.test.ts
+++ b/src/sync/nativeKeyHooks.test.ts
@@ -3,11 +3,21 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { IDBFactory } from 'fake-indexeddb'
 
 const nativeStore = new Map<string, string>()
+const broken = { value: false }
 vi.mock('@/native/secureStore', () => ({
   isSecureStoreAvailable: true,
-  secureGet: vi.fn(async (key: string) => (nativeStore.has(key) ? nativeStore.get(key)! : null)),
-  secureSet: vi.fn(async (key: string, value: string) => { nativeStore.set(key, value) }),
-  secureDelete: vi.fn(async (key: string) => { nativeStore.delete(key) }),
+  secureGet: vi.fn(async (key: string) => {
+    if (broken.value) throw new Error('native failure')
+    return nativeStore.has(key) ? nativeStore.get(key)! : null
+  }),
+  secureSet: vi.fn(async (key: string, value: string) => {
+    if (broken.value) throw new Error('native failure')
+    nativeStore.set(key, value)
+  }),
+  secureDelete: vi.fn(async (key: string) => {
+    if (broken.value) throw new Error('native failure')
+    nativeStore.delete(key)
+  }),
 }))
 
 import { FILE_SYNC_KEY_HOOKS, DB_ROOT_KEY_HOOKS } from './nativeKeyHooks'
@@ -45,6 +55,7 @@ function readLegacy(dbName: string, storeName: string, id: string): Promise<unkn
 describe('nativeKeyHooks', () => {
   beforeEach(() => {
     nativeStore.clear()
+    broken.value = false
     // Fresh IndexedDB universe per test.
     globalThis.indexedDB = new IDBFactory()
   })
@@ -101,6 +112,19 @@ describe('nativeKeyHooks', () => {
     const dbRoot = JSON.parse(atob((await DB_ROOT_KEY_HOOKS.nativeGetSyncKey!())!))
     expect(file.rawKey).toEqual([1])
     expect(dbRoot.rootBytes).toEqual([2])
+  })
+
+  it('a failing native layer still returns the legacy key and keeps the record for retry', async () => {
+    // Regression companion to the 2.1.0 rc Keystore bug: a broken SecureStore
+    // must not present as a lost encryption key (passphrase re-prompt).
+    await seedLegacyDb('lastglance-crypto', 'keys', { id: 'sync-key', rawKey: [3, 1, 4], salt: [1, 5] })
+    broken.value = true
+
+    const blob = await FILE_SYNC_KEY_HOOKS.nativeGetSyncKey!()
+    expect(JSON.parse(atob(blob!))).toEqual({ rawKey: [3, 1, 4], salt: [1, 5] })
+    // Legacy record survives for the next boot's migration retry.
+    expect(await readLegacy('lastglance-crypto', 'keys', 'sync-key')).not.toBeNull()
+    expect(nativeStore.size).toBe(0)
   })
 
   it('a malformed legacy record reads as absent (fail-safe)', async () => {

--- a/src/sync/nativeKeyHooks.ts
+++ b/src/sync/nativeKeyHooks.ts
@@ -94,15 +94,26 @@ function makeHooks(
   if (!isSecureStoreAvailable) return {}
   return {
     nativeGetSyncKey: async () => {
-      const existing = await secureGet(storeKey)
-      if (existing !== null) return existing
+      try {
+        const existing = await secureGet(storeKey)
+        if (existing !== null) return existing
+      } catch {
+        // SecureStore read failed — fall through to the legacy record so a
+        // native fault degrades to pre-migration behavior, not a re-prompt.
+      }
       const record = await readLegacyRecord(legacy.dbName, legacy.storeName, legacy.id)
       if (!record) return null
       const blob = recordToBlob(record)
       if (!blob) return null
       const b64 = btoa(JSON.stringify(blob))
-      await secureSet(storeKey, b64)
-      await deleteLegacyRecord(legacy.dbName, legacy.storeName, legacy.id)
+      try {
+        await secureSet(storeKey, b64)
+        await deleteLegacyRecord(legacy.dbName, legacy.storeName, legacy.id)
+      } catch {
+        // Secure write failed: keep the legacy record and still return the
+        // key so this session works; the migration retries next boot. Never
+        // let a broken native layer present as a lost encryption key.
+      }
       return b64
     },
     nativeStoreSyncKey: (b64: string | null) => {

--- a/src/sync/secureConfigShim.test.ts
+++ b/src/sync/secureConfigShim.test.ts
@@ -1,14 +1,26 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // In-memory stand-in for the native SecureStore plugin. `available` is
-// mutable so individual tests can exercise the non-Android no-op path.
+// mutable so individual tests can exercise the non-Android no-op path, and
+// `broken` simulates a native layer whose calls all reject (the 2.1.0 rc
+// Keystore bug) to pin down the fail-open behavior.
 const nativeStore = new Map<string, string>()
 const availability = { value: true }
+const broken = { value: false }
 vi.mock('@/native/secureStore', () => ({
   get isSecureStoreAvailable() { return availability.value },
-  secureGet: vi.fn(async (key: string) => (nativeStore.has(key) ? nativeStore.get(key)! : null)),
-  secureSet: vi.fn(async (key: string, value: string) => { nativeStore.set(key, value) }),
-  secureDelete: vi.fn(async (key: string) => { nativeStore.delete(key) }),
+  secureGet: vi.fn(async (key: string) => {
+    if (broken.value) throw new Error('native failure')
+    return nativeStore.has(key) ? nativeStore.get(key)! : null
+  }),
+  secureSet: vi.fn(async (key: string, value: string) => {
+    if (broken.value) throw new Error('native failure')
+    nativeStore.set(key, value)
+  }),
+  secureDelete: vi.fn(async (key: string) => {
+    if (broken.value) throw new Error('native failure')
+    nativeStore.delete(key)
+  }),
 }))
 
 // The vitest environment is node: no Storage / window / localStorage. The shim
@@ -38,6 +50,7 @@ describe('secureConfigShim', () => {
     g.window = globalThis
     nativeStore.clear()
     availability.value = true
+    broken.value = false
     vi.resetModules()
     shim = await import('./secureConfigShim')
   })
@@ -110,6 +123,23 @@ describe('secureConfigShim', () => {
     sessionStorage.setItem(SECRET_KEY, 'session-value')
     expect(sessionStorage.getItem(SECRET_KEY)).toBe('session-value')
     await shim.flushSecureWrites()
+    expect(nativeStore.size).toBe(0)
+  })
+
+  it('a failing native layer still serves legacy settings and keeps the plaintext for retry', async () => {
+    // Regression: the 2.1.0 rc Keystore bug made every secureSet reject, and
+    // hydration left the cache empty while the shim shadowed the intact
+    // plaintext — presenting as wiped sync settings.
+    const legacy = JSON.stringify({ enabled: true, appPassword: 'hunter2' })
+    localStorage.setItem(SECRET_KEY, legacy)
+    broken.value = true
+    shim.installSecureConfigShim()
+    await shim.hydrateSecureConfig()
+    // Settings must still be readable through the shim...
+    expect(localStorage.getItem(SECRET_KEY)).toBe(legacy)
+    // ...and the plaintext must survive for the next boot's retry.
+    shim.uninstallSecureConfigShimForTests()
+    expect(localStorage.getItem(SECRET_KEY)).toBe(legacy)
     expect(nativeStore.size).toBe(0)
   })
 

--- a/src/sync/secureConfigShim.ts
+++ b/src/sync/secureConfigShim.ts
@@ -106,19 +106,25 @@ export async function hydrateSecureConfig(): Promise<void> {
     try {
       // Migrate legacy plaintext first. If a plaintext copy exists it is the
       // newest write (pre-shim builds wrote here), so it wins over any secure
-      // copy; removal makes the migration one-time.
+      // copy; removal makes the migration one-time. The cache is seeded BEFORE
+      // the secure write and the plaintext is removed only AFTER it succeeds:
+      // a native failure must present as "still works like before, migrates
+      // next boot", never as wiped settings (the 2.1.0 rc bug — a Keystore
+      // rejection made every write fail, and the shim shadowed the intact
+      // plaintext with an empty cache).
       const legacy = origGetItem.call(window.localStorage, key)
       if (legacy !== null) {
+        cache.set(key, legacy)
         await secureSet(key, legacy)
         origRemoveItem.call(window.localStorage, key)
-        cache.set(key, legacy)
         continue
       }
       const value = await secureGet(key)
       if (value !== null) cache.set(key, value)
     } catch {
-      // SecureStore unavailable for this key — the app degrades to "not
-      // configured" for that credential rather than failing to boot.
+      // SecureStore unavailable for this key. With legacy plaintext present
+      // the cache is already seeded above, so the app behaves exactly as
+      // pre-migration; without it there is genuinely nothing to serve.
     }
   }
 }


### PR DESCRIPTION
Fixes the "Cloud Sync settings wiped" report from device testing of the 2.1.0 release candidate. **Must land before the 2.1.0 release is cut.**

## Root cause

Every `SecureStore.set()` failed on Android. `encrypt()` passed a caller-generated IV to `cipher.init()`, but Keystore keys are created with randomized-encryption-required (the secure default, which this plugin correctly never opts out of), and for such keys Android rejects caller-provided IVs: `InvalidAlgorithmParameterException` ("Caller-provided IV not permitted") on every call.

So the #240 migration never succeeded — and the config shim, finding nothing in the secure store, served empty values while shadowing the still-intact plaintext. Sync, vault, and intents settings all read as empty. A shadowing bug presenting as data loss.

**No data was lost.** Plaintext removal and legacy-record deletion only run after a successful secure write, which never happened. Affected devices self-heal on the next launch after this fix installs: settings reappear, then actually migrate. (Values re-entered during a broken session were shadow-layer writes and are gone; the pre-update originals return.) Web and iOS were never affected — the shim and hooks are hard-gated to Android.

## Fix

- **Native (`SecureStorePlugin.java`):** the Keystore generates the IV — `cipher.init(ENCRYPT_MODE, key)` then `cipher.getIV()` — the canonical pattern. Stored `v1:iv:ct` format unchanged.

## Hardening: native faults can no longer present as data loss

- `hydrateSecureConfig` seeds its cache from legacy plaintext **before** the secure write and removes the plaintext only after success — a broken native layer now degrades to exact pre-migration behavior.
- `nativeGetSyncKey` returns the migrated key blob even when the secure write fails (keeping the legacy record for retry) — encryption unlock keeps working instead of re-prompting for the passphrase.
- Two regression tests pin the fail-open behavior for both paths.

## Checks

- `tsc -b`, `eslint --max-warnings 0`, `vitest run` (**271 passed**, 2 new), `vite build` all green
- No Android SDK in this environment, so the Java change is not compile-checked here; it is the standard documented Keystore pattern
- Device pass before release: settings reappear on the affected device → **survive a restart** (first-ever real-hardware proof of the decrypt path on freshly written ciphertext) → back-button and billing smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPFhHzd9YNDgm8ZAnAZWpj)_