### PR TITLE
Version 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps `versionName` to 2.2.0 for the release bundling #246 through #249 and #252: GLANCEvault SSE push (web transport and the native Android reader), the sync 1.10.0 backoff and error handling, the stale overdue-toast reconciliation, the seed-gate fix, and the sync error locale backfill. New features with no breaking changes, so a minor bump.

Only package.json and package-lock.json change; the in-app badge, Android `versionName`, derived `versionCode` (2020000, keeping the +100 pre-release headroom), and README badge all follow package.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_