### PR TITLE
Backfill translations for the 16 pre-existing sync.errors keys

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -282,8 +282,24 @@
   "sync": {
     "title": "Cloud-Sync",
     "errors": {
+      "APP_ID_MISMATCH": "Dieser Sync-Ordner gehört zu einer anderen App. Wähle einen von lastGLANCE erstellten Ordner.",
+      "SCHEMA_FORWARD_INCOMPATIBLE": "Diese Daten wurden von einer neueren Version von lastGLANCE gespeichert. Aktualisiere die App, um zu synchronisieren.",
+      "PASSPHRASE_REQUIRED": "Gib deine Sync-Passphrase ein, um fortzufahren.",
+      "PRECONDITION_FAILED": "Die Synchronisierung ist auf einen Konflikt gestoßen und muss es erneut versuchen. Bitte synchronisiere noch einmal.",
+      "FORBIDDEN": "Der Sync-Server hat den Zugriff verweigert. Prüfe die Berechtigungen deines Kontos.",
+      "AUTH_FAILURE": "Anmeldung fehlgeschlagen. Prüfe Benutzername und Passwort.",
+      "LOCKED": "Ein anderes Gerät synchronisiert gerade. Versuche es gleich noch einmal.",
+      "NETWORK_ERROR": "Der Sync-Server ist nicht erreichbar. Prüfe deine Verbindung und versuche es erneut.",
+      "KEY_MISMATCH": "Falsche Sync-Passphrase – sie muss exakt mit der Passphrase deiner anderen Geräte übereinstimmen.",
+      "ROW_DECRYPT_FAILED": "Einige synchronisierte Daten konnten nicht entschlüsselt werden. Prüfe deine Sync-Passphrase.",
+      "VERIFIER_UNSUPPORTED": "Dein Sync-Server muss aktualisiert werden, um die Schlüsselprüfung zu unterstützen.",
+      "ACCOUNT_ID_REQUIRED": "Die Sync-Einrichtung wird abgeschlossen – versuche es gleich noch einmal.",
       "CREDENTIAL_INVALID": "Der Sync-Server akzeptiert den Sync-Zugriff dieses Geräts nicht mehr. Deine Änderungen sind auf diesem Gerät gespeichert. Bitte die Person, die deinen Sync-Server betreibt, den Zugriff für dieses Gerät wiederherzustellen.",
-      "QUOTA_EXCEEDED": "Der Sync-Server hat das Limit für dieses Konto erreicht. Deine Änderungen sind auf diesem Gerät gespeichert und die Synchronisierung versucht es automatisch erneut. Bitte die Person, die deinen Sync-Server betreibt, das Limit zu erhöhen."
+      "QUOTA_EXCEEDED": "Der Sync-Server hat das Limit für dieses Konto erreicht. Deine Änderungen sind auf diesem Gerät gespeichert und die Synchronisierung versucht es automatisch erneut. Bitte die Person, die deinen Sync-Server betreibt, das Limit zu erhöhen.",
+      "passphraseNeeded": "Gib deine Sync-Passphrase ein, um fortzufahren.",
+      "vaultUnreachable": "GLANCEvault ist nicht erreichbar: {{detail}}",
+      "requestFailed": "Sync-Anfrage fehlgeschlagen. Bitte versuche es erneut.",
+      "iCloudUnavailable": "iCloud ist nicht verfügbar: {{error}}"
     },
     "syncHalted": "Sync unterbrochen",
     "haltedDescription": "Ein kritischer Fehler ist aufgetreten. Problem beheben und löschen, um erneut zu versuchen.",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -282,8 +282,24 @@
   "sync": {
     "title": "Sincronización en la nube",
     "errors": {
+      "APP_ID_MISMATCH": "Esta carpeta de sincronización pertenece a otra app. Elige una carpeta creada por lastGLANCE.",
+      "SCHEMA_FORWARD_INCOMPATIBLE": "Estos datos se guardaron con una versión más reciente de lastGLANCE. Actualiza la app para sincronizar.",
+      "PASSPHRASE_REQUIRED": "Introduce tu contraseña de sincronización para continuar.",
+      "PRECONDITION_FAILED": "La sincronización encontró un conflicto y debe reintentarse. Sincroniza de nuevo.",
+      "FORBIDDEN": "El servidor de sincronización rechazó el acceso. Comprueba los permisos de tu cuenta.",
+      "AUTH_FAILURE": "Error al iniciar sesión. Comprueba tu usuario y contraseña.",
+      "LOCKED": "Otro dispositivo está sincronizando ahora mismo. Inténtalo de nuevo en un momento.",
+      "NETWORK_ERROR": "No se pudo conectar con el servidor de sincronización. Comprueba tu conexión e inténtalo de nuevo.",
+      "KEY_MISMATCH": "Contraseña de sincronización incorrecta: debe coincidir exactamente con la de tus otros dispositivos.",
+      "ROW_DECRYPT_FAILED": "Algunos datos sincronizados no se pudieron descifrar. Comprueba tu contraseña de sincronización.",
+      "VERIFIER_UNSUPPORTED": "Tu servidor de sincronización necesita actualizarse para admitir la verificación de claves.",
+      "ACCOUNT_ID_REQUIRED": "Finalizando la configuración de sincronización: inténtalo de nuevo en un momento.",
       "CREDENTIAL_INVALID": "El servidor de sincronización ya no acepta el acceso de este dispositivo. Tus cambios están guardados en este dispositivo. Pide a quien administra tu servidor de sincronización que restaure el acceso para este dispositivo.",
-      "QUOTA_EXCEEDED": "El servidor de sincronización ha alcanzado el límite de esta cuenta. Tus cambios están guardados en este dispositivo y la sincronización se reintentará automáticamente. Pide a quien administra tu servidor de sincronización que aumente el límite."
+      "QUOTA_EXCEEDED": "El servidor de sincronización ha alcanzado el límite de esta cuenta. Tus cambios están guardados en este dispositivo y la sincronización se reintentará automáticamente. Pide a quien administra tu servidor de sincronización que aumente el límite.",
+      "passphraseNeeded": "Introduce tu contraseña de sincronización para continuar.",
+      "vaultUnreachable": "No se pudo conectar con GLANCEvault: {{detail}}",
+      "requestFailed": "La solicitud de sincronización falló. Inténtalo de nuevo.",
+      "iCloudUnavailable": "iCloud no está disponible: {{error}}"
     },
     "syncHalted": "Sincronización detenida",
     "haltedDescription": "Ocurrió un error crítico. Resuelve el problema y borra para reintentar.",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -282,8 +282,24 @@
   "sync": {
     "title": "Sync cloud",
     "errors": {
+      "APP_ID_MISMATCH": "Ce dossier de synchronisation appartient à une autre application. Choisissez un dossier créé par lastGLANCE.",
+      "SCHEMA_FORWARD_INCOMPATIBLE": "Ces données ont été enregistrées par une version plus récente de lastGLANCE. Mettez l'application à jour pour synchroniser.",
+      "PASSPHRASE_REQUIRED": "Saisissez votre phrase secrète de sync pour continuer.",
+      "PRECONDITION_FAILED": "La synchronisation a rencontré un conflit et doit réessayer. Veuillez synchroniser à nouveau.",
+      "FORBIDDEN": "Le serveur de synchronisation a refusé l'accès. Vérifiez les autorisations de votre compte.",
+      "AUTH_FAILURE": "Échec de la connexion. Vérifiez votre nom d'utilisateur et votre mot de passe.",
+      "LOCKED": "Un autre appareil synchronise en ce moment. Réessayez dans un instant.",
+      "NETWORK_ERROR": "Impossible de joindre le serveur de synchronisation. Vérifiez votre connexion et réessayez.",
+      "KEY_MISMATCH": "Phrase secrète incorrecte — elle doit correspondre exactement à celle de vos autres appareils.",
+      "ROW_DECRYPT_FAILED": "Certaines données synchronisées n'ont pas pu être déchiffrées. Vérifiez votre phrase secrète.",
+      "VERIFIER_UNSUPPORTED": "Votre serveur de synchronisation doit être mis à jour pour prendre en charge la vérification des clés.",
+      "ACCOUNT_ID_REQUIRED": "Finalisation de la configuration de la sync — réessayez dans un instant.",
       "CREDENTIAL_INVALID": "Le serveur de synchronisation n'accepte plus l'accès de cet appareil. Vos modifications sont enregistrées sur cet appareil. Demandez à la personne qui gère votre serveur de synchronisation de rétablir l'accès pour cet appareil.",
-      "QUOTA_EXCEEDED": "Le serveur de synchronisation a atteint la limite de ce compte. Vos modifications sont enregistrées sur cet appareil et la synchronisation réessaiera automatiquement. Demandez à la personne qui gère votre serveur de synchronisation d'augmenter la limite."
+      "QUOTA_EXCEEDED": "Le serveur de synchronisation a atteint la limite de ce compte. Vos modifications sont enregistrées sur cet appareil et la synchronisation réessaiera automatiquement. Demandez à la personne qui gère votre serveur de synchronisation d'augmenter la limite.",
+      "passphraseNeeded": "Saisissez votre phrase secrète de sync pour continuer.",
+      "vaultUnreachable": "Impossible de joindre GLANCEvault : {{detail}}",
+      "requestFailed": "La requête de synchronisation a échoué. Veuillez réessayer.",
+      "iCloudUnavailable": "iCloud est indisponible : {{error}}"
     },
     "syncHalted": "Sync interrompue",
     "haltedDescription": "Une erreur critique s'est produite. Résolvez le problème puis cliquez sur Effacer pour réessayer.",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -282,8 +282,24 @@
   "sync": {
     "title": "Sincronizzazione cloud",
     "errors": {
+      "APP_ID_MISMATCH": "Questa cartella di sincronizzazione appartiene a un'altra app. Scegli una cartella creata da lastGLANCE.",
+      "SCHEMA_FORWARD_INCOMPATIBLE": "Questi dati sono stati salvati da una versione più recente di lastGLANCE. Aggiorna l'app per sincronizzare.",
+      "PASSPHRASE_REQUIRED": "Inserisci la tua passphrase di sincronizzazione per continuare.",
+      "PRECONDITION_FAILED": "La sincronizzazione ha incontrato un conflitto e deve riprovare. Sincronizza di nuovo.",
+      "FORBIDDEN": "Il server di sincronizzazione ha rifiutato l'accesso. Controlla i permessi del tuo account.",
+      "AUTH_FAILURE": "Accesso non riuscito. Controlla nome utente e password.",
+      "LOCKED": "Un altro dispositivo sta sincronizzando in questo momento. Riprova tra poco.",
+      "NETWORK_ERROR": "Impossibile raggiungere il server di sincronizzazione. Controlla la connessione e riprova.",
+      "KEY_MISMATCH": "Passphrase errata — deve corrispondere esattamente a quella degli altri tuoi dispositivi.",
+      "ROW_DECRYPT_FAILED": "Alcuni dati sincronizzati non possono essere decifrati. Controlla la tua passphrase.",
+      "VERIFIER_UNSUPPORTED": "Il tuo server di sincronizzazione deve essere aggiornato per supportare la verifica delle chiavi.",
+      "ACCOUNT_ID_REQUIRED": "Completamento della configurazione della sincronizzazione — riprova tra poco.",
       "CREDENTIAL_INVALID": "Il server di sincronizzazione non accetta più l'accesso di questo dispositivo. Le tue modifiche sono salvate su questo dispositivo. Chiedi a chi gestisce il tuo server di sincronizzazione di ripristinare l'accesso per questo dispositivo.",
-      "QUOTA_EXCEEDED": "Il server di sincronizzazione ha raggiunto il limite di questo account. Le tue modifiche sono salvate su questo dispositivo e la sincronizzazione riproverà automaticamente. Chiedi a chi gestisce il tuo server di sincronizzazione di aumentare il limite."
+      "QUOTA_EXCEEDED": "Il server di sincronizzazione ha raggiunto il limite di questo account. Le tue modifiche sono salvate su questo dispositivo e la sincronizzazione riproverà automaticamente. Chiedi a chi gestisce il tuo server di sincronizzazione di aumentare il limite.",
+      "passphraseNeeded": "Inserisci la tua passphrase di sincronizzazione per continuare.",
+      "vaultUnreachable": "Impossibile raggiungere GLANCEvault: {{detail}}",
+      "requestFailed": "Richiesta di sincronizzazione non riuscita. Riprova.",
+      "iCloudUnavailable": "iCloud non è disponibile: {{error}}"
     },
     "syncHalted": "Sincronizzazione interrotta",
     "haltedDescription": "Si è verificato un errore critico. Risolvi il problema e cancella per riprovare.",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -282,8 +282,24 @@
   "sync": {
     "title": "Sincronização na nuvem",
     "errors": {
+      "APP_ID_MISMATCH": "Esta pasta de sincronização pertence a outra aplicação. Escolha uma pasta criada pelo lastGLANCE.",
+      "SCHEMA_FORWARD_INCOMPATIBLE": "Estes dados foram guardados por uma versão mais recente do lastGLANCE. Atualize a aplicação para sincronizar.",
+      "PASSPHRASE_REQUIRED": "Introduza a sua frase-passe de sincronização para continuar.",
+      "PRECONDITION_FAILED": "A sincronização encontrou um conflito e precisa de tentar novamente. Sincronize outra vez.",
+      "FORBIDDEN": "O servidor de sincronização recusou o acesso. Verifique as permissões da sua conta.",
+      "AUTH_FAILURE": "Falha ao iniciar sessão. Verifique o nome de utilizador e a palavra-passe.",
+      "LOCKED": "Outro dispositivo está a sincronizar neste momento. Tente novamente daqui a pouco.",
+      "NETWORK_ERROR": "Não foi possível contactar o servidor de sincronização. Verifique a ligação e tente novamente.",
+      "KEY_MISMATCH": "Frase-passe incorreta — tem de corresponder exatamente à dos seus outros dispositivos.",
+      "ROW_DECRYPT_FAILED": "Alguns dados sincronizados não puderam ser decifrados. Verifique a sua frase-passe.",
+      "VERIFIER_UNSUPPORTED": "O seu servidor de sincronização precisa de ser atualizado para suportar a verificação de chaves.",
+      "ACCOUNT_ID_REQUIRED": "A concluir a configuração da sincronização — tente novamente daqui a pouco.",
       "CREDENTIAL_INVALID": "O servidor de sincronização já não aceita o acesso deste dispositivo. As suas alterações estão guardadas neste dispositivo. Peça a quem gere o seu servidor de sincronização para restaurar o acesso deste dispositivo.",
-      "QUOTA_EXCEEDED": "O servidor de sincronização atingiu o limite desta conta. As suas alterações estão guardadas neste dispositivo e a sincronização será repetida automaticamente. Peça a quem gere o seu servidor de sincronização para aumentar o limite."
+      "QUOTA_EXCEEDED": "O servidor de sincronização atingiu o limite desta conta. As suas alterações estão guardadas neste dispositivo e a sincronização será repetida automaticamente. Peça a quem gere o seu servidor de sincronização para aumentar o limite.",
+      "passphraseNeeded": "Introduza a sua frase-passe de sincronização para continuar.",
+      "vaultUnreachable": "Não foi possível contactar o GLANCEvault: {{detail}}",
+      "requestFailed": "O pedido de sincronização falhou. Tente novamente.",
+      "iCloudUnavailable": "iCloud não está disponível: {{error}}"
     },
     "syncHalted": "Sincronização interrompida",
     "haltedDescription": "Ocorreu um erro crítico. Resolva o problema e limpe para tentar novamente.",


### PR DESCRIPTION
Closes #251

## What

Translates the full `sync.errors` block into de, es, fr, it, and pt. Before this change those five files carried only the two keys added with the sync 1.10.0 bump (#246); the other 16 keys fell back to English via i18next's `fallbackLng: 'en'`, so non-English users saw English error text (never raw wire messages — #251 documents that nuance).

The two #246 keys (`CREDENTIAL_INVALID`, `QUOTA_EXCEEDED`) are carried forward **verbatim** — no rewording of already-approved strings.

## Terminology and register

Each language follows the conventions already established in its own file (surveyed from the existing sync settings modal strings and general tone):

| Lang | Passphrase term | Register |
|------|-----------------|----------|
| de | Sync-Passphrase | du (informal) |
| es | contraseña de sincronización | tú (informal) |
| fr | phrase secrète | vous (formal) |
| it | passphrase | tu (informal) |
| pt | frase-passe | formal European Portuguese |

Key order matches en; the `{{detail}}` (vaultUnreachable) and `{{error}}` (iCloudUnavailable) interpolation placeholders are preserved in every language.

## Verification

- i18next render harness: for each of the five languages, all 18 `sync.errors.*` keys resolve from that language's own file (no en fallback triggered), and interpolation spot-checks substitute correctly — ALL PASS.
- All five JSON files re-validated after injection.
- `npm test` from repo root: 303/303 passing (29 files).
- `npm run lint`: clean at `--max-warnings 0`.

Diff is confined to the `sync.errors` blocks of the five non-English locale files: 5 files, +85/−5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_