### PR TITLE
Vault SSE phase 2: native Android reader (Capacitor plugin)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -106,6 +106,10 @@ dependencies {
     // WebDavHttpPlugin: CapacitorHttp's HttpURLConnection backend rejects WebDAV
     // verbs (PROPFIND/MKCOL), OkHttp does not.
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
+    // Explicit for the vault SSE reader (sse/VaultSseClient.kt). Already on the
+    // classpath transitively via androidx.glance (which is coroutine-based), but
+    // the reader must not depend on a transitive staying around.
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/app/src/main/java/com/lastglance/app/MainActivity.java
+++ b/android/app/src/main/java/com/lastglance/app/MainActivity.java
@@ -22,6 +22,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(BillingBridgePlugin.class);
         registerPlugin(WebDavHttpPlugin.class);
         registerPlugin(SecureStorePlugin.class);
+        registerPlugin(com.lastglance.app.sse.VaultSsePlugin.class);
         super.onCreate(savedInstanceState);
         captureWidgetDeepLink(getIntent());
         captureSharedText(getIntent());

--- a/android/app/src/main/java/com/lastglance/app/sse/SseBackoff.kt
+++ b/android/app/src/main/java/com/lastglance/app/sse/SseBackoff.kt
@@ -1,0 +1,50 @@
+package com.lastglance.app.sse
+
+/**
+ * Capped exponential backoff with a stability reset — the Kotlin mirror of the
+ * reconnect policy in `createVaultEventClient` (src/sync/vaultEventStream.ts).
+ * Ported from dayGLANCE's production reader (dayglance-android sse/SseBackoff.kt).
+ *
+ * A connection that stays open at least [minStableMs] is treated as healthy and
+ * resets the attempt counter, so a genuine long-lived stream that finally drops
+ * reconnects promptly. A connection that opens then drops immediately (a flap —
+ * server closing fast, proxy timeout, network reset) keeps backing off, up to
+ * [maxMs], so a broken endpoint can never storm the vault with reconnects.
+ *
+ * Pure and deterministic, so it is unit-testable with no clock or network.
+ */
+class SseBackoff(
+    private val baseMs: Long = 1_000,
+    private val maxMs: Long = 30_000,
+    private val minStableMs: Long = 5_000,
+) {
+
+    private var attempt = 0
+
+    /**
+     * The delay to wait before the NEXT reconnect attempt, then advances the
+     * counter. `base * 2^attempt`, capped at [maxMs]. The shift amount is clamped
+     * so a large attempt count can't overflow / wrap the Long shift.
+     */
+    fun nextDelayMs(): Long {
+        val shift = attempt.coerceIn(0, 30)
+        val delay = minOf(maxMs, baseMs shl shift)
+        attempt++
+        return delay
+    }
+
+    /**
+     * Record that a connection closed, given how long it had been open. Resets the
+     * backoff only when the connection was open at least [minStableMs] (a healthy
+     * stream), so the next reconnect starts back at [baseMs] rather than continuing
+     * to grow; a flap leaves the counter climbing.
+     */
+    fun onClosed(openDurationMs: Long) {
+        if (openDurationMs >= minStableMs) attempt = 0
+    }
+
+    /** Reset the backoff to its initial state. */
+    fun reset() {
+        attempt = 0
+    }
+}

--- a/android/app/src/main/java/com/lastglance/app/sse/SseFraming.kt
+++ b/android/app/src/main/java/com/lastglance/app/sse/SseFraming.kt
@@ -1,0 +1,77 @@
+package com.lastglance.app.sse
+
+/**
+ * Incremental Server-Sent-Events frame boundary detector — the Kotlin mirror of
+ * the renderer's `drainSseBuffer` (src/sync/vaultEventStream.ts). Ported from
+ * dayGLANCE's production reader (dayglance-android sse/SseFraming.kt).
+ *
+ * It does ONLY transport-level framing: accumulate stream text across reads, split
+ * complete event blocks on the blank-line delimiter, and hand each block back
+ * verbatim. It deliberately does NOT parse the `{seq}` nudge — that extraction
+ * stays in the renderer's single `parseSseFrame`, which this shell feeds each
+ * block through via the plugin event. Keeping ONE nudge parser (in the renderer)
+ * is the whole point of the bridge-fed design: the native side is a dumb, robust
+ * byte framer.
+ *
+ * Stateful per instance (holds the partial-block remainder between reads) and pure
+ * otherwise, so it is unit-testable with no network.
+ */
+class SseFraming(
+    // Cap on the retained (un-delimited) buffer. A server that streams bytes but
+    // never the "\n\n" block delimiter would otherwise grow this without bound
+    // (memory exhaustion). Real vault events are tiny nudges, so 1 MB is far above
+    // anything legitimate; a breach is treated as a stream failure by the caller.
+    private val maxBufferChars: Int = 1_048_576,
+) {
+
+    private val buffer = StringBuilder()
+
+    /**
+     * Append a decoded stream chunk and return every COMPLETE event block now
+     * available (delimited by a blank line). CRLF/CR are normalised to LF first,
+     * matching the renderer. Comment-only / heartbeat blocks (no `data:` line) are
+     * dropped here so the bridge isn't woken ~every 20 s for a frame the renderer
+     * would only parse to null anyway — a bandwidth/wakeup optimisation, not a
+     * correctness one (the renderer's parser would ignore them regardless).
+     */
+    fun append(chunk: String): List<String> {
+        buffer.append(chunk.replace("\r\n", "\n").replace('\r', '\n'))
+        val blocks = mutableListOf<String>()
+        var idx = buffer.indexOf("\n\n")
+        while (idx != -1) {
+            val block = buffer.substring(0, idx)
+            buffer.delete(0, idx + 2)
+            if (hasDataLine(block)) blocks.add(block)
+            idx = buffer.indexOf("\n\n")
+        }
+        // After draining every complete block, whatever remains is a single partial
+        // block still awaiting its delimiter. If that alone exceeds the cap the peer
+        // is misbehaving (or hostile) — bail so the caller can drop and reconnect
+        // rather than buffer unboundedly.
+        if (buffer.length > maxBufferChars) {
+            throw SseFramingOverflowException(buffer.length, maxBufferChars)
+        }
+        return blocks
+    }
+
+    /**
+     * Discard any partial block. Called when a connection drops and a new one is
+     * opened, so a half-received event from the dead stream can't be glued onto the
+     * first bytes of the fresh stream.
+     */
+    fun reset() {
+        buffer.setLength(0)
+    }
+
+    private fun hasDataLine(block: String): Boolean =
+        block.split('\n').any { it.startsWith("data:") }
+}
+
+/**
+ * Thrown by [SseFraming.append] when the retained partial-block buffer exceeds its
+ * cap. The reader treats it like any other read failure (drop the connection and
+ * reconnect with backoff), so a server that never delimits frames can't exhaust
+ * memory.
+ */
+class SseFramingOverflowException(size: Int, cap: Int) :
+    RuntimeException("SSE frame buffer exceeded cap: $size > $cap chars")

--- a/android/app/src/main/java/com/lastglance/app/sse/VaultSseClient.kt
+++ b/android/app/src/main/java/com/lastglance/app/sse/VaultSseClient.kt
@@ -1,0 +1,258 @@
+package com.lastglance.app.sse
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Native GLANCEvault SSE reader. Ported from dayGLANCE's production reader
+ * (dayglance-android sse/VaultSseClient.kt); the transport, lifecycle, and
+ * terminal-error policy are identical — only the renderer delivery differs
+ * (Capacitor plugin events via [VaultSsePlugin], not a WebView global).
+ *
+ * The WebView cannot stream `text/event-stream` (vault HTTP rides the buffered
+ * CapacitorHttp path), so the SHELL opens the stream instead: an authenticated
+ * `GET {vaultUrl}/events` with the Bearer device token, read incrementally,
+ * framed into SSE event blocks ([SseFraming]), and each block pushed into the
+ * renderer via [frameSink] (which [VaultSsePlugin] wires to notifyListeners).
+ * The renderer reuses its EXISTING `parseSseFrame` + coalescer + drains — this
+ * class owns ONLY the socket, its lifecycle, and reconnect.
+ *
+ * Because this is a native HTTP client (no browser origin), it needs NO vault
+ * CORS change. POLLING in the renderer stays the correctness backstop; these
+ * pushes only add instant drains on top.
+ *
+ * LIFECYCLE — the reader runs only when BOTH are true:
+ *   • the renderer has declared SSE desired ([enable] / [disable]), and
+ *   • the Activity is foreground ([setForeground]).
+ * It drops on background and reconnects with capped exponential backoff on any
+ * drop ([SseBackoff]). Every transition funnels through [reconcile], which
+ * starts or stops the SINGLE reader coroutine, so there is never more than one
+ * connection.
+ *
+ * RECONNECT-RECONCILE — on each (re)connect the vault sends its `ready` frame
+ * carrying the account's latest seq (`{"seq":N}`); it flows through [frameSink]
+ * like any other, so the renderer's coalescer drains and catches anything missed
+ * while disconnected.
+ */
+class VaultSseClient(
+    private val frameSink: (String) -> Unit,
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var readerJob: Job? = null
+
+    // The connection currently being read, so cancellation (background / disable)
+    // can force-close it and unblock the reader's blocking read().
+    @Volatile private var activeConnection: HttpURLConnection? = null
+
+    @Volatile private var desired = false
+    @Volatile private var foreground = false
+    @Volatile private var vaultUrl: String? = null
+    @Volatile private var token: String? = null
+    @Volatile private var accountId: String? = null
+
+    /** Renderer → "SSE desired ON", with the vault connection params. */
+    @Synchronized
+    fun enable(url: String, bearer: String, account: String) {
+        vaultUrl = url.trimEnd('/')
+        token = bearer
+        accountId = account
+        desired = true
+        reconcile()
+    }
+
+    /** Renderer → "SSE desired OFF". */
+    @Synchronized
+    fun disable() {
+        desired = false
+        reconcile()
+    }
+
+    /** Activity foreground/background (handleOnStart / handleOnStop). */
+    @Synchronized
+    fun setForeground(fg: Boolean) {
+        foreground = fg
+        reconcile()
+    }
+
+    /** Full teardown — Activity destroyed. No leaked connection or coroutine. */
+    @Synchronized
+    fun shutdown() {
+        desired = false
+        foreground = false
+        stopReader()
+        scope.cancel()
+    }
+
+    private fun shouldRun(): Boolean =
+        desired && foreground && vaultUrl != null && token != null && accountId != null
+
+    private fun reconcile() {
+        if (shouldRun()) startReader() else stopReader()
+    }
+
+    private fun startReader() {
+        if (readerJob?.isActive == true) return
+        val url = vaultUrl ?: return
+        val bearer = token ?: return
+        val account = accountId ?: return
+        readerJob = scope.launch { runLoop(url, bearer, account) }
+    }
+
+    private fun stopReader() {
+        readerJob?.cancel()
+        readerJob = null
+        // Unblock a reader parked in a blocking read(): coroutine cancellation alone
+        // won't interrupt java.io, so force-close the socket.
+        try { activeConnection?.disconnect() } catch (_: Exception) {}
+    }
+
+    private suspend fun runLoop(url: String, bearer: String, account: String) {
+        val backoff = SseBackoff()
+        while (coroutineContext[Job]?.isActive == true) {
+            val openedAt = System.currentTimeMillis()
+            try {
+                connectAndRead(url, bearer, account)
+            } catch (e: SseTerminalException) {
+                // TERMINAL (auth failure / insecure URL): retrying can't help, so stop
+                // the reader entirely — no reconnect. Push a coded event so the renderer
+                // surfaces it exactly once instead of every 30s. A later enable() (user
+                // fixed the token/URL) launches a fresh reader normally.
+                if (coroutineContext[Job]?.isActive != true) return
+                Log.w(TAG, "SSE terminal (${e.code}): ${e.message}")
+                push(JSONObject().put("type", "error").put("code", e.code).put("message", e.message ?: e.code))
+                return
+            } catch (e: Exception) {
+                if (coroutineContext[Job]?.isActive != true) return // cancelled → done
+                Log.w(TAG, "SSE read error: ${e.message}")
+                push(JSONObject().put("type", "error").put("message", e.message ?: "sse error"))
+            }
+            if (coroutineContext[Job]?.isActive != true) return
+            // The stream ended (server close / read timeout / drop). Tell the
+            // renderer, then reconnect with backoff — resetting it only if the
+            // connection had been healthy long enough.
+            push(JSONObject().put("type", "closed"))
+            backoff.onClosed(System.currentTimeMillis() - openedAt)
+            delay(backoff.nextDelayMs())
+        }
+    }
+
+    private suspend fun connectAndRead(url: String, bearer: String, account: String) {
+        val target = URL("$url/events?accountId=" + URLEncoder.encode(account, "UTF-8"))
+        // Belt-and-braces (the settings form is the primary gate): never send the
+        // Bearer token over cleartext http on the public internet. https is always
+        // fine; http is allowed only for loopback/LAN hosts. A refusal is TERMINAL —
+        // reconnecting can't fix a bad scheme. (Android's manifest also blocks
+        // cleartext to non-local hosts; this fails EARLY and with a clear reason.)
+        if (!isSecureOrLanUrl(target)) {
+            throw SseTerminalException("insecure", "vault SSE refused: insecure http URL")
+        }
+        val conn = (target.openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            setRequestProperty("Authorization", "Bearer $bearer")
+            setRequestProperty("Accept", "text/event-stream")
+            connectTimeout = 20_000
+            // Longer than the ~20 s server heartbeat so a healthy idle stream never
+            // trips it, but a silently-dead connection is detected and reconnected
+            // within the timeout instead of parking forever.
+            readTimeout = 60_000
+            instanceFollowRedirects = true
+        }
+        activeConnection = conn
+        try {
+            val code = conn.responseCode
+            // 401/403 are auth failures — a revoked/invalid device token. Retrying just
+            // reconnects forever at the 30s cap and re-hits the same 401, so this is
+            // TERMINAL: stop the reader and push a distinct coded event the renderer
+            // surfaces once. A fresh enable() (user fixed the token) reconnects normally.
+            if (code == 401 || code == 403) {
+                throw SseTerminalException("auth", "vault SSE auth failed: $code")
+            }
+            // 404 means the server predates /events entirely (Express default route).
+            // Same terminal logic: reconnecting cannot grow a route; the renderer's
+            // polling covers the app identically. Mirrors the web transport's
+            // SseUnsupportedError classification.
+            if (code == 404) {
+                throw SseTerminalException("unsupported", "vault SSE unavailable: server predates /events")
+            }
+            if (code !in 200..299) throw RuntimeException("vault SSE connect failed: $code")
+            push(JSONObject().put("type", "open"))
+
+            val framing = SseFraming()
+            val reader = BufferedReader(InputStreamReader(conn.inputStream, Charsets.UTF_8))
+            val chunk = CharArray(2048)
+            while (coroutineContext[Job]?.isActive == true) {
+                val n = reader.read(chunk) // blocks until data, EOF (-1), or read timeout
+                if (n == -1) break         // server closed the stream
+                for (block in framing.append(String(chunk, 0, n))) {
+                    push(JSONObject().put("type", "frame").put("block", block))
+                }
+            }
+        } finally {
+            activeConnection = null
+            try { conn.disconnect() } catch (_: Exception) {}
+        }
+    }
+
+    private fun push(msg: JSONObject) {
+        // frameSink is any-thread safe: VaultSsePlugin routes it through
+        // notifyListeners, which queues onto the Capacitor bridge.
+        frameSink(msg.toString())
+    }
+
+    // ── URL transport-security allowlist ─────────────────────────────────────
+
+    /** https is always allowed; http only for loopback/LAN hosts; anything else no. */
+    private fun isSecureOrLanUrl(url: URL): Boolean {
+        val scheme = (url.protocol ?: "").lowercase()
+        if (scheme == "https") return true
+        if (scheme != "http") return false
+        return isLocalOrLanHost(url.host ?: "")
+    }
+
+    /** True for loopback / private-LAN / *.local hosts, where cleartext http is ok. */
+    private fun isLocalOrLanHost(rawHost: String): Boolean {
+        var host = rawHost.trim().lowercase()
+        if (host.startsWith("[") && host.endsWith("]")) host = host.substring(1, host.length - 1)
+        if (host.isEmpty()) return false
+        if (host == "localhost" || host.endsWith(".localhost")) return true
+        if (host == "::1") return true
+        if (host.endsWith(".local")) return true
+        val m = Regex("""^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$""").find(host) ?: return false
+        val octets = m.groupValues.drop(1).map { it.toInt() }
+        if (octets.any { it > 255 }) return false
+        val (a, b) = octets
+        return when {
+            a == 127 -> true               // 127.0.0.0/8 loopback
+            a == 10 -> true                // 10.0.0.0/8
+            a == 192 && b == 168 -> true   // 192.168.0.0/16
+            a == 172 && b in 16..31 -> true // 172.16.0.0/12
+            else -> false
+        }
+    }
+
+    companion object {
+        private const val TAG = "VaultSseClient"
+    }
+}
+
+/**
+ * A TERMINAL SSE error: the reader must stop and NOT reconnect (retrying can't
+ * help). [code] distinguishes the cause for the renderer ('auth' =
+ * revoked/invalid token; 'insecure' = refused cleartext URL; 'unsupported' =
+ * server predates /events).
+ */
+class SseTerminalException(val code: String, message: String) : Exception(message)

--- a/android/app/src/main/java/com/lastglance/app/sse/VaultSsePlugin.kt
+++ b/android/app/src/main/java/com/lastglance/app/sse/VaultSsePlugin.kt
@@ -1,0 +1,79 @@
+package com.lastglance.app.sse
+
+import com.getcapacitor.JSObject
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+import org.json.JSONObject
+
+/**
+ * Capacitor face of the native GLANCEvault SSE reader ([VaultSseClient]).
+ *
+ * The renderer (src/hooks/useVaultEventStream.ts, 'native-bridge' transport)
+ * declares intent with start/stop and receives every reader message as an
+ * `sseMessage` plugin event — the same `{type, block?/message?/code?}` shapes
+ * dayGLANCE's shells push, so the renderer-side bridge client is shared code:
+ *   {type:'open'}                    a (re)connection was established
+ *   {type:'frame', block:'…'}        one raw SSE event block → parseSseFrame
+ *   {type:'closed'}                  the stream dropped (native will reconnect)
+ *   {type:'error', message, code?}   a coded error is TERMINAL (native stopped)
+ *
+ * The plugin owns only the wiring: lifecycle (foreground/background via the
+ * Capacitor activity callbacks) and delivery (notifyListeners, any-thread
+ * safe). The socket, reconnect, and terminal policy live in [VaultSseClient].
+ * Capability detection needs no method here — the renderer probes
+ * Capacitor.isPluginAvailable('VaultSse'), which an older shell without this
+ * plugin answers false, degrading cleanly to polling.
+ */
+@CapacitorPlugin(name = "VaultSse")
+class VaultSsePlugin : Plugin() {
+
+    private var client: VaultSseClient? = null
+
+    override fun load() {
+        client = VaultSseClient { msg ->
+            try {
+                notifyListeners("sseMessage", JSObject.fromJSONObject(JSONObject(msg)))
+            } catch (_: Exception) {
+                // A malformed reader message must never break the bridge.
+            }
+        }
+    }
+
+    @PluginMethod
+    fun start(call: PluginCall) {
+        val url = call.getString("vaultUrl")
+        val token = call.getString("vaultToken")
+        val account = call.getString("accountId")
+        if (url.isNullOrEmpty() || token.isNullOrEmpty() || account.isNullOrEmpty()) {
+            call.reject("vaultUrl, vaultToken, and accountId are required")
+            return
+        }
+        client?.enable(url, token, account)
+        call.resolve()
+    }
+
+    @PluginMethod
+    fun stop(call: PluginCall) {
+        client?.disable()
+        call.resolve()
+    }
+
+    // Foreground/background gating mirrors dayGLANCE's Activity wiring: the
+    // reader connects only while the Activity is started, drops on stop (the OS
+    // would kill the socket anyway), and the vault's `ready` frame reconciles on
+    // every reconnect.
+    override fun handleOnStart() {
+        client?.setForeground(true)
+    }
+
+    override fun handleOnStop() {
+        client?.setForeground(false)
+    }
+
+    override fun handleOnDestroy() {
+        client?.shutdown()
+        client = null
+    }
+}

--- a/android/app/src/test/java/com/lastglance/app/sse/SseBackoffTest.kt
+++ b/android/app/src/test/java/com/lastglance/app/sse/SseBackoffTest.kt
@@ -1,0 +1,59 @@
+package com.lastglance.app.sse
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for the native reconnect backoff. Mirrors the flap-guard / stability-
+ * reset policy the renderer's createVaultEventClient is tested for, so native and
+ * web reconnect behaviour match: a flap keeps backing off (no storm), a healthy
+ * connection resets so a later drop reconnects fast.
+ */
+class SseBackoffTest {
+
+    @Test
+    fun `grows exponentially and caps at maxMs`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        assertEquals(1_000, b.nextDelayMs())  // 1000 * 2^0
+        assertEquals(2_000, b.nextDelayMs())  // 2^1
+        assertEquals(4_000, b.nextDelayMs())  // 2^2
+        assertEquals(8_000, b.nextDelayMs())  // 2^3
+        assertEquals(16_000, b.nextDelayMs()) // 2^4
+        assertEquals(30_000, b.nextDelayMs()) // 32000 capped to 30000
+        assertEquals(30_000, b.nextDelayMs()) // stays capped
+    }
+
+    @Test
+    fun `a flap (closed before minStableMs) does NOT reset — backoff keeps growing`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        assertEquals(1_000, b.nextDelayMs())
+        b.onClosed(50)                        // opened then dropped fast → no reset
+        assertEquals(2_000, b.nextDelayMs())  // continues to grow, no 1s storm
+        b.onClosed(100)
+        assertEquals(4_000, b.nextDelayMs())
+    }
+
+    @Test
+    fun `a stable connection (open past minStableMs) resets so the next reconnect is fast`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 60_000, minStableMs = 5_000)
+        b.nextDelayMs(); b.nextDelayMs(); b.nextDelayMs() // climb to attempt=3
+        b.onClosed(10_000)                    // healthy: open 10s ≥ 5s → reset
+        assertEquals(1_000, b.nextDelayMs())  // back to base
+    }
+
+    @Test
+    fun `reset returns to base`() {
+        val b = SseBackoff(baseMs = 500)
+        b.nextDelayMs(); b.nextDelayMs()
+        b.reset()
+        assertEquals(500, b.nextDelayMs())
+    }
+
+    @Test
+    fun `many attempts never overflow the delay (stays capped, non-negative)`() {
+        val b = SseBackoff(baseMs = 1_000, maxMs = 30_000, minStableMs = 5_000)
+        repeat(200) { b.nextDelayMs() }
+        val d = b.nextDelayMs()
+        assertEquals(30_000, d) // clamped shift → no overflow/wrap to a bogus delay
+    }
+}

--- a/android/app/src/test/java/com/lastglance/app/sse/SseFramingTest.kt
+++ b/android/app/src/test/java/com/lastglance/app/sse/SseFramingTest.kt
@@ -1,0 +1,90 @@
+package com.lastglance.app.sse
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the native SSE frame boundary detector. Mirrors the behaviour
+ * the renderer's drainSseBuffer is tested for (src/sync/vaultEventStream.test.ts),
+ * so the native framing and the JS parser agree on what a "complete event block"
+ * is. Fixtures use the REAL wire format — named `ready`/`activity` events whose
+ * data is exactly {"seq":N} — never fabricated fields.
+ */
+class SseFramingTest {
+
+    @Test
+    fun `emits complete blocks and carries the partial remainder across reads`() {
+        val f = SseFraming()
+        // Two complete events plus a partial third, split awkwardly across reads.
+        val first = f.append("event: ready\ndata: {\"seq\":1}\n\nevent: activity\ndata: {\"seq\":2")
+        assertEquals(listOf("event: ready\ndata: {\"seq\":1}"), first)
+
+        // The partial second event is buffered — nothing emitted yet.
+        val second = f.append("}\n\n")
+        assertEquals(listOf("event: activity\ndata: {\"seq\":2}"), second)
+    }
+
+    @Test
+    fun `normalizes CRLF and CR frame boundaries`() {
+        val f = SseFraming()
+        val blocks = f.append("event: activity\r\ndata: {\"seq\":7}\r\n\r\n")
+        assertEquals(listOf("event: activity\ndata: {\"seq\":7}"), blocks)
+    }
+
+    @Test
+    fun `drops heartbeat and comment-only blocks (no data line)`() {
+        val f = SseFraming()
+        val blocks = f.append(": heartbeat\n\nevent: ping\n\nevent: activity\ndata: {\"seq\":4}\n\n")
+        // Only the block carrying a data: line is forwarded.
+        assertEquals(listOf("event: activity\ndata: {\"seq\":4}"), blocks)
+    }
+
+    @Test
+    fun `multi-line block is forwarded verbatim for the renderer to parse`() {
+        val f = SseFraming()
+        val block = "event: activity\nid: 9\ndata: {\"seq\":9}"
+        val blocks = f.append("$block\n\n")
+        assertEquals(listOf(block), blocks)
+    }
+
+    @Test
+    fun `reset discards a partial block so a new stream does not glue onto the old`() {
+        val f = SseFraming()
+        f.append("event: activity\ndata: {\"seq\":1") // partial, buffered
+        f.reset()
+        // Fresh stream after reconnect: the leftover partial must be gone.
+        val blocks = f.append("event: ready\ndata: {\"seq\":2}\n\n")
+        assertEquals(listOf("event: ready\ndata: {\"seq\":2}"), blocks)
+    }
+
+    @Test(expected = SseFramingOverflowException::class)
+    fun `throws when a single undelimited frame exceeds the cap`() {
+        // A server that streams bytes but never the "\n\n" delimiter must not grow the
+        // buffer without bound — append throws once the retained partial exceeds the cap.
+        val f = SseFraming(maxBufferChars = 1024)
+        f.append("data: " + "x".repeat(2000)) // no blank-line boundary, over cap
+    }
+
+    @Test
+    fun `does not throw while the buffer stays under the cap and still drains`() {
+        val f = SseFraming(maxBufferChars = 1024)
+        // Under-cap partial is retained (no throw); a later delimiter completes it.
+        assertEquals(emptyList<String>(), f.append("event: activity\ndata: {\"seq\":1"))
+        val blocks = f.append("}\n\n")
+        assertEquals(listOf("event: activity\ndata: {\"seq\":1}"), blocks)
+    }
+
+    @Test
+    fun `handles several complete blocks in one chunk`() {
+        val f = SseFraming()
+        val blocks = f.append(
+            "event: ready\ndata: {\"seq\":1}\n\n" +
+                "event: activity\ndata: {\"seq\":2}\n\n" +
+                "event: activity\ndata: {\"seq\":3}\n\n"
+        )
+        assertEquals(3, blocks.size)
+        assertTrue(blocks[0].contains("ready"))
+        assertTrue(blocks[2].contains("{\"seq\":3}"))
+    }
+}

--- a/src/hooks/useVaultEventStream.ts
+++ b/src/hooks/useVaultEventStream.ts
@@ -19,8 +19,11 @@
 // current — the same lifecycle contract the DB engine construction relies on.
 
 import { useEffect, useRef } from 'react'
+import type { PluginListenerHandle } from '@capacitor/core'
 import { getVaultConfig, isVaultEnabled } from '@/sync/vaultConfig'
+import { VaultSse } from '@/native/vaultSse'
 import {
+  createBridgeSseClient,
   createNudgeCoalescer,
   createVaultEventClient,
   detectSseTransport,
@@ -38,6 +41,10 @@ interface VaultSseDiag {
   lastEventSeq: number | null
   lastError: string | null
   stalled: boolean
+  // A terminal code from the native reader ('auth' | 'insecure' |
+  // 'unsupported'): native stopped and will NOT reconnect. Fixing the config
+  // reloads the app, which starts a fresh reader.
+  terminal: string | null
   lastConnectedAt: string | null
 }
 
@@ -56,9 +63,9 @@ export function useVaultEventStream({ drainSync, drainIntents }: {
     if (!isVaultEnabled()) return undefined
 
     const transport = detectSseTransport()
-    if (transport !== 'web') {
-      // 'native-unsupported' (Capacitor shell, phase 2 pending) / 'none' (SSR):
-      // nothing to open, nothing to clean up — polling backstop only.
+    if (transport !== 'web' && transport !== 'native-bridge') {
+      // 'native-unsupported' (a shell without the VaultSse plugin) / 'none'
+      // (SSR): nothing to open, nothing to clean up — polling backstop only.
       if (import.meta.env?.DEV) {
         console.info('[vault-sse] streaming unavailable on', transport, '— polling backstop only')
       }
@@ -75,7 +82,8 @@ export function useVaultEventStream({ drainSync, drainIntents }: {
     // stalled diagnostic still log unconditionally.
     const diag: VaultSseDiag = {
       state: 'idle', transport, connects: 0, events: 0, drains: 0,
-      lastEventSeq: null, lastError: null, stalled: false, lastConnectedAt: null,
+      lastEventSeq: null, lastError: null, stalled: false, terminal: null,
+      lastConnectedAt: null,
     }
     ;(window as unknown as Record<string, unknown>).__glanceVaultSse = diag
 
@@ -104,8 +112,19 @@ export function useVaultEventStream({ drainSync, drainIntents }: {
         diag.stalled = true
         console.warn('[vault-sse] stream opened but no frame arrived — a reverse proxy is likely buffering /events; SSE is inert and polling is covering')
       } else if (state === 'error') {
-        diag.lastError = detail instanceof Error ? detail.message : String(detail ?? 'error')
-        console.warn('[vault-sse] error:', diag.lastError)
+        const coded = detail as { message?: string; code?: string } | null
+        diag.lastError = detail instanceof Error ? detail.message
+          : coded?.message ?? String(detail ?? 'error')
+        // A coded error from the native reader is TERMINAL: native stopped and
+        // will not reconnect ('auth' / 'insecure' / 'unsupported'). It surfaces
+        // exactly once — warn loudly; fixing the config reloads the app, which
+        // starts a fresh reader. Polling covers meanwhile.
+        if (coded && typeof coded === 'object' && coded.code) {
+          diag.terminal = coded.code
+          console.warn(`[vault-sse] terminal error (${coded.code}) — native reader stopped, not reconnecting:`, diag.lastError)
+        } else {
+          console.warn('[vault-sse] error:', diag.lastError)
+        }
       } else if (state === 'unsupported-server') {
         console.warn('[vault-sse] this GLANCEvault server predates /events — push disabled, polling covers')
       } else if (sseDebug()) {
@@ -120,15 +139,48 @@ export function useVaultEventStream({ drainSync, drainIntents }: {
         : null
     }
 
+    const onEvent = (evt: unknown) => {
+      diag.events += 1
+      const seq = (evt as { seq?: number } | null)?.seq
+      if (typeof seq === 'number') diag.lastEventSeq = seq
+      coalescer.handleEvent(evt)
+    }
+
+    // ── NATIVE-BRIDGE: the shell owns the socket + reconnect + fg/bg ─────────
+    if (transport === 'native-bridge') {
+      const client = createBridgeSseClient({
+        getConnection,
+        // JS → native: hand over the connection and say "SSE desired on". The
+        // shell connects only while the Activity is foreground and reconnects
+        // with backoff — all invisible here.
+        startNative: (c) => {
+          VaultSse.start({ vaultUrl: c.vaultUrl, vaultToken: c.vaultToken, accountId: c.accountId })
+            .catch(err => onStateChange('error', err instanceof Error ? err.message : String(err)))
+        },
+        stopNative: () => { VaultSse.stop().catch(() => { /* teardown is best-effort */ }) },
+        onEvent,
+        onStateChange,
+      })
+      // Native → JS: every reader message arrives as an sseMessage plugin event.
+      let handle: PluginListenerHandle | undefined
+      VaultSse.addListener('sseMessage', client.receive).then(h => { handle = h })
+      // No visibilitychange wiring here: the native shell owns
+      // foreground/background (Activity lifecycle) and reconnect. The renderer
+      // only declares intent and hands over the connection.
+      client.start()
+
+      return () => {
+        client.stop()
+        handle?.remove()
+        coalescer.cancel()
+      }
+    }
+
+    // ── WEB: JS owns the fetch stream + reconnect/backoff ────────────────────
     const client = createVaultEventClient({
       getConnection,
       openStream: openWebSseStream,
-      onEvent: (evt) => {
-        diag.events += 1
-        const seq = (evt as { seq?: number } | null)?.seq
-        if (typeof seq === 'number') diag.lastEventSeq = seq
-        coalescer.handleEvent(evt)
-      },
+      onEvent,
       onStateChange,
     })
 

--- a/src/native/vaultSse.ts
+++ b/src/native/vaultSse.ts
@@ -1,0 +1,45 @@
+import { Capacitor, registerPlugin, type PluginListenerHandle } from '@capacitor/core'
+
+// Native GLANCEvault SSE reader (Android today; the iOS shell will implement the
+// same plugin surface). The WebView cannot stream /events (vault HTTP rides the
+// buffered CapacitorHttp path), so the SHELL owns the socket — connecting while
+// foreground, dropping on background, reconnecting with backoff — and pushes
+// every reader message in as an `sseMessage` plugin event. The renderer's bridge
+// client (createBridgeSseClient in src/sync/vaultEventStream.ts) funnels frames
+// through the SAME parseSseFrame → coalescer → drains as the web transport.
+//
+// Message shapes (identical to dayGLANCE's shells, so the renderer logic is
+// shared across the app family):
+//   {type:'open'}                    a native (re)connection was established
+//   {type:'frame', block:'…'}        one raw SSE event block
+//   {type:'closed'}                  the stream dropped (native will reconnect)
+//   {type:'error', message, code?}   coded errors are TERMINAL — native stopped
+//                                    and will NOT reconnect ('auth' = rejected
+//                                    token, 'insecure' = refused cleartext URL,
+//                                    'unsupported' = server predates /events)
+
+export interface VaultSseNativeMessage {
+  type: 'open' | 'frame' | 'closed' | 'error'
+  block?: string
+  message?: string
+  code?: string
+}
+
+export interface VaultSsePluginType {
+  start(options: { vaultUrl: string; vaultToken: string; accountId: string }): Promise<void>
+  stop(): Promise<void>
+  addListener(
+    eventName: 'sseMessage',
+    listenerFunc: (msg: VaultSseNativeMessage) => void,
+  ): Promise<PluginListenerHandle>
+}
+
+export const VaultSse = registerPlugin<VaultSsePluginType>('VaultSse')
+
+// Strict capability probe: true only when a native shell actually registered
+// the plugin. An older shell (APK predating the reader) answers false and the
+// app keeps its polling behavior — the same degrade-to-polling contract
+// dayGLANCE's shells established.
+export function isVaultSseNativeAvailable(): boolean {
+  return Capacitor.isNativePlatform() && Capacitor.isPluginAvailable('VaultSse')
+}

--- a/src/sync/vaultEventStream.test.ts
+++ b/src/sync/vaultEventStream.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   parseSseFrame,
   drainSseBuffer,
+  createBridgeSseClient,
   createNudgeCoalescer,
   createVaultEventClient,
   openWebSseStream,
@@ -225,6 +226,80 @@ describe('createVaultEventClient', () => {
     })
     client.start()
     await vi.waitFor(() => expect(states).toContain('stalled'))
+  })
+})
+
+describe('createBridgeSseClient', () => {
+  const connection = { vaultUrl: 'http://v', vaultToken: 't', accountId: 'a' }
+
+  function make(getConnection: () => typeof connection | null = () => connection) {
+    const started: unknown[] = []
+    let stops = 0
+    const events: unknown[] = []
+    const states: Array<[SseClientState, unknown?]> = []
+    const client = createBridgeSseClient({
+      getConnection,
+      startNative: c => started.push(c),
+      stopNative: () => { stops++ },
+      onEvent: e => events.push(e),
+      onStateChange: (s, d) => states.push([s, d]),
+    })
+    return { client, started, events, states, stops: () => stops }
+  }
+
+  it('start hands the connection to native; stop tears down; both idempotent', () => {
+    const { client, started, stops } = make()
+    expect(client.start()).toBe(true)
+    expect(client.start()).toBe(false) // already running
+    expect(started).toEqual([connection])
+    client.stop()
+    client.stop()
+    expect(stops()).toBe(1)
+    expect(client.isRunning()).toBe(false)
+  })
+
+  it('does not start without a connection (polling covers)', () => {
+    const { client, started } = make(() => null)
+    expect(client.start()).toBe(false)
+    expect(started).toEqual([])
+  })
+
+  it('routes frames through the shared parser and forwards only real nudges', () => {
+    const { client, events } = make()
+    client.receive({ type: 'frame', block: 'event: ready\ndata: {"seq":3}' })
+    client.receive({ type: 'frame', block: 'event: activity\ndata: {"seq":7}' })
+    client.receive({ type: 'frame', block: ': heartbeat' })    // parses to null → dropped
+    client.receive({ type: 'frame', block: 'data: not-json' }) // unparseable → dropped
+    expect(events).toEqual([{ seq: 3 }, { seq: 7 }])
+  })
+
+  it('accepts JSON-string messages from a stringifying shell', () => {
+    const { client, events, states } = make()
+    client.receive('{"type":"open"}')
+    client.receive('{"type":"frame","block":"event: activity\\ndata: {\\"seq\\":9}"}')
+    expect(states).toEqual([['open', undefined]])
+    expect(events).toEqual([{ seq: 9 }])
+  })
+
+  it('surfaces coded (terminal) errors with the code attached, plain errors without', () => {
+    const { client, states } = make()
+    client.receive({ type: 'error', message: 'auth failed: 401', code: 'auth' })
+    client.receive({ type: 'error', message: 'read reset' })
+    expect(states).toEqual([
+      ['error', { message: 'auth failed: 401', code: 'auth' }],
+      ['error', 'read reset'],
+    ])
+  })
+
+  it('ignores malformed pushes without throwing', () => {
+    const { client, events, states } = make()
+    client.receive(null)
+    client.receive(42)
+    client.receive('not json')
+    client.receive({ type: 'mystery' })
+    client.receive({ type: 'frame' }) // no block
+    expect(events).toEqual([])
+    expect(states).toEqual([])
   })
 })
 

--- a/src/sync/vaultEventStream.ts
+++ b/src/sync/vaultEventStream.ts
@@ -29,20 +29,23 @@
 // backoff (@glance-apps/sync 1.10.0) additionally guarantees a nudge-triggered
 // cycle can never hammer a failing server.
 //
-// TRANSPORTS (phase 1: web only):
+// TRANSPORTS:
 //   • WEB (browser/PWA): EventSource cannot set an Authorization header, and the
 //     vault authenticates with a Bearer token — so we use a fetch-based
 //     streaming reader (response.body.getReader()). See openWebSseStream.
-//   • NATIVE (Capacitor Android/iOS): vault HTTP rides CapacitorHttp (whole-body,
-//     cannot stream), and a WebView fetch to the vault is constrained by the
-//     same CORS/cleartext realities that made CapacitorHttp necessary — so
-//     streaming inside the WebView is not attempted. detectSseTransport reports
-//     'native-unsupported' and the app keeps its polling behavior, exactly as
-//     dayGLANCE's shells did before their native readers shipped. Phase 2 is a
-//     small Capacitor plugin owning the socket natively (reference
-//     implementations: dayGLANCE's VaultSseClient.kt / VaultSseBridge.swift).
+//   • NATIVE-BRIDGE (Capacitor shells with the VaultSse plugin): vault HTTP
+//     rides CapacitorHttp (whole-body, cannot stream), so the SHELL owns the
+//     socket — a native SSE reader (Android sse/VaultSseClient.kt; iOS pending)
+//     that connects while foreground, drops on background, reconnects with
+//     backoff, and pushes each raw SSE block in as a plugin event. The renderer
+//     reuses the SAME parseSseFrame + coalescer + drains — only the transport
+//     INPUT differs (see createBridgeSseClient). No vault CORS change: a native
+//     HTTP client has no browser origin.
+//   • NATIVE-UNSUPPORTED (a shell without the plugin — an older APK, or iOS
+//     until its reader ships): polling only, exactly today's behavior.
 
 import { isNativePlatform } from './nativeHttp'
+import { isVaultSseNativeAvailable } from '@/native/vaultSse'
 
 // ─── SSE frame parsing ───────────────────────────────────────────────────────
 
@@ -101,16 +104,18 @@ export function drainSseBuffer(buffer: string, onEvent: (evt: unknown) => void):
 
 // ─── transport detection ─────────────────────────────────────────────────────
 
-export type SseTransport = 'web' | 'native-unsupported' | 'none'
+export type SseTransport = 'web' | 'native-bridge' | 'native-unsupported' | 'none'
 
 /**
- * Which SSE consumption path this runtime supports. 'web' opens a stream; every
- * other value degrades to polling (the permanent correctness backstop).
+ * Which SSE consumption path this runtime supports. 'web' and 'native-bridge'
+ * open a stream; every other value degrades to polling (the permanent
+ * correctness backstop).
  */
 export function detectSseTransport(): SseTransport {
   if (typeof window === 'undefined') return 'none'
-  // Capacitor shell: no streaming vault path exists in phase 1 (see header).
-  if (isNativePlatform) return 'native-unsupported'
+  // Capacitor shell: the shell streams natively when it carries the VaultSse
+  // plugin; an older shell degrades to polling (see header).
+  if (isNativePlatform) return isVaultSseNativeAvailable() ? 'native-bridge' : 'native-unsupported'
   if (typeof fetch === 'function' && typeof ReadableStream !== 'undefined') return 'web'
   return 'none'
 }
@@ -424,5 +429,108 @@ export function createVaultEventClient({
     },
     isRunning: () => !stopped,
     isSupported: () => supported,
+  }
+}
+
+// ─── bridge-fed client (native shell owns the socket) ────────────────────────
+
+export interface BridgeSseClient {
+  receive: (msg: unknown) => void
+  start: () => boolean
+  stop: () => void
+  isRunning: () => boolean
+}
+
+/**
+ * The renderer half of the 'native-bridge' transport, ported from dayGLANCE.
+ * Unlike createVaultEventClient (which owns a fetch stream + JS-side
+ * reconnect/backoff), here the NATIVE SHELL owns the socket and its whole
+ * lifecycle: it connects when foreground, drops on background, and reconnects
+ * with backoff — all invisible to JS. This client's job is only to (a) tell
+ * native "SSE desired on/off" with the connection params, and (b) funnel the
+ * raw SSE blocks native pushes back through the SAME parseSseFrame + onEvent
+ * (→ coalescer → drains) the web path uses. There is deliberately NO JS
+ * reconnect loop here — reconnect belongs to exactly ONE owner per transport,
+ * and for native that owner is the shell. Polling remains the backstop.
+ *
+ * `receive` is fed by the VaultSse plugin's `sseMessage` events (see
+ * src/native/vaultSse.ts for the message shapes). A coded error means the
+ * native reader stopped TERMINALLY and will not reconnect ('auth',
+ * 'insecure', 'unsupported') — surfaced once via onStateChange with the code
+ * attached so the consumer can distinguish it.
+ */
+export function createBridgeSseClient({
+  getConnection,
+  startNative,
+  stopNative,
+  onEvent,
+  onStateChange,
+}: {
+  getConnection: () => VaultSseConnection | null
+  startNative: (connection: VaultSseConnection) => void
+  stopNative: () => void
+  onEvent: (evt: unknown) => void
+  onStateChange?: (state: SseClientState, detail?: unknown) => void
+}): BridgeSseClient {
+  let running = false
+
+  // The native shell pushes messages here. Accepts a parsed object OR a JSON
+  // string (a shell that stringifies is handled too). Never throws — a
+  // malformed push is ignored so it can't break the bridge.
+  const receive = (msg: unknown) => {
+    if (typeof msg === 'string') {
+      try { msg = JSON.parse(msg) } catch { return }
+    }
+    if (!msg || typeof msg !== 'object') return
+    const m = msg as { type?: string; block?: string; message?: string; code?: string }
+    switch (m.type) {
+      case 'open':
+        onStateChange?.('open')
+        break
+      case 'frame': {
+        // Reuse the EXISTING parser: native did transport + frame boundary
+        // detection; {seq} extraction stays in ONE place (parseSseFrame).
+        if (typeof m.block === 'string') {
+          const evt = parseSseFrame(m.block)
+          if (evt) onEvent(evt)
+        }
+        break
+      }
+      case 'closed':
+        onStateChange?.('closed')
+        break
+      case 'error':
+        // A coded error is terminal — native stopped and will NOT reconnect —
+        // so it surfaces exactly once. Non-coded errors are informational
+        // (native owns the retry).
+        onStateChange?.('error', m.code ? { message: m.message, code: m.code } : m.message)
+        break
+      default:
+        break
+    }
+  }
+
+  return {
+    receive,
+    start() {
+      if (running) return false
+      const connection = getConnection()
+      if (!connection) return false // nothing to connect to → polling covers it
+      running = true
+      onStateChange?.('connecting')
+      try {
+        startNative(connection)
+      } catch (err) {
+        onStateChange?.('error', err instanceof Error ? err.message : String(err))
+      }
+      return true
+    },
+    stop() {
+      if (!running) return
+      running = false
+      try { stopNative() } catch { /* teardown must not throw */ }
+      onStateChange?.('stopped')
+    },
+    isRunning: () => running,
   }
 }


### PR DESCRIPTION
**Stacked on #248** (base is `claude/vault-sse-phase1`; GitHub will retarget to `main` when #248 merges). Extends SSE push to the Android APK: phone and tablet get the same near-instant delivery the PWA got in phase 1.

## Design

The APK's WebView cannot stream `/events` — vault HTTP rides the buffered CapacitorHttp path, and a WebView fetch would hit the CORS/cleartext constraints that made CapacitorHttp necessary in the first place. Same problem dayGLANCE hit, same solution, repackaged: **the shell owns the socket**. A native Kotlin reader connects while the Activity is foreground, drops on background, reconnects with capped backoff, and pushes each raw SSE block into the renderer as an `sseMessage` Capacitor plugin event. The renderer's bridge-fed client funnels every block through the *same* `parseSseFrame` → coalescer → drains as the web transport — the native side is a dumb, robust byte framer, and `{seq}` extraction stays in exactly one place. No vault CORS change: a native HTTP client has no browser origin.

Reconnect ownership is deliberately exclusive per transport: the web client owns its own loop; on native the shell owns it and the JS bridge client has none. Polling remains the correctness backstop on both, untouched.

## Kotlin side (`android/.../sse/`)

- **`SseFraming.kt`, `SseBackoff.kt`** — verbatim ports of dayGLANCE's production framer (blank-line boundary detection, heartbeat drop so the bridge isn't woken every 20s, 1 MB overflow guard against a never-delimiting peer) and backoff (1s doubling to 30s cap, stability reset, overflow-clamped shift).
- **`VaultSseClient.kt`** — near-verbatim port of dayGLANCE's reader: one reader coroutine reconciled from desired+foreground state, blocking read with a 60s timeout (above the 20s heartbeat, so a silently dead socket is detected within a minute), terminal no-reconnect classification for auth 401/403 and refused cleartext URLs (https always; http only for loopback/LAN/.local hosts). One deliberate addition over dayGLANCE: **404 is terminal too** (`'unsupported'` — the server predates `/events`), mirroring the web transport's `SseUnsupportedError` so both transports classify an old server identically.
- **`VaultSsePlugin.kt`** — the Capacitor wrapper: `start`/`stop` methods, `handleOnStart`/`handleOnStop`/`handleOnDestroy` lifecycle, `notifyListeners` delivery (any-thread safe). Registered in `MainActivity`. `kotlinx-coroutines-android` is now an explicit dependency (previously only transitive via androidx.glance — the reader must not depend on a transitive staying around).

## Renderer side

- **`createBridgeSseClient`** (ported from dayGLANCE) in `vaultEventStream.ts`: declares intent to native, funnels `open`/`frame`/`closed`/`error` messages, tolerates JSON-string pushes, never throws on malformed input. Coded errors (`auth`/`insecure`/`unsupported`) mean the native reader stopped terminally — surfaced once, recorded in `window.__glanceVaultSse.terminal`.
- **`src/native/vaultSse.ts`** — the typed plugin surface, following the `intentsBridge` conventions. Capability probe is `Capacitor.isPluginAvailable('VaultSse')`: an older APK without the plugin answers false and keeps polling — the same degrade contract as everywhere else.
- **`detectSseTransport`** now reports `'native-bridge'` on shells carrying the plugin; the hook's native branch has no visibility wiring (the shell owns foreground/background via the Activity lifecycle).

The message shapes are identical to dayGLANCE's shells, so when the iOS phase lands, its Swift reader (`VaultSseBridge.swift` is the reference) plugs into this exact plugin surface and bridge client with zero renderer changes.

## Verification — and its honest limits

- **JS: 303 tests green** (6 new bridge-client tests: connection handoff, idempotent start/stop, frame routing through the shared parser with real wire fixtures, JSON-string tolerance, coded-vs-plain error surfacing, malformed-push immunity). `tsc -b` and `eslint --max-warnings 0` clean.
- **Kotlin framing + backoff: actually executed.** No Android SDK exists in this environment (gradle/AGP cannot run), so I ran the ported `SseFraming`/`SseBackoff` and their test classes under a standalone kotlinc + JUnit 4: **13 tests, all passing**. Test fixtures use the real wire format (dayGLANCE's Kotlin test fixtures still carry the pre-#1316 `kind` fiction; not propagated here).
- **`VaultSseClient.kt`: compile-verified** against kotlinx-coroutines + android + org.json stub jars — zero errors. Meaningful because the file was retyped, not copied.
- **`VaultSsePlugin.kt`: NOT compiled here** — it needs Capacitor's Android classes, which need the SDK. It's an 80-line wrapper following `WebDavHttpPlugin`'s conventions, but treat it as unverified until `./build-android.sh` succeeds.

**What needs your device:** build the APK, enable the vault, then check `window.__glanceVaultSse` via Chrome DevTools remote debugging — `transport: 'native-bridge'`, `state: 'open'`, and a completion from another device landing while the app is foregrounded. Backgrounding should drop the stream (native logs `VaultSseClient`); foregrounding should reconnect and reconcile via the `ready` frame.

## Remaining

iOS (iPhone/iPad): a Swift-side port of dayGLANCE's `VaultSseBridge.swift` implementing this same plugin surface. Left out of this PR deliberately — adding a Swift file to the iOS target requires `project.pbxproj` changes that are best made (or at least compile-verified) in Xcode, which this environment lacks entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_