### PR TITLE
Retract stale overdue toasts when a synced completion lands

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -8,6 +8,12 @@ export interface ToastOptions {
   body?: string
   type?: 'default' | 'success' | 'warning'
   duration?: number
+  // Identity of the chore an overdue toast is about, when there is one. Warning
+  // toasts persist until acted on, but the fact they announce can go stale: a
+  // completion made on another device (or in dayGLANCE) lands via sync/intents
+  // AFTER the toast fired from the pre-sync local read. dismissWhere uses this
+  // to retract a toast whose chore is no longer overdue.
+  choreId?: number
   onAction?: () => Promise<void> | void
   onDetails?: () => void
   onSendToDayGlance?: () => Promise<boolean>
@@ -15,10 +21,16 @@ export interface ToastOptions {
 
 interface ToastItem extends ToastOptions {
   id: string
+  // Set by dismissWhere; the card notices and runs its normal exit animation,
+  // so a programmatic retraction looks the same as a user dismissal.
+  exiting?: boolean
 }
 
 interface ToastContextValue {
   showToast: (opts: ToastOptions) => void
+  // Retract every visible toast matching the predicate (with the exit
+  // animation). Used by the overdue-toast reconciler in useNotifications.
+  dismissWhere: (pred: (toast: ToastOptions) => boolean) => void
 }
 
 const ToastContext = createContext<ToastContextValue | null>(null)
@@ -128,6 +140,11 @@ function ToastCard({ toast, onDismiss }: { toast: ToastItem; onDismiss: () => vo
     return () => clearTimeout(timer)
   }, [duration, exit])
 
+  // Programmatic retraction (dismissWhere): animate out like a user dismissal.
+  useEffect(() => {
+    if (toast.exiting) exit()
+  }, [toast.exiting, exit])
+
   const Icon = toast.type === 'success' ? Check : Bell
   const iconColor =
     toast.type === 'success' ? 'text-green-400' :
@@ -175,12 +192,18 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     })
   }, [])
 
+  // Mark matches as exiting rather than removing them, so each card runs its
+  // exit animation and then removes itself through the normal dismiss path.
+  const dismissWhere = useCallback((pred: (toast: ToastOptions) => boolean) => {
+    setToasts(prev => prev.map(t => (pred(t) && !t.exiting ? { ...t, exiting: true } : t)))
+  }, [])
+
   function dismiss(id: string) {
     setToasts(prev => prev.filter(t => t.id !== id))
   }
 
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext.Provider value={{ showToast, dismissWhere }}>
       {children}
       {createPortal(
         <div className="fixed z-[60] flex flex-col gap-2 items-end bottom-20 right-4 min-[1060px]:bottom-6 min-[1060px]:right-6">

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -7,10 +7,51 @@ import { useIntents } from '@/intents/IntentsContext'
 import { emitCreateIntent } from '@/intents/emitter'
 import { getMultiUserEnabled, getMeUserSyncId } from '@/multiuser/settings'
 import { ownedByMe } from '@/utils/choreFilter'
+import { isPastCadence } from '@/utils/cadence'
+import type { ChoreWithLastCompletion } from '@/types'
 import dayjs from 'dayjs'
 
 const STORAGE_KEY = (choreId: number) => `lg_notified_${choreId}`
 const AUTO_SCHED_KEY = (choreId: number) => `lg_autosched_${choreId}`
+
+// The overdue checks read the LOCAL DB, which on launch/foreground predates the
+// sync and intents deliveries kicked off at the same moment — a chore completed
+// on another device (or in dayGLANCE) still reads as overdue for a few seconds.
+// Two mitigations, matched to what each mistake costs:
+//
+//  - The toast is retractable, so it fires immediately and a reconciler
+//    dismisses it if an arriving completion makes it stale (see the second
+//    effect below). Applies from any lg:chore-logged/lg:sync-applied source:
+//    both sync tiers, both intents pollers, and local completions.
+//  - The dayGLANCE auto-schedule emit is durable and CANNOT be recalled, so it
+//    instead waits out a grace period and re-reads fresh rows before deciding.
+//    A settle signal would be nicer than a delay, but "sync is done" has no
+//    single definition here — completions arrive via the file tier, the vault
+//    tier, or either intents poller, each optional, and (since sync 1.10.0) a
+//    cycle may legitimately be suppressed by backoff — so the honest gate is a
+//    delay that comfortably covers a normal launch sync, then the freshest
+//    data available. Nothing user-visible waits on it, and the once-per-day
+//    marker means the delay is imperceptible.
+const RECONCILE_DEBOUNCE_MS = 400
+const AUTO_SCHED_SYNC_GRACE_MS = 15_000
+
+// Chores the current user acts on: everything, or in multi-user mode only
+// chores owned by "Me" — shared (unassigned) or assigned to me, and not inside
+// a category assigned to someone else. Mirrors the "Mine" view filter
+// (filterCategoryData) so we don't surface (or auto-schedule) another user's
+// chores.
+async function candidateChores(): Promise<ChoreWithLastCompletion[]> {
+  const categories = await getCategories()
+  const allChores = (await Promise.all(categories.map(c => getChoresForCategory(c.id)))).flat()
+  const meId = getMeUserSyncId()
+  if (!getMultiUserEnabled() || !meId) return allChores
+  const categoryById = new Map(categories.map(c => [c.id, c]))
+  return allChores.filter(chore => {
+    const category = categoryById.get(chore.category_id)
+    return ownedByMe(category?.assigned_user_sync_ids ?? [], meId) &&
+      ownedByMe(chore.assigned_user_sync_ids ?? [], meId)
+  })
+}
 
 async function fireBrowserNotification(title: string, body: string) {
   if (Notification.permission !== 'granted') return
@@ -50,7 +91,7 @@ export async function requestNotificationPermission(): Promise<NotificationPermi
 }
 
 export function useNotifications() {
-  const { showToast } = useToast()
+  const { showToast, dismissWhere } = useToast()
   // Ref so the async checkAndNotify closure always sees the latest showToast
   const showToastRef = useRef<(opts: ToastOptions) => void>(showToast)
   useEffect(() => { showToastRef.current = showToast }, [showToast])
@@ -60,32 +101,38 @@ export function useNotifications() {
   useEffect(() => { isConfiguredRef.current = isConfigured }, [isConfigured])
 
   useEffect(() => {
-    async function checkAndNotify() {
+    // Trailing-edge: each trigger restarts the grace window, and the evaluation
+    // re-reads the DB after it, so it always runs on the freshest rows.
+    let autoSchedTimer: ReturnType<typeof setTimeout> | null = null
+
+    async function runAutoSchedule() {
       const today = dayjs().format('YYYY-MM-DD')
-      const categories = await getCategories()
-      const allChores = (await Promise.all(categories.map(c => getChoresForCategory(c.id)))).flat()
-
-      // In multi-user mode, only act on chores owned by "Me" — shared
-      // (unassigned) or assigned to me, and not inside a category assigned to
-      // someone else. Mirrors the "Mine" view filter (filterCategoryData) so we
-      // don't surface (or auto-schedule) another user's chores.
-      const meId = getMeUserSyncId()
-      const filterByMe = getMultiUserEnabled() && !!meId
-      const categoryById = new Map(categories.map(c => [c.id, c]))
-
-      for (const chore of allChores) {
-        if (filterByMe) {
-          const category = categoryById.get(chore.category_id)
-          if (!ownedByMe(category?.assigned_user_sync_ids ?? [], meId!) ||
-              !ownedByMe(chore.assigned_user_sync_ids ?? [], meId!)) {
-            continue
+      for (const chore of await candidateChores()) {
+        // Auto-schedule: emit at most once per day when overdue
+        if (
+          chore.auto_schedule_to_dayglance &&
+          isConfiguredRef.current &&
+          isPastCadence(chore.target_cadence_days, chore.elapsed_days)
+        ) {
+          if (localStorage.getItem(AUTO_SCHED_KEY(chore.id!)) !== today) {
+            // Write the "sent today" marker ONLY after a durable enqueue. The old
+            // order wrote it BEFORE the send, so a failed send was both lost and
+            // suppressed for the rest of the day. Enqueue is durable, so once it
+            // resolves the intent will be delivered (retried as needed); a failed
+            // enqueue leaves the marker unset so the next pass retries.
+            const queued = await emitCreateIntent(chore).catch(() => false)
+            if (queued) localStorage.setItem(AUTO_SCHED_KEY(chore.id!), today)
           }
         }
+      }
+    }
 
+    async function checkAndNotify() {
+      const today = dayjs().format('YYYY-MM-DD')
+
+      for (const chore of await candidateChores()) {
         const isOverdue = chore.notify_when_overdue &&
-          chore.target_cadence_days &&
-          chore.elapsed_days !== null &&
-          chore.elapsed_days >= chore.target_cadence_days
+          isPastCadence(chore.target_cadence_days, chore.elapsed_days)
 
         if (isOverdue) {
           if (localStorage.getItem(STORAGE_KEY(chore.id!)) !== today) {
@@ -100,6 +147,10 @@ export function useNotifications() {
                 title: chore.name,
                 body,
                 type: 'warning',
+                // Lets the reconciler retract this toast if a completion for
+                // the chore lands after the fact (synced from another device,
+                // or made in dayGLANCE).
+                choreId,
                 onAction: async () => {
                   await logCompletion(choreId, { completedByUserSyncId: getMeUserSyncId() })
                   window.dispatchEvent(new CustomEvent('lg:chore-logged'))
@@ -122,26 +173,15 @@ export function useNotifications() {
             localStorage.setItem(STORAGE_KEY(chore.id!), today)
           }
         }
-
-        // Auto-schedule: emit at most once per day when overdue
-        if (
-          chore.auto_schedule_to_dayglance &&
-          isConfiguredRef.current &&
-          chore.target_cadence_days &&
-          chore.elapsed_days !== null &&
-          chore.elapsed_days >= chore.target_cadence_days
-        ) {
-          if (localStorage.getItem(AUTO_SCHED_KEY(chore.id!)) !== today) {
-            // Write the "sent today" marker ONLY after a durable enqueue. The old
-            // order wrote it BEFORE the send, so a failed send was both lost and
-            // suppressed for the rest of the day. Enqueue is durable, so once it
-            // resolves the intent will be delivered (retried as needed); a failed
-            // enqueue leaves the marker unset so the next pass retries.
-            const queued = await emitCreateIntent(chore).catch(() => false)
-            if (queued) localStorage.setItem(AUTO_SCHED_KEY(chore.id!), today)
-          }
-        }
       }
+
+      // The irreversible half runs after the sync grace, on a fresh read (see
+      // the constants above for why this is a delay and not a settle signal).
+      if (autoSchedTimer) clearTimeout(autoSchedTimer)
+      autoSchedTimer = setTimeout(() => {
+        autoSchedTimer = null
+        runAutoSchedule().catch(() => {/* next trigger retries */})
+      }, AUTO_SCHED_SYNC_GRACE_MS)
     }
 
     checkAndNotify()
@@ -151,6 +191,45 @@ export function useNotifications() {
     return () => {
       clearInterval(interval)
       document.removeEventListener('visibilitychange', onVisibilityChange)
+      if (autoSchedTimer) clearTimeout(autoSchedTimer)
     }
   }, [])
+
+  // Reconcile visible overdue toasts against reality whenever a completion
+  // lands. Every path that writes a completion into Dexie dispatches
+  // lg:chore-logged (both sync tiers, both intents pollers, the native pending
+  // path, and local logging), so this is the complete "data changed" signal.
+  // The vault tier fires per applied row, so a pull produces a burst — debounce
+  // and re-check once. A chore that vanished entirely (remote delete) also
+  // leaves the overdue set, which retracts its toast too.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    async function reconcile() {
+      const categories = await getCategories()
+      const chores = (await Promise.all(categories.map(c => getChoresForCategory(c.id)))).flat()
+      const stillOverdue = new Set(
+        chores
+          .filter(c => isPastCadence(c.target_cadence_days, c.elapsed_days))
+          .map(c => c.id!),
+      )
+      dismissWhere(t => t.choreId != null && !stillOverdue.has(t.choreId))
+    }
+
+    function scheduleReconcile() {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        reconcile().catch(() => {/* transient read failure; next event retries */})
+      }, RECONCILE_DEBOUNCE_MS)
+    }
+
+    window.addEventListener('lg:chore-logged', scheduleReconcile)
+    window.addEventListener('lg:sync-applied', scheduleReconcile)
+    return () => {
+      window.removeEventListener('lg:chore-logged', scheduleReconcile)
+      window.removeEventListener('lg:sync-applied', scheduleReconcile)
+      if (timer) clearTimeout(timer)
+    }
+  }, [dismissWhere])
 }

--- a/src/utils/cadence.test.ts
+++ b/src/utils/cadence.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { isPastCadence } from './cadence'
+
+// The single overdue definition shared by the overdue toast, the toast
+// reconciler, and the dayGLANCE auto-schedule. The null/undefined cases encode
+// real states: no cadence configured, and never-completed (elapsed null) —
+// neither may ever count as overdue, or a fresh chore would toast on creation.
+describe('isPastCadence', () => {
+  it('is false without a cadence', () => {
+    expect(isPastCadence(null, 10)).toBe(false)
+    expect(isPastCadence(undefined, 10)).toBe(false)
+    expect(isPastCadence(0, 10)).toBe(false)
+  })
+
+  it('is false for a never-completed chore (elapsed null)', () => {
+    expect(isPastCadence(7, null)).toBe(false)
+    expect(isPastCadence(7, undefined)).toBe(false)
+  })
+
+  it('is false while within cadence', () => {
+    expect(isPastCadence(7, 0)).toBe(false)
+    expect(isPastCadence(7, 6.9)).toBe(false)
+  })
+
+  it('is true at and past the cadence boundary', () => {
+    expect(isPastCadence(7, 7)).toBe(true)
+    expect(isPastCadence(7, 30)).toBe(true)
+    expect(isPastCadence(1, 1)).toBe(true)
+  })
+})

--- a/src/utils/cadence.ts
+++ b/src/utils/cadence.ts
@@ -29,6 +29,23 @@ export function needsAttention(targetCadenceDays: number | null, elapsedDays: nu
 }
 
 /**
+ * True when a chore has aged past its full cadence — the strict "overdue"
+ * threshold (ratio >= 1), as opposed to needsAttention's earlier amber zone.
+ * Chores without a cadence, or never completed (elapsed null), never qualify.
+ *
+ * This is the single overdue definition shared by the overdue toast, the
+ * toast reconciler that dismisses it once a completion lands, and the
+ * dayGLANCE auto-schedule — so they can never drift apart.
+ */
+export function isPastCadence(
+  targetCadenceDays: number | null | undefined,
+  elapsedDays: number | null | undefined,
+): boolean {
+  if (!targetCadenceDays || elapsedDays == null) return false
+  return elapsedDays >= targetCadenceDays
+}
+
+/**
  * Within cadence (ratio 0→1): green → amber.
  * Overdue (ratio 1→2+): amber → red. Full red at 2× overdue.
  *


### PR DESCRIPTION
Fixes the stale overdue toast: completing a chore on another device (or in dayGLANCE) and then opening lastGLANCE still showed the overdue toast, because the overdue check reads the local DB at launch/foreground, which predates the sync and intents deliveries kicked off at the same moment — and warning toasts persist until dismissed by hand.

Independent of #246 (branched from main; no dependency either way).

## Approach: reconcile, not gate

Of the two candidate fixes (delay toasts until sync completes, or retract toasts the sync invalidates), this implements retraction:

- "After sync completes" has no single definition here: completions arrive via the file tier, the vault tier, or either intents poller (that last one is how dayGLANCE completions land), each optional; and since sync 1.10.0 a cycle can be legitimately suppressed by backoff, so a gate needs a timeout after which it shows the stale toast anyway.
- A gate only narrows the race (a peer that syncs 30s after launch re-creates it); reconciliation also covers completions landing mid-session.
- Gating delays every launch's legitimately-overdue toasts to cover the rare cross-device case.

The signal already existed and is complete: every path that writes a completion into Dexie dispatches `lg:chore-logged` (both sync tiers, both intents pollers, native pending completions, and local logging). The reconciler listens for it (and `lg:sync-applied`), debounces 400ms (the vault tier fires per applied row, so a pull is a burst), re-reads overdue state, and retracts any chore toast whose chore is no longer past cadence. A chore deleted remotely leaves the overdue set too, so its toast also retracts. Bonus: completing a chore in the app by any means now retracts its standing toast.

## Changes

- **`Toast.tsx`**: `ToastOptions` gains optional `choreId` identity; the context gains `dismissWhere(pred)`, which marks matches as exiting so they leave through the normal exit animation rather than vanishing. Toasts without `choreId` (row-quarantine warnings, success toasts) are never touched.
- **`useNotifications.ts`**: overdue toasts carry `choreId`; new reconcile effect as above. The once-per-day `lg_notified_` marker semantics are unchanged.
- **`utils/cadence.ts`**: the overdue definition is extracted to `isPastCadence`, now shared by the toast check, the reconciler, and the auto-schedule so the three cannot drift. Unit-tested (`cadence.test.ts`), including the null cases that must never count as overdue (no cadence configured; never completed).

## The same bug's irreversible sibling: dayGLANCE auto-schedule

`checkAndNotify` also auto-schedules overdue chores into dayGLANCE from the same stale read — and that emit is a durable enqueue that cannot be recalled, so a chore completed last night elsewhere could get re-created in dayGLANCE on this device's next launch. Retraction cannot fix that path, so it now waits out a 15-second grace period after each trigger (launch, foreground, hourly) and re-reads fresh rows before deciding. A settle signal would be tidier than a delay, but per the transport plurality above, "sync is done" has no honest single definition; the grace comfortably covers a normal launch sync, nothing user-visible waits on it, and the once-per-day marker makes the delay imperceptible. Residual risk (sync slower than 15s) is unchanged-or-better versus today, where the window was zero.

## Verification

- Full suite green: 275 tests (271 existing + 4 new), `tsc -b` clean, `eslint --max-warnings 0` clean.
- End-to-end in Chromium against the dev build, reproducing the reported scenario: two seed chores made overdue (cadence 1 day, last completed 5 days ago, notify on); on reload **both toasts fire** from the stale pre-sync read. Then a completion event for one chore is written into Dexie and the sync events dispatched — exactly what `dbEngine.applyRemoteEntity` + `notifyApplied` do when a remote completion arrives — and **that toast retracts while the other stays standing**:

```
overdue chores seeded: [{"id":1,"name":"Mop kitchen"},{"id":2,"name":"Clean bathrooms"}]
toasts visible after reload: Mop kitchen=true Clean bathrooms=true
after simulated remote completion of "Mop kitchen":
  its toast retracted: true
  "Clean bathrooms" toast still standing: true
PASS
```

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_