### PR TITLE
Exit the sync 1.10 credential halt when vault credentials are edited

### DIFF
--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -5,7 +5,7 @@ import type { SyncEngine, DbSyncEngine, SyncErrorCode } from '@glance-apps/sync'
 import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, DEFAULT_SYNC_FOLDER, SYNC_FOLDER_KEY } from '@/sync/engine'
 import { flushSecureWrites } from '@/sync/secureConfigShim'
 import { syncErrorText } from '@/sync/syncErrorText'
-import { getVaultConfig, setVaultConfig } from '@/sync/vaultConfig'
+import { clearCredentialHalt, getVaultConfig, setVaultConfig } from '@/sync/vaultConfig'
 import { testVaultConnection } from '@/sync/testVaultConnection'
 import { cloudSyncProviders } from '@/utils/cloudSyncProviders'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
@@ -144,6 +144,11 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
     // credential writes above are an async write-through to the SecureStore
     // (issue #210) — wait for them, or the reload could tear the page down with
     // the new credentials not yet persisted. Off Android this resolves at once.
+    // An edited vault credential exits any standing sync 1.10 credential halt
+    // (issue #257): the user just changed the thing the halt is about, so the
+    // reconstructed engine gets one fresh attempt. Still-bad credentials
+    // re-halt on their first rejected cycle.
+    if (vaultChanged && nextVault) clearCredentialHalt()
     if (folderPath !== originalFolder.current || vaultChanged) {
       flushSecureWrites().finally(() => window.location.reload())
     }

--- a/src/sync/vaultConfig.test.ts
+++ b/src/sync/vaultConfig.test.ts
@@ -53,3 +53,14 @@ describe('vaultConfig', () => {
     expect(getVaultConfig()).toBeNull()
   })
 })
+
+describe('clearCredentialHalt (#257)', () => {
+  it('removes exactly the credential-halt key, nothing else', async () => {
+    const { clearCredentialHalt } = await import('./vaultConfig')
+    localStorage.setItem('lastglance-db-sync-credential-halt', '{"message":"rejected"}')
+    localStorage.setItem('lastglance-db-sync-hwm', '42')
+    clearCredentialHalt()
+    expect(localStorage.getItem('lastglance-db-sync-credential-halt')).toBeNull()
+    expect(localStorage.getItem('lastglance-db-sync-hwm')).toBe('42')
+  })
+})

--- a/src/sync/vaultConfig.ts
+++ b/src/sync/vaultConfig.ts
@@ -43,3 +43,14 @@ export function isVaultEnabled(): boolean {
   const c = getVaultConfig()
   return !!(c && c.enabled && c.vaultUrl && c.vaultToken && c.accountId)
 }
+
+// The sync 1.10 credential halt persists under the engine's storage prefix and
+// is cleared by the package only via per-account recovery, which shared-token
+// mode never runs (issue #257). This is the wrapper-level exit: called from
+// SyncSettingsModal's save when the vault credentials were actually edited, it
+// grants exactly one fresh attempt — a still-rejected credential re-halts on
+// the first cycle, so a user re-saving a bad token can never turn this into a
+// retry storm. Cursors are untouched.
+export function clearCredentialHalt(): void {
+  try { localStorage.removeItem('lastglance-db-sync-credential-halt') } catch { /* storage unavailable */ }
+}


### PR DESCRIPTION
Closes #257 — the lastGLANCE half of the credential-halt recovery gap found in lifeGLANCE's pre-release audit (its #298 / PR #300).

The sync 1.10 `CREDENTIAL_INVALID` halt persists under `lastglance-db-sync-credential-halt` and is cleared by the package only via per-account recovery, which shared-token mode never runs. SyncSettingsModal *displays* the halt (`isHardStopped()`), but its save path never cleared it — so a device whose token was fixed stayed halted forever: the post-reload engine re-read the standing halt and refused to sync, while the UI kept telling the user to ask their server admin for access they already had.

## The fix

`saveConfig` clears the halt key when the vault credentials were **actually edited** (`vaultChanged` with a non-null next config), just before the reload reconstructs the engines. The safety property: this grants exactly **one** fresh attempt — a still-rejected credential re-halts on its first cycle, so re-saving a bad token can never become a retry storm. Cursors are untouched.

Design note vs lifeGLANCE: its verify-before-save flow gates the clear on a successful authenticated probe; lastGLANCE saves without verification, so the credential edit itself is the gate, with the one-attempt bound doing the safety work.

## Severity

Unreachable in today's shared-token deployments — the halt only fires on the vault's per-account-mode 401 body. Real the day GLANCEvault per-account credentials ship, which is why it's landing now instead of waiting to be rediscovered then.

## Verification

New unit test (the clear removes exactly the halt key, leaves cursors); 304 total passing; lint clean at `--max-warnings 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_