### PR TITLE
Emit SHA-256 checksums for release artifacts

### DIFF
--- a/build-android.sh
+++ b/build-android.sh
@@ -157,6 +157,22 @@ if $RELEASE; then
     echo "    (apksigner not found on PATH or in \$ANDROID_HOME; skipping signature check)"
   fi
 
+  # SHA-256 checksums for both release artifacts, written with bare filenames
+  # so `sha256sum -c SHA256SUMS.txt` works wherever they are downloaded to.
+  # Publish the file with the GitHub release: single-engine AV heuristics can
+  # flag the Play/sideload signature split as "repacked" (issue #255), and a
+  # checksum match is the user-side proof their APK is the authentic build.
+  echo "==> Writing SHA-256 checksums..."
+  (
+    cd "$OUT_DIR"
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum lastglance.apk lastglance.aab > SHA256SUMS.txt
+    else
+      shasum -a 256 lastglance.apk lastglance.aab > SHA256SUMS.txt
+    fi
+    sed 's/^/    /' SHA256SUMS.txt
+  )
+
   echo ""
   echo "==> Android release build complete. outputs/:"
   ls -lh "$OUT_DIR"


### PR DESCRIPTION
Follow-up to #255. `./build-android.sh --release` now writes `outputs/SHA256SUMS.txt` covering `lastglance.apk` and `lastglance.aab`, printed to the console as well.

- Bare filenames in the file, so a user who downloads the APK and the checksum file into the same directory can verify with `sha256sum -c SHA256SUMS.txt` as-is.
- `sha256sum` when available, `shasum -a 256` fallback for macOS.
- Verified end to end with fixture files: generation plus a round-trip `sha256sum -c` pass; `bash -n` clean.

This doesn't change BitDefender's verdict (that needs the false-positive submission), but publishing the file with each GitHub release gives sideloaders proof their download is the authentic build — the practical reassurance behind #255. One workflow note: attach `SHA256SUMS.txt` to the release alongside the APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_