### PR TITLE
Reset per-stream vault sync state on re-link and identity change

### DIFF
--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -5,7 +5,7 @@ import type { SyncEngine, DbSyncEngine, SyncErrorCode } from '@glance-apps/sync'
 import { setupEncryptionKey, clearEncryptionKey, ensureSyncFolder, resetEnsuredFolder, CRYPTO_CONFIG, getRemoteBackupsEnabled, setRemoteBackupsEnabled, DEFAULT_SYNC_FOLDER, SYNC_FOLDER_KEY } from '@/sync/engine'
 import { flushSecureWrites } from '@/sync/secureConfigShim'
 import { syncErrorText } from '@/sync/syncErrorText'
-import { clearCredentialHalt, getVaultConfig, setVaultConfig } from '@/sync/vaultConfig'
+import { clearCredentialHalt, getVaultConfig, resetVaultSyncState, setVaultConfig, vaultIdentityChanged } from '@/sync/vaultConfig'
 import { testVaultConnection } from '@/sync/testVaultConnection'
 import { cloudSyncProviders } from '@/utils/cloudSyncProviders'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
@@ -144,11 +144,20 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
     // credential writes above are an async write-through to the SecureStore
     // (issue #210) — wait for them, or the reload could tear the page down with
     // the new credentials not yet persisted. Off Android this resolves at once.
-    // An edited vault credential exits any standing sync 1.10 credential halt
-    // (issue #257): the user just changed the thing the halt is about, so the
-    // reconstructed engine gets one fresh attempt. Still-bad credentials
-    // re-halt on their first rejected cycle.
-    if (vaultChanged && nextVault) clearCredentialHalt()
+    // Stream-state hygiene on vault changes, decided BEFORE the reload
+    // reconstructs the engines:
+    //  - identity change (different account/server) or UNLINK: reset ALL
+    //    per-stream state (cursors, seed flag, halt). Cursors from one account
+    //    must never be applied to another, and an unlink drops the credentials,
+    //    so the next link has no identity to compare against — it must start
+    //    clean. The next cycle re-seeds in both directions.
+    //  - same-identity credential edit: exit any standing sync 1.10 credential
+    //    halt only (issue #257) — the stream didn't move, cursors stay.
+    if (vaultIdentityChanged(prevVault, nextVault) || (prevVault && !nextVault)) {
+      resetVaultSyncState()
+    } else if (vaultChanged && nextVault) {
+      clearCredentialHalt()
+    }
     if (folderPath !== originalFolder.current || vaultChanged) {
       flushSecureWrites().finally(() => window.location.reload())
     }

--- a/src/sync/vaultConfig.test.ts
+++ b/src/sync/vaultConfig.test.ts
@@ -64,3 +64,33 @@ describe('clearCredentialHalt (#257)', () => {
     expect(localStorage.getItem('lastglance-db-sync-hwm')).toBe('42')
   })
 })
+
+describe('resetVaultSyncState + vaultIdentityChanged (re-link reset)', () => {
+  it('clears the seed flag and every engine cursor; preserves device-scoped keys', async () => {
+    const { resetVaultSyncState } = await import('./vaultConfig')
+    const streamKeys = [
+      'lastglance-db-sync-snapshot-seeded', 'lastglance-db-sync-config',
+      'lastglance-db-sync-hwm', 'lastglance-db-sync-push-ack',
+      'lastglance-db-sync-dirty', 'lastglance-db-sync-quarantine',
+      'lastglance-db-sync-last-synced', 'lastglance-db-sync-credential-halt',
+    ]
+    for (const k of streamKeys) localStorage.setItem(k, 'x')
+    localStorage.setItem('lastglance-device-id', 'dev-keep')
+    localStorage.setItem('lastglance-db-sync-hwm-recovery-gen', '2')
+    resetVaultSyncState()
+    for (const k of streamKeys) expect(localStorage.getItem(k)).toBeNull()
+    expect(localStorage.getItem('lastglance-device-id')).toBe('dev-keep')
+    expect(localStorage.getItem('lastglance-db-sync-hwm-recovery-gen')).toBe('2')
+  })
+
+  it('identity comparison: account/server changes count, token rotation does not', async () => {
+    const { vaultIdentityChanged } = await import('./vaultConfig')
+    const base = { vaultUrl: 'https://vault.example', accountId: 'house-1' }
+    expect(vaultIdentityChanged(base, { ...base })).toBe(false)
+    expect(vaultIdentityChanged(base, { ...base, vaultUrl: 'https://vault.example ' })).toBe(false) // trim
+    expect(vaultIdentityChanged(base, { vaultUrl: 'https://other.example', accountId: 'house-1' })).toBe(true)
+    expect(vaultIdentityChanged(base, { vaultUrl: 'https://vault.example', accountId: 'house-2' })).toBe(true)
+    expect(vaultIdentityChanged(null, base)).toBe(false)  // fresh link: unlink reset covers it
+    expect(vaultIdentityChanged(base, null)).toBe(false)  // unlink handled separately
+  })
+})

--- a/src/sync/vaultConfig.ts
+++ b/src/sync/vaultConfig.ts
@@ -54,3 +54,53 @@ export function isVaultEnabled(): boolean {
 export function clearCredentialHalt(): void {
   try { localStorage.removeItem('lastglance-db-sync-credential-halt') } catch { /* storage unavailable */ }
 }
+
+// Every piece of persisted vault-sync state that belongs to one account's data
+// stream. Key names must match @glance-apps/sync dbEngine.js's
+// `${storageKeyPrefix}-...` keys for storageKeyPrefix 'lastglance', plus the
+// wrapper's one-shot seed flag (dbEngine.ts SNAPSHOT_SEEDED_FLAG). Two device-
+// scoped keys deliberately survive a reset: 'lastglance-device-id' (identifies
+// the device, not the stream) and 'lastglance-db-sync-hwm-recovery-gen' (a
+// completed one-time migration marker; the reset clears the HWM anyway, so
+// re-running that recovery would be redundant, not corrective).
+const STREAM_STATE_KEYS = [
+  'lastglance-db-sync-snapshot-seeded', // wrapper's one-shot full-snapshot seed
+  'lastglance-db-sync-config',          // engine's saved identity record
+  'lastglance-db-sync-hwm',             // pull cursor
+  'lastglance-db-sync-push-ack',        // push idempotency marker
+  'lastglance-db-sync-dirty',           // persisted dirty set
+  'lastglance-db-sync-quarantine',      // undecryptable-row retry set (seq-based)
+  'lastglance-db-sync-last-synced',     // display timestamp
+  'lastglance-db-sync-credential-halt', // sync 1.10 hard halt
+]
+
+// Reset all per-stream vault sync state. Cursors from one account must never
+// be applied to another: a stale pull cursor would suppress the new account's
+// low-seq rows, and the one-shot seed flag would keep this device's existing
+// local data from ever uploading (the lastGLANCE twin of lifeGLANCE #286).
+// Called from SyncSettingsModal's save on an IDENTITY change (different
+// accountId or vaultUrl) and on UNLINK — unlike lifeGLANCE, disabling the
+// vault here drops the credentials entirely, so the next link has no previous
+// identity to compare against and must start from clean state. A token-only
+// rotation keeps the identity and therefore the cursors. After a reset, the
+// next cycle re-seeds: HWM=0 pulls everything the account has, and the
+// snapshot seed marks all local entities dirty for the full push.
+export function resetVaultSyncState(): void {
+  for (const key of STREAM_STATE_KEYS) {
+    try { localStorage.removeItem(key) } catch { /* storage unavailable — nothing to clear */ }
+  }
+}
+
+// True when two vault configs point at DIFFERENT data streams (server or
+// account changed). Token differences are deliberately ignored: a rotated
+// token is the same stream. Null on either side is not an identity change —
+// fresh links start clean via the unlink reset, and unlink itself is handled
+// separately in saveConfig.
+export function vaultIdentityChanged(
+  prev: Pick<VaultConfig, 'vaultUrl' | 'accountId'> | null | undefined,
+  next: Pick<VaultConfig, 'vaultUrl' | 'accountId'> | null | undefined,
+): boolean {
+  if (!prev || !next) return false
+  return prev.vaultUrl.trim() !== next.vaultUrl.trim() ||
+    prev.accountId.trim() !== next.accountId.trim()
+}


### PR DESCRIPTION
Nothing cleared the one-shot snapshot-seed flag or the engine's persisted cursors when the vault config changed accounts or servers — only the credential halt was (#257). A device re-linked to a **different account** never re-seeded: its local data silently never reached the new account, and the stale pull cursor suppressed the new account's low-seq rows. This is the lastGLANCE twin of lifeGLANCE's re-link gap, ported from that proven fix (its #295).

## One structural difference from the lifeGLANCE port

lifeGLANCE keeps credentials through a disable, so it resets only when a saved identity *differs*. lastGLANCE's unlink **drops the vault config entirely** — the next link has no previous identity to compare against — so here an **unlink also resets**. That closes the different-account-after-unlink hole at the cost of a one-time full re-seed when re-linking the same account after an unlink (a superset re-push plus full re-pull: heavier, but idempotent and correct).

## What

- **`vaultConfig.ts`**: `resetVaultSyncState()` — clears the seed flag plus all seven engine stream keys (`-db-sync-config`, `-hwm`, `-push-ack`, `-dirty`, `-quarantine`, `-last-synced`, `-credential-halt`). Two device-scoped keys deliberately survive: `lastglance-device-id` (identifies the device, not the stream) and `-db-sync-hwm-recovery-gen` (a completed one-time migration marker — the reset clears the HWM anyway, so re-running that recovery would be redundant, not corrective). Plus the pure `vaultIdentityChanged()` — account/server changes count, **token rotation does not** (no fleet-wide re-seed storm after a credential refresh).
- **SyncSettingsModal** `saveConfig`, decided before the reload reconstructs the engines: identity change or unlink → full reset; same-identity credential edit → the existing #257 halt-only clear, cursors stay.

## Verification

Two new tests (the reset clears exactly the stream keys and preserves the device-scoped ones; the identity comparison's full truth table including trim and null handling) — 314 total passing; typecheck, lint (`--max-warnings 0`), and build clean.

Dormant-risk note: like #258 this changes nothing for a device that never re-links; it exists so an account switch or server migration is correct the day it happens instead of silently lossy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014am4oBJnT6X3JYZtXbzWsZ)_