### PR TITLE
Take @glance-apps/sync 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@capacitor/status-bar": "^8.0.2",
         "@glance-apps/billing": "0.2.1",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.6.1",
+        "@glance-apps/sync": "1.10.0",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -2884,9 +2884,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.6.1.tgz",
-      "integrity": "sha512-cRdLWkX7AreC4h0Gz0lnxum/Nn/uq4OO+Jcjjxq8e4uhT5c3Z25kBDXXbA5VxLw5HGtHYBQanTy4QuYyTzBspw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.10.0.tgz",
+      "integrity": "sha512-/OCQZPm/dsv6OmOMdXj8gjmbKR9F/eXaJdr/8BR7Rs04ScxaSdw1ozSu5cejfLyziMHaelcBecaeKVK8wvmF8A==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@capacitor/status-bar": "^8.0.2",
     "@glance-apps/billing": "0.2.1",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.6.1",
+    "@glance-apps/sync": "1.10.0",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -281,6 +281,10 @@
   },
   "sync": {
     "title": "Cloud-Sync",
+    "errors": {
+      "CREDENTIAL_INVALID": "Der Sync-Server akzeptiert den Sync-Zugriff dieses Geräts nicht mehr. Deine Änderungen sind auf diesem Gerät gespeichert. Bitte die Person, die deinen Sync-Server betreibt, den Zugriff für dieses Gerät wiederherzustellen.",
+      "QUOTA_EXCEEDED": "Der Sync-Server hat das Limit für dieses Konto erreicht. Deine Änderungen sind auf diesem Gerät gespeichert und die Synchronisierung versucht es automatisch erneut. Bitte die Person, die deinen Sync-Server betreibt, das Limit zu erhöhen."
+    },
     "syncHalted": "Sync unterbrochen",
     "haltedDescription": "Ein kritischer Fehler ist aufgetreten. Problem beheben und löschen, um erneut zu versuchen.",
     "clearHalt": "Löschen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -302,6 +302,8 @@
       "ROW_DECRYPT_FAILED": "Some synced data couldn't be decrypted. Check your sync passphrase.",
       "VERIFIER_UNSUPPORTED": "Your sync server needs to be updated to support key verification.",
       "ACCOUNT_ID_REQUIRED": "Finishing sync setup — try again in a moment.",
+      "CREDENTIAL_INVALID": "The sync server no longer accepts this device's sync access. Your changes are saved on this device. Ask whoever runs your sync server to restore access for this device.",
+      "QUOTA_EXCEEDED": "The sync server has reached its limit for this account. Your changes are saved on this device and syncing will retry automatically. Ask whoever runs your sync server to raise the limit.",
       "passphraseNeeded": "Enter your sync passphrase to continue.",
       "vaultUnreachable": "Couldn't reach GLANCEvault: {{detail}}",
       "requestFailed": "Sync request failed. Please try again.",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -281,6 +281,10 @@
   },
   "sync": {
     "title": "Sincronización en la nube",
+    "errors": {
+      "CREDENTIAL_INVALID": "El servidor de sincronización ya no acepta el acceso de este dispositivo. Tus cambios están guardados en este dispositivo. Pide a quien administra tu servidor de sincronización que restaure el acceso para este dispositivo.",
+      "QUOTA_EXCEEDED": "El servidor de sincronización ha alcanzado el límite de esta cuenta. Tus cambios están guardados en este dispositivo y la sincronización se reintentará automáticamente. Pide a quien administra tu servidor de sincronización que aumente el límite."
+    },
     "syncHalted": "Sincronización detenida",
     "haltedDescription": "Ocurrió un error crítico. Resuelve el problema y borra para reintentar.",
     "clearHalt": "Borrar",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -281,6 +281,10 @@
   },
   "sync": {
     "title": "Sync cloud",
+    "errors": {
+      "CREDENTIAL_INVALID": "Le serveur de synchronisation n'accepte plus l'accès de cet appareil. Vos modifications sont enregistrées sur cet appareil. Demandez à la personne qui gère votre serveur de synchronisation de rétablir l'accès pour cet appareil.",
+      "QUOTA_EXCEEDED": "Le serveur de synchronisation a atteint la limite de ce compte. Vos modifications sont enregistrées sur cet appareil et la synchronisation réessaiera automatiquement. Demandez à la personne qui gère votre serveur de synchronisation d'augmenter la limite."
+    },
     "syncHalted": "Sync interrompue",
     "haltedDescription": "Une erreur critique s'est produite. Résolvez le problème puis cliquez sur Effacer pour réessayer.",
     "clearHalt": "Effacer",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -281,6 +281,10 @@
   },
   "sync": {
     "title": "Sincronizzazione cloud",
+    "errors": {
+      "CREDENTIAL_INVALID": "Il server di sincronizzazione non accetta più l'accesso di questo dispositivo. Le tue modifiche sono salvate su questo dispositivo. Chiedi a chi gestisce il tuo server di sincronizzazione di ripristinare l'accesso per questo dispositivo.",
+      "QUOTA_EXCEEDED": "Il server di sincronizzazione ha raggiunto il limite di questo account. Le tue modifiche sono salvate su questo dispositivo e la sincronizzazione riproverà automaticamente. Chiedi a chi gestisce il tuo server di sincronizzazione di aumentare il limite."
+    },
     "syncHalted": "Sincronizzazione interrotta",
     "haltedDescription": "Si è verificato un errore critico. Risolvi il problema e cancella per riprovare.",
     "clearHalt": "Cancella",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -281,6 +281,10 @@
   },
   "sync": {
     "title": "Sincronização na nuvem",
+    "errors": {
+      "CREDENTIAL_INVALID": "O servidor de sincronização já não aceita o acesso deste dispositivo. As suas alterações estão guardadas neste dispositivo. Peça a quem gere o seu servidor de sincronização para restaurar o acesso deste dispositivo.",
+      "QUOTA_EXCEEDED": "O servidor de sincronização atingiu o limite desta conta. As suas alterações estão guardadas neste dispositivo e a sincronização será repetida automaticamente. Peça a quem gere o seu servidor de sincronização para aumentar o limite."
+    },
     "syncHalted": "Sincronização interrompida",
     "haltedDescription": "Ocorreu um erro crítico. Resolva o problema e limpe para tentar novamente.",
     "clearHalt": "Limpar",


### PR DESCRIPTION
Bumps `@glance-apps/sync` from 1.6.1 to 1.10.0 and adds the two new locale keys. Nothing else changed: no app code, no tests. The four intermediate releases touch only the DB (GLANCEvault) tier; `engine.js`, `providers.js`, `crypto.js`, `autoBackup.js`, and `merge.js` are byte-identical between 1.6.1 and 1.10.0 (verified by checksum), so the file/WebDAV tier is untouched by construction.

## The four questions

**1. Does every sync trigger go through `dbSyncCycle`?** Yes. All five app-side triggers route through it: mount / visibility / 5-minute interval (`runDbSync`, `App.tsx`), the post-write debounced sync (`dirtyTracker.ts`), the post-passphrase sync (`App.tsx`), and manual "Sync now" (`SyncSettingsModal.tsx`). `pushDirtyRows` and `pullRemoteChanges` are called directly in exactly one place, `dbEngineMultiDevice.test.ts`, deliberately, to prove the 1.4.0 cursor-split contract, which 1.10.0 preserves; that test passes unchanged. `updateDeviceCursor` is never called by app code. Backoff, quota suppression, and the credential halt therefore all arrive with zero code changes.

**2. Cycle-result reads and side-effect inference.** Two sites, both confirmed compatible. (a) `App.tsx` reads `res?.skipped ?? 0` for the durable quarantine badge: a suppressed cycle returns `skipped: 0`, which zeroes the badge, but 1.6.1's failure path already returned `{applied: 0, skipped: 0}`, so any non-clean cycle has always zeroed it; semantics unchanged. (b) `SyncSettingsModal` infers manual-sync success from `getLastSynced()` advancing: under 1.10.0 `lastSynced` advances only on a cycle with no failed and no skipped half, so the inference is strictly more truthful than before. A manual sync during a backoff window reports error, which is correct: no sync happened. No other code reads any cycle-result field.

**3. Tests.** None affected, and none modified; that no test needed to change is the strongest evidence this was a pure bump. The upstream concern (mock `vaultClient` without a `device()` method now warns per cycle) does not apply here: the only test constructing the engine with a mock client (`dbEngineMultiDevice.test.ts`) already implements `device()` and passes explicit `deviceId`s. The `dirtyTracker` tests use plain fake objects and never construct a real engine; `dbEngine.test.ts` constructs a real engine but never runs a cycle, and its localStorage shim satisfies 1.8.0's construction-time device-id persistence. Full suite: 27 files, 271 tests, green on 1.6.1 and green on 1.10.0 with zero edits; `tsc -b` and `eslint --max-warnings 0` both clean.

**4. Anything else?** Only the findings below. One benign coincidence worth recording: the app's device-id key (`lastglance-device-id`, `src/sync/deviceId.ts`) is byte-identical to the package's new `{prefix}-device-id` fallback key. The app always passes `deviceId` explicitly so the fallback never runs; if it ever did, it would read the same id.

## Locale wording

`sync.errors.QUOTA_EXCEEDED` (en): *"The sync server has reached its limit for this account. Your changes are saved on this device and syncing will retry automatically. Ask whoever runs your sync server to raise the limit."*

`sync.errors.CREDENTIAL_INVALID` (en): *"The sync server no longer accepts this device's sync access. Your changes are saved on this device. Ask whoever runs your sync server to restore access for this device."*

Rationale, including the deliberate choices:

- Neither message implies the user can free space by deleting things; on a self-hosted vault, deletes leave tombstones and reclaim is an operator action. Both point at the server operator and reassure that local data is safe and usable.
- The quota message omits the `{quota, limit, used, requested}` numbers. `syncErrorText` passes no interpolation values, the descriptor lives only in the cycle result, and numbers help someone who can act on them; nobody here can. Plumbing the descriptor through would be new UI state for marginal value.
- The quota message avoids the word "storage": the only quota dimension reachable from this package is `rows` (blobs and intents never route through it), and "storage limit" would imply bytes.
- The credential message avoids "password" and "passphrase", which would send users to the passphrase prompt, the wrong fix. It is unreachable under today's shared-token auth and becomes reachable only if a server is switched to per-account mode, so it is worded to read sensibly to someone who has never heard of per-account auth.
- Translations follow each file's existing register: de informal (du), fr formal (vous), es/it informal (tú/tu), pt European ("o seu").

## Correction found during review: `sync.errors.*` was English-only

The premise "without these keys the codes render the engine's raw English message" was wrong in one detail: all 16 existing codes reach non-English users through i18next's `fallbackLng: 'en'`, as English UI text rather than raw engine text (raw text renders only when no language has the key). The two keys added here are therefore the only genuinely translated codes. **Outstanding work, deliberately not done here:** backfilling translations for the other 14 codes in de/es/fr/it/pt. It belongs in its own PR so the translation sweep and the dependency bump stay independently reviewable and revertible.

## Finding: backoff visibility gap (out of scope here; applies to lifeGLANCE too)

Wider than the earlier "manual sync shows a generic message" framing. The engine fires its usual `onError(null)` reset at the start of every cycle, including suppressed ones, and quiet (transport/auth) backoff windows deliberately do not re-surface their error afterwards. So an app that stores the last `onError` message, as lastGLANCE's `vaultSyncError` state does, sees its standing error text *cleared* on the first suppressed cycle: a user in a transport backoff sees **no error at all** rather than a stale one, and a manual sync during the window falls through to the generic `sync.syncFailed`. Quota windows and the credential halt are exceptions; both re-surface every cycle and stay visible.

This is the package's documented, intended contract: treat `onError` as an event stream, not a status store, and render standing backoff from `getBackoffState()` (`reason` + `until` gives "retrying in Xs"). For lifeGLANCE, when its `onError` gets wired: do not store the last message as standing status; render standing state from `getBackoffState()`, or accept the quiet-window blankness knowingly. Not built here per scope.

## Test changes

None. See question 3.

## Runtime verification

Performed by driving the real 1.10.0 engine (the exact bits in `node_modules`, constructed with the same config shape as `createDbEngine`) over real HTTP against a local stub GLANCEvault implementing the documented wire protocol, with scripted failure injection, a request log, and a virtual clock so the escalation is observable deterministically. The harness replicates the app's exact read sites: `App.tsx`'s `res?.skipped ?? 0` and `SyncSettingsModal`'s before/after `getLastSynced()` comparison.

**1. Normal sync, unchanged:**

```
t+0s cycle -> applied=1 skipped=0 lastSynced=2026-08-02T04:52:51.860Z
requests: GET /sync/lastglance/__glance_keycheck 404 | POST batch 200 | POST batch 200 | GET list 200 | POST device 200
```

**2. Persistent failure backs off (server returns 500 on everything; app polls every 10 virtual seconds):**

```
time     HTTP reqs  result flags                                                            backoff push/pull (s remaining)
t+   0s   3         pushFailed=true  pushSkipped=false pullFailed=true  pullSkipped=false   30/30  [transport]
t+  10s   0         pushFailed=false pushSkipped=true  pullFailed=false pullSkipped=true    20/20  [transport]
t+  20s   0         pushFailed=false pushSkipped=true  pullFailed=false pullSkipped=true    10/10  [transport]
t+  30s   3         pushFailed=true  pushSkipped=false pullFailed=true  pullSkipped=false   60/60  [transport]
t+  90s   3         pushFailed=true  pushSkipped=false pullFailed=true  pullSkipped=false   120/120 [transport]
t+ 210s   3         pushFailed=true  pushSkipped=false pullFailed=true  pullSkipped=false   240/240 [transport]
t+ 450s   3         pushFailed=true  pushSkipped=false pullFailed=true  pullSkipped=false   480/300 [transport]
t+ 750s   2         ...                                                                     180/300
t+ 930s   1         ...                                                                     900/120
-> 200 polled cycles over 2000s virtual; only the probe cycles above touched the network
   (27 failed HTTP requests total). 1.6.1 would have sent requests on every one of the ~200 cycles.
```

The 30 -> 60 -> 120 -> 240 -> 480 -> 900s escalation is visible, the pull caps at 300s and the push at 900s as specified, and the two directions then probe on independent schedules (the 2- and 1-request rows).

**3. Automatic recovery, no restart, no user action:** with the server healthy again mid-window, the pull direction resumed at its next window expiry while the push waited out its own 900s window, then pushed the retained dirty row on its first probe. `server now holds cat-2: true`; `backoff state cleared: push.until=0 pull.until=0`. The dirty row survived the entire failure window; backoff changed when it was retried, never whether.

**4. Skipped indicator:** an undecryptable remote row reports `res.skipped=1`, App indicator `1`, `onRowsSkipped={"count":1,"ids":["evil-row"]}`; a suppressed cycle reports `res.skipped=0`, App indicator `0`, with `pullSkipped=true`.

**5. Manual sync truthfulness (modal logic verbatim):** during an open backoff window it reports `'error'` (`lastSynced` did not advance; no sync happened). After recovery it reports `'ok'`.

**6. Locale rendering:** both keys rendered through the app's exact mechanism (`t('sync.errors.<code>', { defaultValue: raw })`) in French and German, with the unmapped-code fallback to the raw engine message confirmed still working.

**7. Full existing suite:** 27 files, 271 tests, green, unmodified.

## Regression guards

- Backoff legitimately stops requests: nothing in the app or tests treats an absent request as a failure (verified by the trigger audit in question 1 and the green unmodified suite).
- `lastSynced` not advancing on a failed or suppressed half: the only consumer is the modal's before/after comparison, which this makes more truthful, demonstrated in item 5.
- File tier untouched: byte-identical modules, checksummed.
- Existing users see no change in normal operation: the changelog's healthy-client guarantee, confirmed by item 1's request pattern matching the 1.6.1 shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_