### PR TITLE
GLANCEvault SSE push, phase 1 (web transport) + seed-gate loop fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,8 @@ import { useReminders } from '@/hooks/useReminders'
 import { usePendingCompletions } from '@/hooks/usePendingCompletions'
 import { usePendingDeepLink } from '@/hooks/usePendingDeepLink'
 import { useIntentsPoller } from '@/hooks/useIntentsPoller'
-import { useDbIntentsPoller } from '@/hooks/useDbIntentsPoller'
+import { useDbIntentsPoller, drainDbIntents } from '@/hooks/useDbIntentsPoller'
+import { useVaultEventStream } from '@/hooks/useVaultEventStream'
 import { useAndroidIntentBridge } from '@/hooks/useAndroidIntentBridge'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
@@ -369,6 +370,13 @@ function AppInner() {
   // GLANCEvault DB intents transport — gated by isDbIntentsEnabled(); a no-op
   // unless the per-user opt-in is on. WebDAV intents above remain the default.
   useDbIntentsPoller(loadHeatmap)
+  // GLANCEvault SSE push: nudges from the vault trigger the SAME drains the
+  // polls run (runDbSync for the sync tier, the intents poller's drain for the
+  // intents tier), so remote changes land in seconds instead of at the next
+  // poll. Purely additive — every poll cadence above stays untouched as the
+  // correctness backstop, and a no-op when the vault is disabled or the
+  // transport can't stream (native shell, pre-/events server).
+  useVaultEventStream({ drainSync: runDbSync, drainIntents: drainDbIntents })
   // Android/Tasker intents transport — lets another Android app drive lastGLANCE
   // via app.lastglance.* intents. No-op off native Android.
   useAndroidIntentBridge(loadHeatmap)

--- a/src/hooks/useDbIntentsPoller.ts
+++ b/src/hooks/useDbIntentsPoller.ts
@@ -26,6 +26,20 @@ import { processNotifyEnvelope } from '@/intents/processNotifyEnvelope'
 // This hook is gated by isDbIntentsEnabled(): when the DB intents transport is
 // off it does nothing, so it can be mounted alongside useIntentsPoller (the
 // WebDAV poller) and only the enabled transport runs.
+
+// The mounted hook's poll, registered so the SSE nudge path (useVaultEventStream)
+// can trigger the SAME drain the timer and focus triggers run — one drain, three
+// triggers. Null while the hook is unmounted; the poll itself no-ops when the
+// DB intents transport is disabled, so callers never need to check.
+let activeDrain: (() => Promise<void>) | null = null
+
+// Trigger one intents receive drain now (SSE nudge entry point). Fire-and-forget:
+// failures surface through the activity log exactly as a timer-triggered poll's
+// would, and the next poll (or nudge) retries — polling stays the backstop.
+export function drainDbIntents(): void {
+  activeDrain?.().catch(() => {/* surfaced via the activity log */})
+}
+
 export function useDbIntentsPoller(onNewCompletion?: () => void): void {
   const onNewCompletionRef = useRef<(() => void) | undefined>(onNewCompletion)
   useEffect(() => { onNewCompletionRef.current = onNewCompletion }, [onNewCompletion])
@@ -116,6 +130,7 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
     }
 
     poll()
+    activeDrain = poll
 
     const intervalMs = getDbIntentsConfig().pollIntervalMinutes * 60 * 1000
     const interval = setInterval(poll, intervalMs)
@@ -126,6 +141,7 @@ export function useDbIntentsPoller(onNewCompletion?: () => void): void {
     document.addEventListener('visibilitychange', onVisibilityChange)
 
     return () => {
+      if (activeDrain === poll) activeDrain = null
       clearInterval(interval)
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }

--- a/src/hooks/useVaultEventStream.ts
+++ b/src/hooks/useVaultEventStream.ts
@@ -1,0 +1,153 @@
+// React lifecycle wrapper for the GLANCEvault SSE push client.
+//
+// Opens the authenticated /events stream when the vault is enabled AND the app
+// is visible, turns nudges into instant drains of the EXISTING sync/intents
+// drains (debounced, seq-deduped), reconnects with jittered backoff on any
+// drop, reconciles via the server's `ready` frame on every (re)connect, and
+// tears the connection down cleanly on background / unmount. The pure transport
+// lives in @/sync/vaultEventStream; this file only wires it to React + the app.
+//
+// CORE INVARIANT: purely ADDITIVE. It never starts, stops, or slows the
+// existing poll cadences (the 5-minute sync interval + focus in App.tsx, and
+// the intents poller's interval + focus). Those keep running as the correctness
+// backstop, so a missed nudge or an SSE-down window is always caught by the
+// next poll. If SSE is unavailable (native shell, old server, buffering proxy)
+// or throws, the app degrades to exactly today's polling behavior.
+//
+// Keyed on mount only: a vault enable/disable/edit reloads the app (see
+// SyncSettingsModal's save path), so the isVaultEnabled() read at mount stays
+// current — the same lifecycle contract the DB engine construction relies on.
+
+import { useEffect, useRef } from 'react'
+import { getVaultConfig, isVaultEnabled } from '@/sync/vaultConfig'
+import {
+  createNudgeCoalescer,
+  createVaultEventClient,
+  detectSseTransport,
+  openWebSseStream,
+  type SseClientState,
+  type VaultSseConnection,
+} from '@/sync/vaultEventStream'
+
+interface VaultSseDiag {
+  state: SseClientState | 'idle'
+  transport: string
+  connects: number
+  events: number
+  drains: number
+  lastEventSeq: number | null
+  lastError: string | null
+  stalled: boolean
+  lastConnectedAt: string | null
+}
+
+export function useVaultEventStream({ drainSync, drainIntents }: {
+  drainSync: () => void
+  drainIntents: () => void
+}): void {
+  // Keep the drain callbacks fresh without re-running the effect (which would
+  // tear down and re-open the connection on every render).
+  const drainSyncRef = useRef(drainSync)
+  drainSyncRef.current = drainSync
+  const drainIntentsRef = useRef(drainIntents)
+  drainIntentsRef.current = drainIntents
+
+  useEffect(() => {
+    if (!isVaultEnabled()) return undefined
+
+    const transport = detectSseTransport()
+    if (transport !== 'web') {
+      // 'native-unsupported' (Capacitor shell, phase 2 pending) / 'none' (SSR):
+      // nothing to open, nothing to clean up — polling backstop only.
+      if (import.meta.env?.DEV) {
+        console.info('[vault-sse] streaming unavailable on', transport, '— polling backstop only')
+      }
+      return undefined
+    }
+
+    // Observability: a live, inspectable snapshot so SSE health can be checked
+    // in a packaged build with no devtools — run `window.__glanceVaultSse` in
+    // the console (same incantation as dayGLANCE, deliberately). Counters make
+    // a reconnect storm (many connects, few events) immediately obvious;
+    // `stalled: true` is the buffering-reverse-proxy signature (stream opened,
+    // no `ready` frame arrived). Per-transition console lines are gated behind
+    // the `lastglance-debug-push` localStorage flag; genuine errors and the
+    // stalled diagnostic still log unconditionally.
+    const diag: VaultSseDiag = {
+      state: 'idle', transport, connects: 0, events: 0, drains: 0,
+      lastEventSeq: null, lastError: null, stalled: false, lastConnectedAt: null,
+    }
+    ;(window as unknown as Record<string, unknown>).__glanceVaultSse = diag
+
+    const sseDebug = () => {
+      try { return localStorage.getItem('lastglance-debug-push') === '1' } catch { return false }
+    }
+
+    const coalescer = createNudgeCoalescer({
+      onDrain: (kind) => {
+        diag.drains += 1
+        if (sseDebug()) console.info('[vault-sse] drain →', kind)
+        if (kind === 'sync') drainSyncRef.current()
+        else drainIntentsRef.current()
+      },
+      onDrainError: (msg, err) => console.warn('[vault-sse]', msg, err instanceof Error ? err.message : err),
+    })
+
+    const onStateChange = (state: SseClientState, detail?: unknown) => {
+      diag.state = state
+      if (state === 'connecting') diag.connects += 1
+      if (state === 'open') { diag.lastConnectedAt = new Date().toISOString(); diag.stalled = false }
+      if (state === 'stalled') {
+        // A healthy path delivers `ready` immediately; an open-but-silent
+        // stream almost certainly means a buffering reverse proxy. Polling
+        // masks this completely, so say it out loud once per occurrence.
+        diag.stalled = true
+        console.warn('[vault-sse] stream opened but no frame arrived — a reverse proxy is likely buffering /events; SSE is inert and polling is covering')
+      } else if (state === 'error') {
+        diag.lastError = detail instanceof Error ? detail.message : String(detail ?? 'error')
+        console.warn('[vault-sse] error:', diag.lastError)
+      } else if (state === 'unsupported-server') {
+        console.warn('[vault-sse] this GLANCEvault server predates /events — push disabled, polling covers')
+      } else if (sseDebug()) {
+        console.info('[vault-sse]', state, `(connects=${diag.connects} events=${diag.events} drains=${diag.drains})`)
+      }
+    }
+
+    const getConnection = (): VaultSseConnection | null => {
+      const c = getVaultConfig()
+      return c && c.vaultUrl && c.vaultToken && c.accountId
+        ? { vaultUrl: c.vaultUrl, vaultToken: c.vaultToken, accountId: c.accountId }
+        : null
+    }
+
+    const client = createVaultEventClient({
+      getConnection,
+      openStream: openWebSseStream,
+      onEvent: (evt) => {
+        diag.events += 1
+        const seq = (evt as { seq?: number } | null)?.seq
+        if (typeof seq === 'number') diag.lastEventSeq = seq
+        coalescer.handleEvent(evt)
+      },
+      onStateChange,
+    })
+
+    // Drop SSE on background, reopen on foreground. The (re)connect delivers a
+    // fresh `ready` seq that reconciles anything missed while hidden; the
+    // focus-triggered polls cover the gap regardless.
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') client.start()
+      else client.stop()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    if (document.visibilityState !== 'hidden') client.start()
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+      client.stop()
+      coalescer.cancel()
+    }
+    // Mount-once by design; see the header note on the reload contract.
+  }, [])
+}

--- a/src/sync/dbEngine.test.ts
+++ b/src/sync/dbEngine.test.ts
@@ -397,3 +397,75 @@ describe('createDbEngine stale pull-cursor recovery', () => {
     expect(localStorage.getItem(RECOVERY_FLAG)).toBe(String(CURRENT_GEN))
   })
 })
+
+describe('first-sync snapshot seeding gate', () => {
+  // Regression guard for the SSE self-nudge loop: the old gate re-ran the
+  // full-snapshot marking on EVERY cycle while getHighWaterMark() === 0, so
+  // with the pull failing (or backed off) while pushes succeeded, each cycle
+  // re-pushed the whole dataset — and under SSE each push's own nudge
+  // triggered the next cycle. The gate is now a one-shot persisted flag: mark
+  // once, latch, and let the engine's persisted dirty set own delivery.
+  //
+  // The cycles below fail fast inside the engine (no passphrase in session →
+  // ensureRootKey throws PASSPHRASE_REQUIRED before any network) — deliberate:
+  // seeding runs before the engine cycle, and a failing cycle is exactly the
+  // state the old gate looped in.
+  const HWM_KEY = 'lastglance-db-sync-hwm'
+  const RECOVERY_FLAG = 'lastglance-db-sync-hwm-recovery-gen'
+  const SEEDED_FLAG = 'lastglance-db-sync-snapshot-seeded'
+  const DIRTY_KEY = 'lastglance-db-sync-dirty'
+
+  beforeAll(() => {
+    setVaultConfig({
+      enabled: true,
+      vaultUrl: 'http://127.0.0.1:9',
+      vaultToken: 'test-token',
+      accountId: 'acct-test',
+    })
+    // Keep the recovery path out of these tests' way.
+    localStorage.setItem(RECOVERY_FLAG, '2')
+  })
+
+  afterAll(() => {
+    setVaultConfig(null)
+    for (const k of [HWM_KEY, RECOVERY_FLAG, SEEDED_FLAG, DIRTY_KEY]) localStorage.removeItem(k)
+  })
+
+  it('seeds once on a fresh device, then never re-marks (the loop regression)', async () => {
+    localStorage.removeItem(HWM_KEY)
+    localStorage.removeItem(SEEDED_FLAG)
+    localStorage.removeItem(DIRTY_KEY)
+
+    const engine = createDbEngine()!
+    await engine.dbSyncCycle()
+
+    // Marking completed and latched: the rows seeded in beforeAll are dirty.
+    expect(localStorage.getItem(SEEDED_FLAG)).toBe('1')
+    const dirty = engine.getDirtySet()
+    expect(dirty).toContain(CAT_ID)
+    expect(dirty).toContain(EVENT_ID)
+
+    // The old gate's loop condition: HWM is STILL 0 (no pull succeeded), and
+    // another cycle runs. It must NOT re-mark — that re-mark is what re-pushed
+    // the full dataset every cycle.
+    engine.clearDirty()
+    expect(engine.getHighWaterMark()).toBe(0)
+    await engine.dbSyncCycle()
+    expect(engine.getDirtySet()).toEqual([])
+  })
+
+  it('migration shim: a pre-flag device whose first sync already completed latches without re-marking', async () => {
+    // An upgrading device: no flag, but a pull cursor past 0 proves the first
+    // sync happened under the old gate. It must not burst a redundant
+    // full-snapshot push (and its fleet-wide nudges) on upgrade.
+    localStorage.setItem(HWM_KEY, '42')
+    localStorage.removeItem(SEEDED_FLAG)
+    localStorage.removeItem(DIRTY_KEY)
+
+    const engine = createDbEngine()!
+    await engine.dbSyncCycle()
+
+    expect(localStorage.getItem(SEEDED_FLAG)).toBe('1')
+    expect(engine.getDirtySet()).toEqual([])
+  })
+})

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -429,8 +429,21 @@ export interface DbEngineCallbacks {
 //   gen 1 (v1.8.6): split-cursor poisoning from @glance-apps/sync ≤ 1.3.x.
 //   gen 2 (v1.8.7): re-pull so completions dropped on a not-yet-present chore by
 //                   the old applyCompletionEvent are re-listed and now parked.
+//
+// A generation rewind forces a full re-PULL only. It deliberately no longer
+// re-snapshot-pushes local data (the seed gate below is a one-shot flag, not an
+// HWM check): both existing generations were pull-side fixes, and push-side
+// loss has always been covered by dirty-retention-until-ack. If a FUTURE
+// generation ever needs a forced re-push (e.g. after server-side data loss), it
+// must ALSO remove SNAPSHOT_SEEDED_FLAG — rewinding the cursor alone will not
+// re-seed.
 const RECOVERY_GENERATION = 2
 const HWM_RECOVERY_FLAG = `${APP_ID}-db-sync-hwm-recovery-gen`
+
+// One-shot gate for the first-sync full-snapshot seed (see the seeding wrapper
+// in createDbEngine). Present-and-'1' means this device has completed its
+// initial marking; the engine's persisted dirty set owns delivery from there.
+const SNAPSHOT_SEEDED_FLAG = `${APP_ID}-db-sync-snapshot-seeded`
 
 function recoverStalePullCursor(engine: DbSyncEngine): void {
   if (typeof localStorage === 'undefined') return
@@ -507,8 +520,10 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
   })
 
   // Recover devices whose pull cursor was poisoned by the ≤1.3.x push/pull bug
-  // before deciding whether this is a first-ever sync below. Resetting to 0 here
-  // also makes the seeding wrapper re-snapshot local data, which is harmless.
+  // before deciding whether this is a first-ever sync below. The cursor rewind
+  // no longer re-triggers the snapshot seed (the seed gate is a one-shot flag,
+  // not an HWM check) — under SSE a rewind-triggered re-seed would not be
+  // harmless; see the seeding wrapper below.
   recoverStalePullCursor(engine)
 
   // Repair categories that were stored flat by an earlier build, immediately on
@@ -520,17 +535,39 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
     .then((n) => { if (n > 0) notifyApplied() })
     .catch((err) => console.warn('[lastglance] category parent repair failed:', err))
 
-  // On the first ever sync (high water mark 0), seed the dirty set with the full
-  // local dataset so existing users get everything pushed, not just new changes.
-  // After a successful first push the high water mark advances past 0, so this
-  // runs once. Seeding failures are non-fatal: the normal cycle still proceeds.
+  // On the first ever sync, seed the dirty set with the full local dataset so
+  // existing users get everything pushed, not just new changes.
+  //
+  // The gate is a ONE-SHOT PERSISTED FLAG (lifeGLANCE's pattern), set only
+  // after marking completes — NOT the old `getHighWaterMark() === 0` check.
+  // The HWM gate re-ran the full-snapshot mark on EVERY cycle until a pull
+  // succeeded, and the server nudges on byte-identical re-upserts, so with
+  // push succeeding while the pull was failing or backed off (exactly the
+  // state 1.9.0's push/pull decoupling sustains) each cycle re-pushed the
+  // whole dataset — under SSE, a self-nudge loop: push → own activity nudge →
+  // drain → re-mark (HWM still 0) → push. The flag latches after ONE
+  // successful marking; the engine's persisted dirty set then carries the
+  // seed until it is fully acked (pushDirtyRows only clears on full ack), so
+  // delivery stays guaranteed without ever re-marking. A marking FAILURE
+  // leaves the flag unset, so the next cycle retries. Seeding failures are
+  // non-fatal: the normal cycle still proceeds.
+  //
+  // Migration shim: a device upgrading from the HWM gate has no flag, but a
+  // pull cursor past 0 proves its first sync completed long ago — latch the
+  // flag without re-marking, so the upgrade does not trigger a fleet-wide
+  // burst of redundant full-snapshot pushes (and their nudges).
   const runCycle = engine.dbSyncCycle.bind(engine)
   const dbSyncCycle = async (): Promise<DbSyncResult> => {
-    if (engine.getHighWaterMark() === 0) {
-      try {
-        await markAllLocalEntitiesDirty(engine)
-      } catch (err) {
-        console.warn('[lastglance] vault initial snapshot failed:', err)
+    if (localStorage.getItem(SNAPSHOT_SEEDED_FLAG) !== '1') {
+      if (engine.getHighWaterMark() > 0) {
+        localStorage.setItem(SNAPSHOT_SEEDED_FLAG, '1')
+      } else {
+        try {
+          await markAllLocalEntitiesDirty(engine)
+          localStorage.setItem(SNAPSHOT_SEEDED_FLAG, '1')
+        } catch (err) {
+          console.warn('[lastglance] vault initial snapshot failed:', err)
+        }
       }
     }
     // The engine's own dbSyncCycle fires config.onRowsSkipped for any quarantined

--- a/src/sync/vaultEventStream.test.ts
+++ b/src/sync/vaultEventStream.test.ts
@@ -1,0 +1,277 @@
+// Tests for the SSE push client core, against the REAL wire format (verified
+// from the glance-vault server source and observed live): named events
+// `event: ready` / `event: activity` whose data is exactly {"seq":N}, plus
+// comment-line heartbeats. No test fabricates fields the server does not send.
+
+import { describe, it, expect, vi } from 'vitest'
+import {
+  parseSseFrame,
+  drainSseBuffer,
+  createNudgeCoalescer,
+  createVaultEventClient,
+  openWebSseStream,
+  SseUnsupportedError,
+  type SseClientState,
+} from './vaultEventStream'
+
+// Real frames, byte-shaped as the server sends them.
+const READY = 'event: ready\ndata: {"seq":3}'
+const ACTIVITY = (seq: number) => `event: activity\ndata: {"seq":${seq}}`
+
+describe('parseSseFrame', () => {
+  it('parses a ready frame to its {seq} nudge (event name not surfaced)', () => {
+    expect(parseSseFrame(READY)).toEqual({ seq: 3 })
+  })
+
+  it('parses an activity frame identically', () => {
+    expect(parseSseFrame(ACTIVITY(7))).toEqual({ seq: 7 })
+  })
+
+  it('returns null for a heartbeat-only block', () => {
+    expect(parseSseFrame(': heartbeat')).toBeNull()
+  })
+
+  it('tolerates CRLF line endings', () => {
+    expect(parseSseFrame('event: activity\r\ndata: {"seq":9}\r')).toEqual({ seq: 9 })
+  })
+
+  it('concatenates multiple data lines per the SSE spec', () => {
+    expect(parseSseFrame('data: {"seq"\ndata: :12}')).toEqual({ seq: 12 })
+  })
+
+  it('returns null on unparseable data and on event-name-only blocks', () => {
+    expect(parseSseFrame('data: not-json')).toBeNull()
+    expect(parseSseFrame('event: ready')).toBeNull()
+  })
+})
+
+describe('drainSseBuffer', () => {
+  it('emits each complete event and returns the unconsumed remainder', () => {
+    const seen: unknown[] = []
+    const rest = drainSseBuffer(`${READY}\n\n${ACTIVITY(5)}\n\n${ACTIVITY(6)}`, e => seen.push(e))
+    expect(seen).toEqual([{ seq: 3 }, { seq: 5 }])
+    expect(rest).toBe(ACTIVITY(6)) // incomplete: no blank-line delimiter yet
+  })
+
+  it('reassembles frames split across chunk boundaries', () => {
+    const seen: unknown[] = []
+    let buf = ''
+    for (const chunk of ['event: acti', 'vity\nda', 'ta: {"seq":42}\n', '\n: heartbeat\n\n']) {
+      buf = drainSseBuffer(buf + chunk, e => seen.push(e))
+    }
+    expect(seen).toEqual([{ seq: 42 }])
+    expect(buf).toBe('')
+  })
+})
+
+// Timer harness: captures scheduled callbacks so tests fire them explicitly.
+function makeTimers() {
+  let nextId = 1
+  const pending = new Map<number, () => void>()
+  return {
+    setTimeoutFn: ((cb: () => void) => { const id = nextId++; pending.set(id, cb); return id }) as unknown as typeof setTimeout,
+    clearTimeoutFn: ((id: number) => { pending.delete(id) }) as unknown as typeof clearTimeout,
+    fire: () => { const cbs = [...pending.values()]; pending.clear(); cbs.forEach(cb => cb()) },
+    pendingCount: () => pending.size,
+  }
+}
+
+describe('createNudgeCoalescer', () => {
+  it('accepts advancing seqs, ignores stale and duplicate ones', () => {
+    const timers = makeTimers()
+    const c = createNudgeCoalescer({ onDrain: () => {}, ...timers })
+    expect(c.handleEvent({ seq: 3 })).toBe(true)   // ready
+    expect(c.handleEvent({ seq: 3 })).toBe(false)  // duplicate
+    expect(c.handleEvent({ seq: 2 })).toBe(false)  // stale
+    expect(c.handleEvent({ seq: 7 })).toBe(true)   // advanced
+    expect(c.handleEvent(null)).toBe(false)
+    expect(c.handleEvent({ seq: NaN })).toBe(false)
+    expect(c.getCursor()).toBe(7)
+  })
+
+  it('coalesces a burst into ONE flush that drains sync then intents', () => {
+    const timers = makeTimers()
+    const drains: string[] = []
+    const c = createNudgeCoalescer({ onDrain: k => drains.push(k), ...timers })
+    c.handleEvent({ seq: 1 })
+    c.handleEvent({ seq: 2 })
+    c.handleEvent({ seq: 3 })
+    expect(drains).toEqual([]) // debounced, nothing yet
+    timers.fire()
+    expect(drains).toEqual(['sync', 'intents'])
+  })
+
+  it('a throwing sync drain does not prevent the intents drain', () => {
+    const timers = makeTimers()
+    const drains: string[] = []
+    const errors: string[] = []
+    const c = createNudgeCoalescer({
+      onDrain: k => { drains.push(k); if (k === 'sync') throw new Error('boom') },
+      onDrainError: msg => errors.push(msg),
+      ...timers,
+    })
+    c.handleEvent({ seq: 1 })
+    timers.fire()
+    expect(drains).toEqual(['sync', 'intents'])
+    expect(errors).toEqual(['vault-sse drain (sync) failed'])
+  })
+
+  it('cancel() drops a pending flush', () => {
+    const timers = makeTimers()
+    const drains: string[] = []
+    const c = createNudgeCoalescer({ onDrain: k => drains.push(k), ...timers })
+    c.handleEvent({ seq: 1 })
+    c.cancel()
+    timers.fire()
+    expect(drains).toEqual([])
+  })
+})
+
+describe('createVaultEventClient', () => {
+  const connection = { vaultUrl: 'http://v', vaultToken: 't', accountId: 'a' }
+
+  // Runs the client loop against a scripted openStream. Reconnect delays are
+  // captured; timers fire on a microtask so the loop advances without real
+  // waiting. random=0.5 makes the ±25% jitter factor exactly 1.0.
+  function run(openStream: (args: { onOpen?: () => void }) => Promise<void>, opts: {
+    nowSteps?: number[]
+    random?: () => number
+  } = {}) {
+    const delays: number[] = []
+    const states: SseClientState[] = []
+    let nowIdx = 0
+    const nowSteps = opts.nowSteps
+    const client = createVaultEventClient({
+      getConnection: () => connection,
+      openStream: openStream as unknown as typeof openWebSseStream,
+      onEvent: () => {},
+      now: nowSteps ? () => nowSteps[Math.min(nowIdx++, nowSteps.length - 1)] : () => 0,
+      random: opts.random ?? (() => 0.5),
+      setTimeoutFn: ((cb: () => void, ms: number) => {
+        delays.push(ms)
+        queueMicrotask(cb)
+        return 0
+      }) as unknown as typeof setTimeout,
+      clearTimeoutFn: (() => {}) as unknown as typeof clearTimeout,
+      onStateChange: s => states.push(s),
+    })
+    return { client, delays, states }
+  }
+
+  it('backs off exponentially with the jitter factor applied, capped at max', async () => {
+    let calls = 0
+    const { client, delays } = run(async () => {
+      calls++
+      if (calls >= 8) client.stop()
+      throw new Error('connect refused')
+    })
+    client.start()
+    await vi.waitFor(() => expect(calls).toBeGreaterThanOrEqual(8))
+    // random=0.5 → factor 1.0 → raw ladder: 1s 2s 4s 8s 16s 30s(cap) 30s ...
+    expect(delays.slice(0, 7)).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000])
+  })
+
+  it('jitter spreads the delay within ±25%', async () => {
+    let calls = 0
+    const { client, delays } = run(async () => {
+      calls++
+      if (calls >= 2) client.stop()
+      throw new Error('nope')
+    }, { random: () => 0 }) // low edge
+    client.start()
+    await vi.waitFor(() => expect(calls).toBeGreaterThanOrEqual(2))
+    expect(delays[0]).toBe(750) // 1000 * 0.75
+  })
+
+  it('resets the backoff only after a connection proves stable', async () => {
+    let calls = 0
+    const { client, delays } = run(
+      async () => {
+        calls++
+        if (calls >= 4) client.stop()
+        throw new Error('drop')
+      },
+      // now() is read twice per connection (startedAt, then the stability
+      // check). Connections 1-2 last 0ms (unstable → ladder climbs); the THIRD
+      // lasts 6s (≥ minStableMs 5s) → attempt resets, so its delay drops back
+      // to the base instead of continuing to 4s.
+      { nowSteps: [0, 0, 0, 0, 1000, 7000, 7000, 7000] },
+    )
+    client.start()
+    await vi.waitFor(() => expect(calls).toBeGreaterThanOrEqual(4))
+    expect(delays.slice(0, 3)).toEqual([1000, 2000, 1000])
+  })
+
+  it('treats a 404 (SseUnsupportedError) as terminal: stops, never retries', async () => {
+    let calls = 0
+    const { client, states, delays } = run(async () => {
+      calls++
+      throw new SseUnsupportedError()
+    })
+    client.start()
+    await vi.waitFor(() => expect(states).toContain('unsupported-server'))
+    expect(calls).toBe(1)
+    expect(delays).toEqual([]) // no reconnect was ever scheduled
+    expect(client.isRunning()).toBe(false)
+  })
+
+  it('reports stalled when a stream opens but no frame arrives in time', async () => {
+    const { client, states } = run(async ({ onOpen }: { onOpen?: () => void }) => {
+      onOpen?.()
+      // Never emits an event, never resolves promptly: the ready timer (also on
+      // the microtask timer harness) fires first.
+      await new Promise<void>(resolve => { setTimeout(resolve, 5) })
+      client.stop()
+    })
+    client.start()
+    await vi.waitFor(() => expect(states).toContain('stalled'))
+  })
+})
+
+describe('openWebSseStream', () => {
+  const connection = { vaultUrl: 'http://vault.test/', vaultToken: 'tok', accountId: 'acct-1' }
+
+  function sseResponse(chunks: string[]): Response {
+    const enc = new TextEncoder()
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(enc.encode(c))
+        controller.close()
+      },
+    })
+    return { ok: true, status: 200, body } as unknown as Response
+  }
+
+  it('requests /events with Bearer auth, no credentials, and pumps real frames', async () => {
+    let captured: { url: string; init: RequestInit } | null = null
+    const seen: unknown[] = []
+    await openWebSseStream({
+      connection,
+      onEvent: e => seen.push(e),
+      fetchImpl: (async (url: string, init: RequestInit) => {
+        captured = { url, init }
+        return sseResponse([`${READY}\n\n`, ': heartbeat\n\n', `${ACTIVITY(4)}\n\n`])
+      }) as unknown as typeof fetch,
+    })
+    expect(captured!.url).toBe('http://vault.test/events?accountId=acct-1')
+    expect((captured!.init.headers as Record<string, string>).Authorization).toBe('Bearer tok')
+    expect(captured!.init.credentials).toBe('omit')
+    expect(seen).toEqual([{ seq: 3 }, { seq: 4 }])
+  })
+
+  it('classifies a 404 as SseUnsupportedError (server predates /events)', async () => {
+    await expect(openWebSseStream({
+      connection,
+      onEvent: () => {},
+      fetchImpl: (async () => ({ ok: false, status: 404, body: null })) as unknown as typeof fetch,
+    })).rejects.toBeInstanceOf(SseUnsupportedError)
+  })
+
+  it('throws a plain retryable error on any other failure status', async () => {
+    await expect(openWebSseStream({
+      connection,
+      onEvent: () => {},
+      fetchImpl: (async () => ({ ok: false, status: 429, body: null })) as unknown as typeof fetch,
+    })).rejects.toThrow('vault SSE connect failed: 429')
+  })
+})

--- a/src/sync/vaultEventStream.ts
+++ b/src/sync/vaultEventStream.ts
@@ -1,0 +1,428 @@
+// GLANCEvault SSE push client — lastGLANCE port of dayGLANCE's proven core
+// (dayglance src/sync/vaultEventStream.js, post-#1316 truthful-protocol fix),
+// adapted to this repo: TypeScript, web transport only, and hardening (jitter,
+// terminal 404 classification, stalled-stream diagnostic) that dayGLANCE's
+// deployment history showed to be worth having from day one.
+//
+// WIRE CONTRACT (verified against the glance-vault server source and observed
+// live): the server emits authenticated per-account named SSE events at
+// GET {vaultUrl}/events?accountId= whose data is exactly {"seq":N}:
+//   • `event: ready`    — once per successful connection, carrying the account's
+//     latest seq (0 for a never-written account); the reconnect reconcile point.
+//   • `event: activity` — whenever the account seq advances.
+// plus comment-line heartbeats (`: ...`) every ~20s. Nothing else is on the
+// wire: no kind/scope discriminator, no `id:`, no `retry:` (reconnect timing is
+// entirely client-owned; the server never reads Last-Event-ID). A nudge carries
+// ONLY the latest account seq — no payload, and no hint of WHAT advanced: sync
+// writes, intent landings, and blob bookkeeping all draw from the one
+// per-account counter (blob bookkeeping without even emitting), so the only
+// correct response to any nudge is to drain everything, and the seq is an
+// opaque watermark — never compare gap sizes against local cursors.
+//
+// CORE INVARIANT: push is an optimization; POLLING IS THE CORRECTNESS BACKSTOP.
+// Nothing here ever stops, slows, or references the existing poll cadences (the
+// 5-minute sync interval + focus in App.tsx, the intents poller's interval +
+// focus). A nudge only ADDS an instant drain on top; if any of this throws or
+// the stream drops, polling keeps delivering. Everything is idempotent — a
+// nudge triggers the SAME drains the polls trigger, and those re-read their own
+// cursors and no-op when there is nothing new. The engine's self-enforced
+// backoff (@glance-apps/sync 1.10.0) additionally guarantees a nudge-triggered
+// cycle can never hammer a failing server.
+//
+// TRANSPORTS (phase 1: web only):
+//   • WEB (browser/PWA): EventSource cannot set an Authorization header, and the
+//     vault authenticates with a Bearer token — so we use a fetch-based
+//     streaming reader (response.body.getReader()). See openWebSseStream.
+//   • NATIVE (Capacitor Android/iOS): vault HTTP rides CapacitorHttp (whole-body,
+//     cannot stream), and a WebView fetch to the vault is constrained by the
+//     same CORS/cleartext realities that made CapacitorHttp necessary — so
+//     streaming inside the WebView is not attempted. detectSseTransport reports
+//     'native-unsupported' and the app keeps its polling behavior, exactly as
+//     dayGLANCE's shells did before their native readers shipped. Phase 2 is a
+//     small Capacitor plugin owning the socket natively (reference
+//     implementations: dayGLANCE's VaultSseClient.kt / VaultSseBridge.swift).
+
+import { isNativePlatform } from './nativeHttp'
+
+// ─── SSE frame parsing ───────────────────────────────────────────────────────
+
+export interface SseNudge {
+  seq: number
+}
+
+/**
+ * Parse ONE SSE event block (the text between blank-line boundaries) into the
+ * nudge object {seq}, or null if the block carries no usable data.
+ *
+ * The event NAME (`ready` | `activity`) is deliberately not surfaced: both carry
+ * the same instruction — the account seq advanced past what we knew — so the
+ * data line is the whole contract. Ignores comment lines (leading ':', used for
+ * heartbeats) and non-data fields (event:, id:, retry: — the server sends only
+ * event: and data: today; tolerating the rest is plain SSE-spec hygiene).
+ * Concatenates multiple data: lines per the SSE spec, then JSON-parses. Returns
+ * null on a heartbeat-only block or unparseable data so the caller can skip it.
+ */
+export function parseSseFrame(block: string): unknown | null {
+  if (!block) return null
+  const dataLines: string[] = []
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    if (!line || line.startsWith(':')) continue // blank or comment (heartbeat)
+    const colon = line.indexOf(':')
+    const field = colon === -1 ? line : line.slice(0, colon)
+    let value = colon === -1 ? '' : line.slice(colon + 1)
+    if (value.startsWith(' ')) value = value.slice(1) // SSE strips one leading space
+    if (field === 'data') dataLines.push(value)
+  }
+  if (dataLines.length === 0) return null
+  try {
+    return JSON.parse(dataLines.join('\n'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Feed a growing SSE text buffer, emitting each COMPLETE event (delimited by a
+ * blank line) via onEvent and returning the unconsumed remainder to carry into
+ * the next chunk. Normalizes CRLF/CR to LF first.
+ */
+export function drainSseBuffer(buffer: string, onEvent: (evt: unknown) => void): string {
+  let buf = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  let idx: number
+  while ((idx = buf.indexOf('\n\n')) !== -1) {
+    const block = buf.slice(0, idx)
+    buf = buf.slice(idx + 2)
+    const evt = parseSseFrame(block)
+    if (evt) onEvent(evt)
+  }
+  return buf
+}
+
+// ─── transport detection ─────────────────────────────────────────────────────
+
+export type SseTransport = 'web' | 'native-unsupported' | 'none'
+
+/**
+ * Which SSE consumption path this runtime supports. 'web' opens a stream; every
+ * other value degrades to polling (the permanent correctness backstop).
+ */
+export function detectSseTransport(): SseTransport {
+  if (typeof window === 'undefined') return 'none'
+  // Capacitor shell: no streaming vault path exists in phase 1 (see header).
+  if (isNativePlatform) return 'native-unsupported'
+  if (typeof fetch === 'function' && typeof ReadableStream !== 'undefined') return 'web'
+  return 'none'
+}
+
+// ─── web streaming reader ────────────────────────────────────────────────────
+
+export interface VaultSseConnection {
+  vaultUrl: string
+  vaultToken: string
+  accountId: string
+}
+
+// Thrown when GET /events comes back 404: the vault predates the SSE endpoint
+// (no catch-all JSON 404 exists server-side, so an unmatched route is Express's
+// default). Terminal for the client — reconnecting cannot fix a server that
+// lacks the route — so the connection loop stops and polling carries on alone.
+// Every other status (400/401/403/429/5xx) means the route exists and the
+// condition may clear, so those stay ordinary retryable connect failures.
+export class SseUnsupportedError extends Error {
+  code = 'SSE_UNSUPPORTED' as const
+  constructor() {
+    super('vault SSE connect failed: 404 — this GLANCEvault server predates /events')
+  }
+}
+
+/**
+ * Open the vault /events SSE stream over a fetch streaming body and pump parsed
+ * {seq} nudges to onEvent until the stream ends or the signal aborts.
+ * Authenticates with the same Bearer token the other vault calls use and scopes
+ * to accountId (query param, mirroring the sync endpoints).
+ *
+ * `credentials: 'omit'` is load-bearing: the vault's CORS layer never sets
+ * Access-Control-Allow-Credentials (the token rides in a header by design), so
+ * an include-credentials fetch would be rejected by the browser.
+ *
+ * Resolves when the server closes the stream (a clean disconnect the caller
+ * will reconnect from). Rejects on connect failure / network error / abort —
+ * and with SseUnsupportedError on 404, which the caller treats as terminal.
+ */
+export async function openWebSseStream({ connection, signal, onOpen, onEvent, fetchImpl }: {
+  connection: VaultSseConnection
+  signal?: AbortSignal
+  onOpen?: () => void
+  onEvent: (evt: unknown) => void
+  fetchImpl?: typeof fetch
+}): Promise<void> {
+  const doFetch = fetchImpl || globalThis.fetch
+  const base = connection.vaultUrl.replace(/\/+$/, '')
+  const url = `${base}/events?accountId=${encodeURIComponent(connection.accountId)}`
+  const res = await doFetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${connection.vaultToken}`,
+      Accept: 'text/event-stream',
+    },
+    credentials: 'omit',
+    signal,
+  })
+  if (res && res.status === 404) throw new SseUnsupportedError()
+  if (!res || !res.ok || !res.body) {
+    throw new Error(`vault SSE connect failed: ${res ? res.status : 'no response'}`)
+  }
+  onOpen?.()
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      buffer = drainSseBuffer(buffer, onEvent)
+    }
+  } finally {
+    try { reader.releaseLock() } catch { /* ignore */ }
+  }
+}
+
+// ─── nudge coalescer (seq cursor + debounce) ─────────────────────────────────
+
+export interface NudgeCoalescer {
+  handleEvent: (evt: unknown) => boolean
+  getCursor: () => number
+  cancel: () => void
+}
+
+/**
+ * Turns a stream of nudge events into debounced drain calls, with a seq cursor
+ * so stale/duplicate nudges are ignored.
+ *
+ * The account seq is a single unified monotonic counter on the server — sync
+ * writes, intent landings, and blob bookkeeping all advance it — so ONE cursor
+ * is correct: an event is "behind" (worth acting on) only when its seq exceeds
+ * the highest we've already reacted to.
+ *
+ * Every accepted nudge drains BOTH sides. The wire carries no scope (data is
+ * exactly {"seq":N}), and the shared counter means a scope couldn't safely
+ * narrow a drain even if one existed. Rapid nudges within debounceMs coalesce
+ * into a single drain pair.
+ *
+ * onDrain(kind) is called with 'sync' then 'intents' on each flush. The split
+ * callback is kept deliberately (mirroring dayGLANCE): it is the ONE seam where
+ * routing would slot in if a future server ever scoped its nudges — no such
+ * protocol exists or is planned today. It runs inside a try/catch so a throwing
+ * drain can never break the debounce timer or the SSE loop.
+ */
+export function createNudgeCoalescer({
+  onDrain,
+  debounceMs = 400,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  onDrainError,
+}: {
+  onDrain: (kind: 'sync' | 'intents') => void
+  debounceMs?: number
+  setTimeoutFn?: typeof setTimeout
+  clearTimeoutFn?: typeof clearTimeout
+  onDrainError?: (msg: string, err: unknown) => void
+}): NudgeCoalescer {
+  let lastSeq = -Infinity
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const runDrain = (kind: 'sync' | 'intents') => {
+    try {
+      onDrain(kind)
+    } catch (err) {
+      onDrainError?.(`vault-sse drain (${kind}) failed`, err)
+    }
+  }
+
+  const flush = () => {
+    timer = null
+    // Deterministic order: sync before intents.
+    runDrain('sync')
+    runDrain('intents')
+  }
+
+  // Debounce ONLY — no throttle. lastGLANCE's one self-nudge exposure (the
+  // first-sync seeding wrapper re-marking while the pull cursor sat at 0) is
+  // fixed at the root in dbEngine.ts (one-shot persisted seed flag), so drains
+  // fire near-instantly on real changes, which is the point of SSE. Polling
+  // remains the backstop for any coalesced nudge.
+  const schedule = () => {
+    if (timer) clearTimeoutFn(timer)
+    timer = setTimeoutFn(flush, debounceMs)
+  }
+
+  const handleEvent = (evt: unknown): boolean => {
+    const seq = (evt as SseNudge | null)?.seq
+    if (typeof seq !== 'number' || Number.isNaN(seq)) return false
+    if (seq <= lastSeq) return false // not behind — coalesced/stale, ignore
+    lastSeq = seq
+    schedule()
+    return true
+  }
+
+  return {
+    handleEvent,
+    getCursor: () => lastSeq,
+    cancel: () => { if (timer) { clearTimeoutFn(timer); timer = null } },
+  }
+}
+
+// ─── connection client (reconnect + backoff) ─────────────────────────────────
+
+export type SseClientState =
+  | 'connecting' | 'open' | 'closed' | 'error' | 'stalled'
+  | 'unsupported' | 'unsupported-server' | 'stopped'
+
+export interface VaultEventClient {
+  start: () => void
+  stop: () => void
+  isRunning: () => boolean
+  isSupported: () => boolean
+}
+
+/**
+ * Manages the SSE connection lifecycle: connect, pump events through onEvent,
+ * and on any drop reconnect with capped, JITTERED exponential backoff. It NEVER
+ * touches polling — polling is a separate concern and remains the backstop for
+ * every gap this client leaves (backoff waits, background, permanent failure).
+ *
+ * Divergences from dayGLANCE's client, each earned by the server audit:
+ *   • Jitter (±25%) on every reconnect delay. SSE connects count against the
+ *     vault's per-IP rate limiter, and the connection-cap slot for a silently
+ *     dead socket can outlive the client that held it — jitter keeps a fleet of
+ *     reconnecting devices from synchronizing into bursts against either.
+ *   • SseUnsupportedError (404) is TERMINAL: the loop stops for good and
+ *     reports 'unsupported-server'. Reconnecting cannot grow a route the server
+ *     doesn't have, and polling covers the app identically either way.
+ *   • Stalled-stream diagnostic: a connection that opens but delivers no frame
+ *     within readyTimeoutMs reports 'stalled' once. The server sends `ready`
+ *     immediately on connect, so a silent open stream almost certainly means a
+ *     buffering reverse proxy — the one SSE failure mode that is otherwise
+ *     invisible, because polling masks it completely.
+ *
+ * Backoff resets only after a connection proves STABLE (open ≥ minStableMs) —
+ * an open-then-immediate-drop endpoint would otherwise reconnect every
+ * backoffBaseMs forever, a storm that also re-fires the ready reconcile drain
+ * every cycle.
+ */
+export function createVaultEventClient({
+  getConnection,
+  openStream,
+  onEvent,
+  supported = true,
+  backoffBaseMs = 1000,
+  backoffMaxMs = 30000,
+  minStableMs = 5000,
+  readyTimeoutMs = 5000,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  now = () => Date.now(),
+  random = Math.random,
+  onStateChange,
+}: {
+  getConnection: () => VaultSseConnection | null
+  openStream: typeof openWebSseStream
+  onEvent: (evt: unknown) => void
+  supported?: boolean
+  backoffBaseMs?: number
+  backoffMaxMs?: number
+  minStableMs?: number
+  readyTimeoutMs?: number
+  setTimeoutFn?: typeof setTimeout
+  clearTimeoutFn?: typeof clearTimeout
+  now?: () => number
+  random?: () => number
+  onStateChange?: (state: SseClientState, detail?: unknown) => void
+}): VaultEventClient {
+  let stopped = true
+  let looping = false
+  let attempt = 0
+  let abortController: AbortController | null = null
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let readyTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearReadyTimer = () => {
+    if (readyTimer) { clearTimeoutFn(readyTimer); readyTimer = null }
+  }
+
+  const loop = async () => {
+    if (looping) return
+    looping = true
+    while (!stopped) {
+      const connection = supported ? getConnection() : null
+      if (!connection) break // nothing to connect to → let polling cover it
+      abortController = typeof AbortController !== 'undefined' ? new AbortController() : null
+      onStateChange?.('connecting')
+      const startedAt = now()
+      try {
+        await openStream({
+          connection,
+          signal: abortController?.signal,
+          // Backoff is NOT reset here — see minStableMs note in the doc block.
+          onOpen: () => {
+            onStateChange?.('open')
+            // The server's `ready` frame arrives immediately on a healthy path;
+            // an open-but-silent stream is the buffering-proxy signature.
+            clearReadyTimer()
+            readyTimer = setTimeoutFn(() => {
+              readyTimer = null
+              onStateChange?.('stalled')
+            }, readyTimeoutMs)
+          },
+          onEvent: (evt) => {
+            clearReadyTimer()
+            onEvent(evt)
+          },
+        })
+        // Stream ended cleanly (server closed / heartbeat gap) — reconnect soon.
+        onStateChange?.('closed')
+      } catch (err) {
+        if ((err as { code?: string } | null)?.code === 'SSE_UNSUPPORTED') {
+          // Terminal: the server has no /events route. Stop for good.
+          onStateChange?.('unsupported-server', err)
+          stopped = true
+          break
+        }
+        // Connect/network/abort error — SSE is additive, so we swallow it and
+        // reconnect. Polling keeps delivering in the meantime.
+        if (!stopped) onStateChange?.('error', err)
+      } finally {
+        clearReadyTimer()
+      }
+      if (stopped) break
+      // Reset backoff ONLY for a connection that stayed open long enough to be
+      // healthy; a flapping open/close keeps backing off (up to backoffMaxMs).
+      if (now() - startedAt >= minStableMs) attempt = 0
+      const delay = Math.min(backoffMaxMs, backoffBaseMs * 2 ** attempt) * (0.75 + random() * 0.5)
+      attempt += 1
+      await new Promise<void>((resolve) => { reconnectTimer = setTimeoutFn(resolve, delay) })
+      reconnectTimer = null
+    }
+    looping = false
+  }
+
+  return {
+    start() {
+      if (!supported) { onStateChange?.('unsupported'); return }
+      stopped = false
+      if (!looping) { attempt = 0; loop() }
+    },
+    stop() {
+      stopped = true
+      clearReadyTimer()
+      if (abortController) { try { abortController.abort() } catch { /* ignore */ } abortController = null }
+      if (reconnectTimer) { clearTimeoutFn(reconnectTimer); reconnectTimer = null }
+      onStateChange?.('stopped')
+    },
+    isRunning: () => !stopped,
+    isSupported: () => supported,
+  }
+}


### PR DESCRIPTION
Phase 1 of real-time vault sync: the app subscribes to the vault's `/events` SSE stream, and each nudge triggers the **same drains the polls already run** — `runDbSync` for the sync tier, the intents poller's own drain for the intents tier — so a completion made on another device (or in dayGLANCE) lands in under a second instead of at the next poll. Purely additive: every poll cadence is untouched as the correctness backstop, and the app degrades to exactly today's behavior when SSE is unavailable.

Also lands the seed-gate fix from the self-nudge-loop audit, in this PR deliberately: SSE is what turns that churn into a loop, so the fix ships with (or before) the thing that weaponizes it.

## What's in it

**`src/sync/vaultEventStream.ts`** — the pure transport core, ported from dayGLANCE's production client (post-#1316 truthful-protocol fix) against the verified wire format: named events `ready`/`activity`, data exactly `{"seq":N}`, no kinds, no `Last-Event-ID`. The seq is treated as an opaque monotonic watermark (blob bookkeeping advances it with no nudge — never compare gaps), and every accepted nudge drains both sides, since the wire carries no scope and the shared counter means a scope couldn't safely narrow a drain anyway. The `onDrain('sync'|'intents')` seam is kept, mirroring dayGLANCE, as the one documented place routing would slot in if the server ever grew scoped nudges.

Three hardenings over the dayGLANCE original, each earned by the GLANCEvault server audit:
- **Reconnect jitter (±25%)** — SSE connects count against the vault's per-IP rate limiter, and a silently-dead connection's cap slot can outlive its client; jitter keeps reconnecting devices from synchronizing into bursts against either.
- **Terminal 404** — a pre-`/events` server (Express default `404` + `text/html`; no JSON catch-all exists) stops the client for good. Reconnecting cannot grow a route, and polling covers identically. Every other status stays retryable.
- **Stalled diagnostic** — a stream that opens but delivers no frame within 5s reports `stalled` and logs loudly. The server sends `ready` immediately, so an open-but-silent stream is the buffering-reverse-proxy signature — the one SSE failure mode polling masks completely.

`credentials: 'omit'` on the stream fetch is load-bearing (the vault's CORS never sets `Allow-Credentials`).

**`src/hooks/useVaultEventStream.ts`** — React wrapper: connects when the vault is enabled and the app is visible, tears down on background (the `ready` frame reconciles on every reconnect), mount-keyed because vault config changes reload the app (SyncSettingsModal's existing contract). Live diagnostics at `window.__glanceVaultSse` (deliberately the same incantation as dayGLANCE); verbose tracing behind the `lastglance-debug-push` localStorage flag.

**Seed-gate fix (`src/sync/dbEngine.ts`)** — the first-sync snapshot seeding was gated on `getHighWaterMark() === 0`, which re-marked and re-pushed the full dataset on *every* cycle until a pull succeeded; the server nudges on byte-identical re-upserts, so with pushes succeeding while the pull failed or was backed off (the state 1.9.0's decoupling sustains), each push's own nudge would trigger the next cycle — a self-nudge loop. The gate is now a **one-shot persisted flag** (lifeGLANCE's pattern — chosen over the `getPushAck() === 0` alternative because a marking failure leaves the flag unset for a clean retry), set only after marking completes; the engine's persisted dirty set owns delivery from there, with full-ack retention unchanged. A **migration shim** latches the flag without re-marking when the pull cursor proves the first sync already completed, so existing devices don't burst redundant full-snapshot pushes (and fleet-wide nudges) on upgrade. Recovery-generation rewinds now force a re-pull only; the `RECOVERY_GENERATION` comment documents that a future generation wanting a forced re-push must clear the seed flag explicitly.

**`src/hooks/useDbIntentsPoller.ts`** — exports `drainDbIntents()`, which invokes the mounted poller's own `poll` (registered/unregistered with the hook's lifecycle). One drain, three triggers: timer, focus, nudge. No-op when unmounted or the transport is disabled.

**`src/App.tsx`** — one hook call wiring `runDbSync` + `drainDbIntents` into the stream. `runDbSync` is reused deliberately so the quarantine-badge (`vaultSkipped`) plumbing stays intact on nudge-triggered cycles.

## Out of scope

Native transports (phase 2): Capacitor shells report `native-unsupported` and keep polling, exactly like dayGLANCE's shells did before their readers shipped. The reference implementations to port are dayGLANCE's `VaultSseClient.kt` and `VaultSseBridge.swift`, repackaged as one Capacitor plugin.

## Verification

**Unit (297 total, 25 new):** frame parser and buffer drainer against real `ready`/`activity`/heartbeat blocks only (no fabricated fields); coalescer seq dedup, burst coalescing, drain-order, throwing-drain isolation; client backoff ladder with exact jitter bounds, stable-connection reset, terminal 404 (one attempt, zero reconnects scheduled), stalled detection; `openWebSseStream` header/credentials/404 contract. Seed gate through the **real** `createDbEngine`: fresh device seeds once and never re-marks across cycles with HWM still 0 (the loop's exact precondition), upgrading device latches without re-marking.

**Node harness** (shipped code bundled from `src/`, stub vault speaking the real wire format over real HTTP):

```
1. Seed-gate loop regression (pull failing 500, push succeeding, SSE live)
   batch writes: 2 (keycheck establish + ONE full-seed push)
   cycles run: 2 (mount + self-nudge-triggered) — no repeat pushes despite HWM=0  → PASS
2. Nudge during open pull-backoff window: pull suppressed by the engine        → PASS
   (SSE cannot bypass the 1.10.0 guard rail; row lands after window expiry)
   steady-state: peer push → applied in 465ms (400ms debounce + cycle)          → PASS
   intents drains fired per nudge (drain-both contract)                        → PASS
3. Reconnect reconcile: rows pushed while disconnected land via ready frame    → PASS
4. Pre-/events server: 404 terminal, exactly 1 attempt, client stopped         → PASS
5. Silent stream (buffering proxy): connecting → open → stalled                → PASS
6. Reconnect gaps under connect failures: 852ms, 2357ms, 4351ms (jittered 1/2/4s) → PASS
```

**Browser E2E** (the real app in Chromium via vite, stub vault with real CORS + preflight, passphrase typed through the actual modal): app connected (`transport=web`, `state=open`), then a node-side peer engine — same account, same passphrase-derived key — pushed a category, and the app **rendered it 905ms later** with no reload, no focus change, no poll trigger (`events=3, drains=4`). Screenshot in the session log.

`tsc -b` and `eslint --max-warnings 0` clean.

## Notes for the operator

- Nudges are account-scoped with no app scoping, so once this deploys, every lastGLANCE push will also wake foregrounded dayGLANCE clients (and vice versa). Each wake drains and no-ops — correct, but expect roughly doubled nudge volume in server logs.
- Your streaming path is already verified end to end (the outside-in `curl -sN` test), so `stalled` should never fire on your deployment; if it ever does, the reverse proxy config regressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_