### PR TITLE
Vault SSE phase 3: native iOS reader on the VaultSse plugin surface

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -17,6 +17,15 @@ const config: CapacitorConfig = {
     // never promote such a build to production.
     webContentsDebuggingEnabled: process.env.CAP_WEBVIEW_DEBUG === '1',
   },
+  ios: {
+    // Same gate, same hazard as Android above, for Release/TestFlight builds:
+    // Capacitor's iOS default (inspectable in Debug builds only) is right, so
+    // the key is set ONLY when CAP_WEBVIEW_DEBUG=1 was exported at `cap sync`
+    // time — an explicit false here would also kill Xcode-Run inspection.
+    // A TestFlight build synced with the flag is Safari-inspectable and must
+    // never be the build submitted for App Store review.
+    ...(process.env.CAP_WEBVIEW_DEBUG === '1' ? { webContentsDebuggingEnabled: true } : {}),
+  },
   plugins: {
     // Route fetch/XHR through the native HTTP stack so WebDAV/Nextcloud sync
     // works without a CORS proxy inside the native WebView.

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
+		7A4E51022E3A9A0100C4F2D1 /* VaultSseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4E51012E3A9A0100C4F2D1 /* VaultSseClient.swift */; };
+		7A4E51042E3A9A0100C4F2D1 /* VaultSsePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4E51032E3A9A0100C4F2D1 /* VaultSsePlugin.swift */; };
+		7A4E51062E3A9A0100C4F2D1 /* BridgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4E51052E3A9A0100C4F2D1 /* BridgeViewController.swift */; };
 		504EC30D1FED79650016851F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30B1FED79650016851F /* Main.storyboard */; };
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
@@ -22,6 +25,9 @@
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7A4E51012E3A9A0100C4F2D1 /* VaultSseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSseClient.swift; sourceTree = "<group>"; };
+		7A4E51032E3A9A0100C4F2D1 /* VaultSsePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultSsePlugin.swift; sourceTree = "<group>"; };
+		7A4E51052E3A9A0100C4F2D1 /* BridgeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeViewController.swift; sourceTree = "<group>"; };
 		504EC30C1FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -64,6 +70,9 @@
 			children = (
 				50379B222058CBB4000EE86E /* capacitor.config.json */,
 				504EC3071FED79650016851F /* AppDelegate.swift */,
+				7A4E51052E3A9A0100C4F2D1 /* BridgeViewController.swift */,
+				7A4E51012E3A9A0100C4F2D1 /* VaultSseClient.swift */,
+				7A4E51032E3A9A0100C4F2D1 /* VaultSsePlugin.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -156,6 +165,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				7A4E51062E3A9A0100C4F2D1 /* BridgeViewController.swift in Sources */,
+				7A4E51022E3A9A0100C4F2D1 /* VaultSseClient.swift in Sources */,
+				7A4E51042E3A9A0100C4F2D1 /* VaultSsePlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/Base.lproj/Main.storyboard
+++ b/ios/App/App/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="BridgeViewController" customModule="App" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>

--- a/ios/App/App/BridgeViewController.swift
+++ b/ios/App/App/BridgeViewController.swift
@@ -1,0 +1,13 @@
+import Capacitor
+import UIKit
+
+/// App-local Capacitor plugins are not auto-discovered on iOS (unlike Android's
+/// registerPlugin in MainActivity), so Main.storyboard instantiates this
+/// subclass instead of CAPBridgeViewController and each plugin is registered
+/// here, after the bridge exists but before the WebView loads the app.
+class BridgeViewController: CAPBridgeViewController {
+
+    override open func capacitorDidLoad() {
+        bridge?.registerPluginInstance(VaultSsePlugin())
+    }
+}

--- a/ios/App/App/VaultSseClient.swift
+++ b/ios/App/App/VaultSseClient.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+/// Native GLANCEvault SSE reader — the Swift sibling of Android's
+/// `VaultSseClient` (android/.../sse/VaultSseClient.kt), ported from dayGLANCE's
+/// production reader (dayglance-ios VaultSseBridge.swift). The transport,
+/// lifecycle, and terminal-error policy are identical across the three readers —
+/// only the renderer delivery differs (a message sink that [VaultSsePlugin]
+/// wires to Capacitor's notifyListeners, not a WebView global).
+///
+/// WHY A NATIVE READER: the WKWebView cannot stream `text/event-stream` — vault
+/// HTTP rides the buffered CapacitorHttp path (whole body as one string), and a
+/// direct fetch from the capacitor:// app origin to the vault is CORS-blocked.
+/// So the SHELL opens the stream: an authenticated `GET {vaultUrl}/events` with
+/// the Bearer device token, read incrementally via `URLSession.bytes(for:)`,
+/// framed into SSE event blocks, and each block pushed to the renderer. The
+/// renderer reuses its EXISTING `parseSseFrame` + coalescer + drains
+/// (src/sync/vaultEventStream.ts) — this class owns ONLY the socket, its
+/// lifecycle, and reconnect. A native HTTP client has no browser origin, so it
+/// needs NO vault CORS change. POLLING in the renderer stays the correctness
+/// backstop; these pushes only add instant drains on top.
+///
+/// LIFECYCLE — the reader runs only when BOTH are true: the renderer declared
+/// SSE desired ([enable]/[disable]) AND the app is foreground ([setForeground],
+/// wired from UIApplication notifications by the plugin). It drops on background
+/// and reconnects with capped exponential backoff on any drop. Every transition
+/// funnels through reconcile, which starts or cancels the SINGLE reader Task, so
+/// there is never more than one connection. On each (re)connect the vault sends
+/// its `ready` frame carrying the account's latest seq (`{"seq":N}`); it flows
+/// through as a normal frame, so the coalescer reconciles anything missed while
+/// disconnected.
+final class VaultSseClient {
+
+    /// Any-thread-safe message sink. All fields are strings:
+    ///   {type:"open"} | {type:"frame", block} | {type:"closed"} |
+    ///   {type:"error", message, code?}   (coded errors are TERMINAL)
+    private let sink: ([String: String]) -> Void
+
+    // ── State (guarded by `lock`, mirroring Android's @Synchronized) ─────────────
+    private let lock = NSLock()
+    // Framing-buffer cap (both the raw byte buffer and the decoded remainder). Real
+    // vault events are tiny nudges; anything approaching 1 MB without a frame
+    // delimiter is a misbehaving/hostile server, so we drop the connection rather
+    // than grow unboundedly. Mirrors Android's SseFraming cap.
+    private static let maxBufferBytes = 1_048_576
+    private var desired = false
+    // Foreground defaults true: the WebView only runs (and thus only calls start)
+    // while the app is active, and the willEnterForeground notification won't fire
+    // for the initial launch. Background transitions flip it false.
+    private var foreground = true
+    private var vaultUrl: String?
+    private var token: String?
+    private var accountId: String?
+    private var readerTask: Task<Void, Never>?
+    // Bumped on every (re)configure / stop so a stale reader that is mid-await
+    // notices it is no longer the current generation and exits.
+    private var generation = 0
+
+    // Dedicated session: a request-idle timeout longer than the 20s server
+    // heartbeat (a healthy idle stream never trips it, a silently-dead one is
+    // detected within the window), and never a cached response. A stored `let`
+    // (not lazy) so its first use from the reader Task can't race initialization.
+    // waitsForConnectivity is OFF: our own reconnect + backoff (SseBackoff) owns
+    // retries, matching Android's fail-and-reconnect model — so a drop surfaces
+    // promptly instead of parking the request on the connectivity monitor.
+    private let session: URLSession = {
+        let cfg = URLSessionConfiguration.default
+        cfg.timeoutIntervalForRequest = 60
+        cfg.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        cfg.waitsForConnectivity = false
+        return URLSession(configuration: cfg)
+    }()
+
+    init(sink: @escaping ([String: String]) -> Void) {
+        self.sink = sink
+    }
+
+    // MARK: - API (called from VaultSsePlugin, any thread)
+
+    /// Renderer → "SSE desired ON", with the vault connection params.
+    func enable(vaultUrl: String, token: String, accountId: String) {
+        lock.lock()
+        self.vaultUrl = trimTrailingSlashes(vaultUrl)
+        self.token = token
+        self.accountId = accountId
+        self.desired = true
+        reconcileLocked()
+        lock.unlock()
+    }
+
+    /// Renderer → "SSE desired OFF".
+    func disable() {
+        lock.lock()
+        desired = false
+        reconcileLocked()
+        lock.unlock()
+    }
+
+    /// App foreground/background (wired from UIApplication notifications).
+    func setForeground(_ fg: Bool) {
+        lock.lock()
+        foreground = fg
+        reconcileLocked()
+        lock.unlock()
+    }
+
+    /// Full teardown — plugin deallocated. No leaked connection or task.
+    func shutdown() {
+        lock.lock()
+        desired = false
+        foreground = false
+        reconcileLocked()
+        lock.unlock()
+        session.invalidateAndCancel()
+    }
+
+    // MARK: - Reconcile (start/stop the single reader) — call with `lock` held
+
+    private func reconcileLocked() {
+        let shouldRun = desired && foreground
+            && vaultUrl != nil && token != nil && accountId != nil
+        if shouldRun {
+            guard readerTask == nil, let url = vaultUrl, let bearer = token, let account = accountId else { return }
+            generation += 1
+            let gen = generation
+            readerTask = Task { [weak self] in
+                await self?.runLoop(url: url, bearer: bearer, account: account, generation: gen)
+                self?.clearReaderTask(ifGeneration: gen)
+            }
+        } else if let task = readerTask {
+            // Bump the generation so the (possibly mid-await) reader exits, and cancel
+            // to unblock the byte stream — URLSession's async iteration throws on Task
+            // cancellation.
+            generation += 1
+            task.cancel()
+            readerTask = nil
+        }
+    }
+
+    // MARK: - Reader loop (reconnect + backoff)
+
+    private func runLoop(url: String, bearer: String, account: String, generation gen: Int) async {
+        var backoff = SseBackoff()
+        while !Task.isCancelled && currentGeneration() == gen {
+            let openedAt = Date()
+            do {
+                try await connectAndRead(url: url, bearer: bearer, account: account, generation: gen)
+            } catch is CancellationError {
+                return
+            } catch let term as SseTerminalError {
+                // TERMINAL (auth failure / insecure URL / server predates /events):
+                // stop the reader entirely, no reconnect. Push a coded event so the
+                // renderer surfaces it exactly once instead of every 30s. A later
+                // enable() (user fixed the token/URL) spins up a fresh reader normally.
+                if Task.isCancelled || currentGeneration() != gen { return }
+                push(["type": "error", "code": term.code, "message": term.message])
+                return
+            } catch {
+                if Task.isCancelled || currentGeneration() != gen { return }
+                push(["type": "error", "message": error.localizedDescription])
+            }
+            if Task.isCancelled || currentGeneration() != gen { return }
+            // The stream ended (server close / idle timeout / drop). Tell the
+            // renderer, then reconnect with backoff — reset only if it had been
+            // healthy long enough.
+            push(["type": "closed"])
+            backoff.onClosed(openDurationMs: Date().timeIntervalSince(openedAt) * 1000)
+            try? await Task.sleep(nanoseconds: UInt64(backoff.nextDelayMs()) * 1_000_000)
+        }
+    }
+
+    private func connectAndRead(url: String, bearer: String, account: String, generation gen: Int) async throws {
+        guard var comps = URLComponents(string: "\(url)/events") else { throw URLError(.badURL) }
+        comps.queryItems = [URLQueryItem(name: "accountId", value: account)]
+        guard let target = comps.url else { throw URLError(.badURL) }
+
+        // Belt-and-braces (the settings form is the primary gate): never send the
+        // Bearer token over cleartext http on the public internet. https is always
+        // fine; http is allowed only for loopback/LAN hosts. A refusal is TERMINAL —
+        // reconnecting can't fix a bad scheme — so it takes the no-retry path above.
+        guard Self.isSecureOrLanUrl(target) else {
+            throw SseTerminalError(code: "insecure", message: "vault SSE refused: insecure http URL")
+        }
+
+        var req = URLRequest(url: target)
+        req.httpMethod = "GET"
+        req.setValue("Bearer \(bearer)", forHTTPHeaderField: "Authorization")
+        req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        req.timeoutInterval = 60
+
+        let (bytes, response) = try await session.bytes(for: req)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        // 401/403 are auth failures — a revoked/invalid device token. Retrying can't
+        // fix them (it would just reconnect forever at the 30s cap and re-hit the same
+        // 401), so this is TERMINAL: stop the reader, push a distinct coded event so
+        // the renderer surfaces it once. A fresh enable() (after the user fixes the
+        // token) begins a new reader normally.
+        if status == 401 || status == 403 {
+            throw SseTerminalError(code: "auth", message: "vault SSE auth failed: \(status)")
+        }
+        // 404 means the server predates /events entirely (Express default route).
+        // Same terminal logic: reconnecting cannot grow a route; the renderer's
+        // polling covers the app identically. Mirrors the web transport's
+        // SseUnsupportedError classification and Android's reader.
+        if status == 404 {
+            throw SseTerminalError(code: "unsupported", message: "vault SSE unavailable: server predates /events")
+        }
+        guard (200...299).contains(status) else {
+            throw NSError(domain: "VaultSse", code: status,
+                          userInfo: [NSLocalizedDescriptionKey: "vault SSE connect failed: \(status)"])
+        }
+        push(["type": "open"])
+
+        // SSE framing at the BYTE level. We deliberately do NOT use bytes.lines
+        // (AsyncLineSequence): it does not reliably yield the EMPTY lines that
+        // delimit SSE event blocks, so a blank-line boundary is never seen and no
+        // frame is ever emitted. Instead we accumulate the stream, normalize CRLF/CR
+        // to LF, and split on the "\n\n" blank-line boundary ourselves — exactly like
+        // Android's SseFraming and the renderer's drainSseBuffer. Decoding only at a
+        // "\n" byte (0x0A, never part of a multibyte UTF-8 sequence) keeps UTF-8 safe
+        // across chunk boundaries. Comment-only / heartbeat blocks (no data: line)
+        // are dropped — matches Android's SseFraming.hasDataLine.
+        var byteBuf = [UInt8]()
+        var pending = ""
+        for try await byte in bytes {
+            if Task.isCancelled || currentGeneration() != gen { break }
+            byteBuf.append(byte)
+            // Cap the un-decoded byte buffer: a server that streams bytes but NEVER a
+            // 0x0A ('\n') would otherwise grow this without bound (memory exhaustion).
+            // Real events are tiny. Treat a breach as a stream failure (generic error →
+            // backoff/reconnect), NOT terminal — a transient bad peer may recover.
+            if byteBuf.count > Self.maxBufferBytes {
+                throw SseStreamOverflowError()
+            }
+            guard byte == 0x0A else { continue }
+            // String(decoding:as:) NEVER fails: invalid UTF-8 is replaced with U+FFFD
+            // (matching Android's InputStreamReader), and byteBuf is ALWAYS cleared
+            // here — a failable decode that left the buffer in place would stall the
+            // stream permanently on a single bad byte.
+            let chunk = String(decoding: byteBuf, as: UTF8.self)
+            byteBuf.removeAll(keepingCapacity: true)
+            pending += chunk.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
+            while let boundary = pending.range(of: "\n\n") {
+                let block = String(pending[pending.startIndex..<boundary.lowerBound])
+                pending = String(pending[boundary.upperBound...])
+                if block.split(separator: "\n", omittingEmptySubsequences: false).contains(where: { $0.hasPrefix("data:") }) {
+                    push(["type": "frame", "block": block])
+                }
+            }
+            // Cap the framing remainder too: a server that sends '\n' bytes but never
+            // the "\n\n" block delimiter would grow `pending` without bound. Same
+            // treatment: fail the stream into backoff/reconnect.
+            if pending.utf8.count > Self.maxBufferBytes {
+                throw SseStreamOverflowError()
+            }
+        }
+    }
+
+    // MARK: - Push to the renderer
+
+    private func push(_ msg: [String: String]) {
+        // The sink (VaultSsePlugin → notifyListeners) is any-thread safe.
+        sink(msg)
+    }
+
+    // MARK: - Helpers
+
+    private func currentGeneration() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        return generation
+    }
+
+    private func clearReaderTask(ifGeneration gen: Int) {
+        lock.lock(); defer { lock.unlock() }
+        // Only clear if we're still the current generation — a newer reconcile may
+        // have already replaced the task.
+        if generation == gen { readerTask = nil }
+    }
+
+    private func trimTrailingSlashes(_ s: String) -> String {
+        var out = s
+        while out.hasSuffix("/") { out.removeLast() }
+        return out
+    }
+
+    // MARK: - URL transport-security allowlist (mirrors src/sync/vaultUrlPolicy.ts)
+
+    /// https is always allowed; http only for loopback/LAN hosts. Any other scheme is
+    /// rejected. Keep in agreement with the renderer's policy and Android's reader.
+    private static func isSecureOrLanUrl(_ url: URL) -> Bool {
+        let scheme = (url.scheme ?? "").lowercased()
+        if scheme == "https" { return true }
+        if scheme != "http" { return false }
+        return isLocalOrLanHost(url.host ?? "")
+    }
+
+    /// True for loopback / private-LAN / *.local hosts, for which cleartext http is
+    /// acceptable. Foundation's URL.host already strips IPv6 brackets; the bracket
+    /// strip below is defensive.
+    private static func isLocalOrLanHost(_ rawHost: String) -> Bool {
+        var host = rawHost.lowercased()
+        if host.hasPrefix("[") && host.hasSuffix("]") { host = String(host.dropFirst().dropLast()) }
+        if host.isEmpty { return false }
+        if host == "localhost" || host.hasSuffix(".localhost") { return true }
+        if host == "::1" { return true }
+        if host.hasSuffix(".local") { return true }
+        let parts = host.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 4 else { return false }
+        let octets = parts.compactMap { Int($0) }
+        guard octets.count == 4, octets.allSatisfy({ $0 >= 0 && $0 <= 255 }) else { return false }
+        let a = octets[0], b = octets[1]
+        if a == 127 { return true }              // 127.0.0.0/8 loopback
+        if a == 10 { return true }               // 10.0.0.0/8
+        if a == 192 && b == 168 { return true }  // 192.168.0.0/16
+        if a == 172 && (16...31).contains(b) { return true } // 172.16.0.0/12
+        return false
+    }
+}
+
+/// A TERMINAL stream error: the reader must stop and NOT reconnect (retrying can't
+/// help). `code` distinguishes the cause for the renderer ('auth' = revoked/invalid
+/// token; 'insecure' = refused cleartext URL; 'unsupported' = server predates
+/// /events). Mirrors Android's SseTerminalException.
+private struct SseTerminalError: Error {
+    let code: String
+    let message: String
+}
+
+/// A NON-terminal stream failure: the SSE framing buffer exceeded its cap. Handled
+/// like any read error — backoff + reconnect (a transient bad peer may recover).
+private struct SseStreamOverflowError: Error {}
+
+/// Capped exponential backoff with a stability reset — the Swift mirror of Android's
+/// `SseBackoff` and the renderer's reconnect policy in `createVaultEventClient`.
+///
+/// A connection open at least `minStableMs` is treated as healthy and resets the
+/// attempt counter, so a long-lived stream that finally drops reconnects promptly.
+/// A connection that opens then drops immediately (a flap) keeps backing off, up to
+/// `maxMs`, so a broken endpoint can never storm the vault with reconnects.
+private struct SseBackoff {
+    private let baseMs: Double
+    private let maxMs: Double
+    private let minStableMs: Double
+    private var attempt = 0
+
+    init(baseMs: Double = 1000, maxMs: Double = 30000, minStableMs: Double = 5000) {
+        self.baseMs = baseMs
+        self.maxMs = maxMs
+        self.minStableMs = minStableMs
+    }
+
+    /// The delay before the NEXT reconnect, then advances the counter. `base * 2^attempt`,
+    /// capped at `maxMs`; the shift is clamped so a large attempt count can't overflow.
+    mutating func nextDelayMs() -> Double {
+        let shift = min(max(attempt, 0), 30)
+        let delay = min(maxMs, baseMs * Double(1 << shift))
+        attempt += 1
+        return delay
+    }
+
+    /// Reset the backoff only when the connection was open at least `minStableMs`
+    /// (a healthy stream); a flap leaves the counter climbing.
+    mutating func onClosed(openDurationMs: Double) {
+        if openDurationMs >= minStableMs { attempt = 0 }
+    }
+}

--- a/ios/App/App/VaultSsePlugin.swift
+++ b/ios/App/App/VaultSsePlugin.swift
@@ -1,0 +1,86 @@
+import Capacitor
+import UIKit
+
+/// Capacitor face of the native GLANCEvault SSE reader ([VaultSseClient]) — the
+/// iOS sibling of android/.../sse/VaultSsePlugin.kt, same plugin surface.
+///
+/// The renderer (src/hooks/useVaultEventStream.ts, 'native-bridge' transport)
+/// declares intent with start/stop and receives every reader message as an
+/// `sseMessage` plugin event — the same `{type, block?/message?/code?}` shapes
+/// dayGLANCE's shells push, so the renderer-side bridge client is shared code:
+///   {type:'open'}                    a (re)connection was established
+///   {type:'frame', block:'…'}        one raw SSE event block → parseSseFrame
+///   {type:'closed'}                  the stream dropped (native will reconnect)
+///   {type:'error', message, code?}   a coded error is TERMINAL (native stopped)
+///
+/// The plugin owns only the wiring: lifecycle (foreground/background via
+/// UIApplication notifications — the iOS analog of Android's activity
+/// callbacks) and delivery (notifyListeners, any-thread safe). The socket,
+/// reconnect, and terminal policy live in [VaultSseClient]. Capability
+/// detection needs no method here — the renderer probes
+/// Capacitor.isPluginAvailable('VaultSse'), which an older shell without this
+/// plugin answers false, degrading cleanly to polling.
+///
+/// REGISTRATION: app-local plugins are not auto-discovered on iOS; this one is
+/// registered in BridgeViewController.capacitorDidLoad().
+@objc(VaultSsePlugin)
+public class VaultSsePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "VaultSsePlugin"
+    public let jsName = "VaultSse"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "start", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "stop", returnType: CAPPluginReturnPromise),
+    ]
+
+    private var client: VaultSseClient?
+
+    override public func load() {
+        client = VaultSseClient { [weak self] msg in
+            var data = JSObject()
+            for (key, value) in msg { data[key] = value }
+            self?.notifyListeners("sseMessage", data: data)
+        }
+        // Foreground/background gating mirrors the Android plugin's
+        // handleOnStart/handleOnStop: the reader connects only while the app is
+        // foreground, drops on background (the OS would suspend the socket
+        // anyway), and the vault's `ready` frame reconciles on every reconnect.
+        // The client's foreground state defaults true, covering the initial
+        // launch (willEnterForeground does not fire for it).
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(appWillEnterForeground),
+            name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(appDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification, object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        client?.shutdown()
+        client = nil
+    }
+
+    @objc func start(_ call: CAPPluginCall) {
+        guard let url = call.getString("vaultUrl"), !url.isEmpty,
+              let token = call.getString("vaultToken"), !token.isEmpty,
+              let account = call.getString("accountId"), !account.isEmpty else {
+            call.reject("vaultUrl, vaultToken, and accountId are required")
+            return
+        }
+        client?.enable(vaultUrl: url, token: token, accountId: account)
+        call.resolve()
+    }
+
+    @objc func stop(_ call: CAPPluginCall) {
+        client?.disable()
+        call.resolve()
+    }
+
+    @objc private func appWillEnterForeground() {
+        client?.setForeground(true)
+    }
+
+    @objc private func appDidEnterBackground() {
+        client?.setForeground(false)
+    }
+}

--- a/src/native/vaultSse.ts
+++ b/src/native/vaultSse.ts
@@ -1,7 +1,7 @@
 import { Capacitor, registerPlugin, type PluginListenerHandle } from '@capacitor/core'
 
-// Native GLANCEvault SSE reader (Android today; the iOS shell will implement the
-// same plugin surface). The WebView cannot stream /events (vault HTTP rides the
+// Native GLANCEvault SSE reader (Android and iOS shells implement the same
+// plugin surface). The WebView cannot stream /events (vault HTTP rides the
 // buffered CapacitorHttp path), so the SHELL owns the socket — connecting while
 // foreground, dropping on background, reconnecting with backoff — and pushes
 // every reader message in as an `sseMessage` plugin event. The renderer's bridge


### PR DESCRIPTION
Completes the SSE rollout across shells (#248 web, #249 Android): the iOS shell now implements the same `VaultSse` Capacitor plugin surface, so the renderer's existing native-bridge transport lights up on iOS with **zero JS changes** — `Capacitor.isPluginAvailable('VaultSse')` answers true and `useVaultEventStream` does the rest.

## What

- **`ios/App/App/VaultSseClient.swift`** — the reader, ported from dayGLANCE's production iOS reader (`VaultSseBridge.swift` at current main, i.e. including the post-#1155 hardening: the UTF-8 decode-stall fix and the 1 MB framing-buffer caps). `URLSession.bytes` streaming, byte-level SSE framing (`bytes.lines` does not reliably yield the blank delimiter lines), desired+foreground reconcile with a generation guard so there is never more than one connection, capped exponential backoff with a 5s stability reset, LAN/loopback-only cleartext allowlist. Terminal (no-reconnect) classification matches the Android reader: `auth` (401/403), `insecure` (cleartext non-LAN URL), and `unsupported` (404, server predates `/events`) — the last one is an addition over the dayGLANCE source, mirroring what #249 added on Android.
- **`ios/App/App/VaultSsePlugin.swift`** — the Capacitor face, surface-identical to Android's `VaultSsePlugin.kt`: `start`/`stop` methods, every reader message delivered as an `sseMessage` event with the shared `{type, block?/message?/code?}` shapes. Foreground gating rides `UIApplication` willEnterForeground/didEnterBackground notifications, the iOS analog of the Android activity callbacks; the client's foreground state defaults true to cover initial launch.
- **`ios/App/App/BridgeViewController.swift`** + **Main.storyboard** — app-local plugins are not auto-discovered on iOS, so the storyboard now instantiates this `CAPBridgeViewController` subclass, which registers the plugin in `capacitorDidLoad()`. This is the documented Capacitor pattern for app-embedded custom plugins.
- **`project.pbxproj`** — the three new sources added to the App target (build files, file references, group membership, Sources phase).
- **`src/native/vaultSse.ts`** — comment updated; it no longer describes iOS as pending.

## Verified here

- pbxproj integrity: each file reference appears in exactly the expected places; braces/parens balanced.
- Plugin option keys (`vaultUrl`, `vaultToken`, `accountId`) match `useVaultEventStream`'s `VaultSse.start` call and the Android plugin's guards.
- `npm test` 303/303, `npm run lint` clean (the TS comment tweak is the only JS-side change).

## Needs a Mac (this environment has no Swift toolchain)

1. `npx cap sync ios` — expect `CapApp-SPM/Package.swift` to pick up the other installed Capacitor plugins (it currently lists only StatusBar; that managed file is just catching up, not a regression from this PR).
2. Open `ios/App/App.xcodeproj`, build. The three new files are already in the target.
3. Run on a device against your vault: look for the connection in GLANCEvault logs, then complete a chore on another device and confirm the sub-second drain (same checks as the Android round). Safari Web Inspector on a debug build shows `window.__glanceVaultSse` (`transport: 'native-bridge'`, `connects`, `events`).
4. Background/foreground the app and confirm the stream drops and reconnects (a `ready` frame on each reconnect reconciles anything missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_