### PR TITLE
Make dates and times follow the app language

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -148,7 +148,16 @@
     "deleteAriaLabel": "{{name}} löschen",
     "quickLogAriaLabel": "{{name}} schnell eintragen",
     "sendAriaLabel": "{{name}} an dayGLANCE senden",
-    "choreLabel": "{{name}} — {{elapsed}}"
+    "choreLabel": "{{name}} — {{elapsed}}",
+    "seasonalRange": "Saisonal: {{start}} – {{end}}"
+  },
+  "dateTimePicker": {
+    "setDate": "Datum wählen…",
+    "time": "Uhrzeit",
+    "clearTime": "löschen",
+    "clear": "Zurücksetzen",
+    "today": "Heute",
+    "noTimeHint": "Keine Uhrzeit — es wird 12 Uhr verwendet"
   },
   "help": {
     "title": "Hilfe & Feedback",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -153,7 +153,16 @@
     "deleteAriaLabel": "Delete {{name}}",
     "quickLogAriaLabel": "Quick-log {{name}}",
     "sendAriaLabel": "Send {{name}} to dayGLANCE",
-    "choreLabel": "{{name}} — {{elapsed}}"
+    "choreLabel": "{{name}} — {{elapsed}}",
+    "seasonalRange": "Seasonal: {{start}} – {{end}}"
+  },
+  "dateTimePicker": {
+    "setDate": "Set date…",
+    "time": "Time",
+    "clearTime": "clear",
+    "clear": "Clear",
+    "today": "Today",
+    "noTimeHint": "No time set — will use noon"
   },
   "help": {
     "title": "Help & Feedback",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -148,7 +148,16 @@
     "deleteAriaLabel": "Eliminar {{name}}",
     "quickLogAriaLabel": "Registrar {{name}} rápidamente",
     "sendAriaLabel": "Enviar {{name}} a dayGLANCE",
-    "choreLabel": "{{name}} — {{elapsed}}"
+    "choreLabel": "{{name}} — {{elapsed}}",
+    "seasonalRange": "Estacional: {{start}} – {{end}}"
+  },
+  "dateTimePicker": {
+    "setDate": "Elegir fecha…",
+    "time": "Hora",
+    "clearTime": "borrar",
+    "clear": "Borrar",
+    "today": "Hoy",
+    "noTimeHint": "Sin hora — se usará el mediodía"
   },
   "help": {
     "title": "Ayuda y comentarios",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -148,7 +148,16 @@
     "deleteAriaLabel": "Supprimer {{name}}",
     "quickLogAriaLabel": "Enregistrer {{name}} rapidement",
     "sendAriaLabel": "Envoyer {{name}} à dayGLANCE",
-    "choreLabel": "{{name}} — {{elapsed}}"
+    "choreLabel": "{{name}} — {{elapsed}}",
+    "seasonalRange": "Saisonnier : {{start}} – {{end}}"
+  },
+  "dateTimePicker": {
+    "setDate": "Choisir une date…",
+    "time": "Heure",
+    "clearTime": "effacer",
+    "clear": "Effacer",
+    "today": "Aujourd'hui",
+    "noTimeHint": "Aucune heure — midi sera utilisé"
   },
   "help": {
     "title": "Aide & Retours",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -148,7 +148,16 @@
     "deleteAriaLabel": "Elimina {{name}}",
     "quickLogAriaLabel": "Registra {{name}} rapidamente",
     "sendAriaLabel": "Invia {{name}} a dayGLANCE",
-    "choreLabel": "{{name}} — {{elapsed}}"
+    "choreLabel": "{{name}} — {{elapsed}}",
+    "seasonalRange": "Stagionale: {{start}} – {{end}}"
+  },
+  "dateTimePicker": {
+    "setDate": "Scegli una data…",
+    "time": "Ora",
+    "clearTime": "cancella",
+    "clear": "Cancella",
+    "today": "Oggi",
+    "noTimeHint": "Nessun orario — verrà usato mezzogiorno"
   },
   "help": {
     "title": "Aiuto e feedback",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -148,7 +148,16 @@
     "deleteAriaLabel": "Eliminar {{name}}",
     "quickLogAriaLabel": "Registar {{name}} rapidamente",
     "sendAriaLabel": "Enviar {{name}} para dayGLANCE",
-    "choreLabel": "{{name}} — {{elapsed}}"
+    "choreLabel": "{{name}} — {{elapsed}}",
+    "seasonalRange": "Sazonal: {{start}} – {{end}}"
+  },
+  "dateTimePicker": {
+    "setDate": "Escolher data…",
+    "time": "Hora",
+    "clearTime": "limpar",
+    "clear": "Limpar",
+    "today": "Hoje",
+    "noTimeHint": "Sem hora — será usado o meio-dia"
   },
   "help": {
     "title": "Ajuda e feedback",

--- a/src/components/BackupModal/BackupModal.tsx
+++ b/src/components/BackupModal/BackupModal.tsx
@@ -3,6 +3,7 @@ import { Download, Upload, Cloud, X, Loader, Trash2, Archive } from 'lucide-reac
 import { exportBackup, restoreFromBackup, hasSeedData, seedChoresUsed, clearSeedData, type BackupPayload } from '@/db/queries'
 import { buildPayload } from '@/sync/engine'
 import { saveJsonFile, stashJsonFile } from '@/utils/exportFile'
+import { formatDateTime } from '@/utils/datetime'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import type { SyncEngine } from '@glance-apps/sync'
 import dayjs from 'dayjs'
@@ -152,7 +153,7 @@ export function BackupModal({ engine, onClose, onImported }: Props) {
 
   function formatDate(iso: string | null) {
     if (!iso) return t('backup.unknownDate')
-    return dayjs(iso).format('MMM D, YYYY h:mm A')
+    return formatDateTime(iso)
   }
 
   return (

--- a/src/components/ChoreRow/ChoreRow.tsx
+++ b/src/components/ChoreRow/ChoreRow.tsx
@@ -92,7 +92,7 @@ export function ChoreRow({ chore, editMode, onTap, onEdit, onDelete, onRefresh, 
           </span>
         )}
         {chore.seasonal_start && (
-          <span data-tooltip={`Seasonal: ${chore.seasonal_start} – ${chore.seasonal_end}`}>
+          <span data-tooltip={t('choreRow.seasonalRange', { start: chore.seasonal_start, end: chore.seasonal_end })}>
             <Leaf size={11} className="text-green-400/60" />
           </span>
         )}

--- a/src/components/CompletionRow/CompletionRow.tsx
+++ b/src/components/CompletionRow/CompletionRow.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react'
 import { Trash2, NotebookPen } from 'lucide-react'
-import dayjs from 'dayjs'
 import type { CompletionEvent } from '@/types'
+import { formatDate, formatTime } from '@/utils/datetime'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -32,7 +32,7 @@ export function CompletionRow({ evt, onDelete, onEditNote, userName, heading }: 
   const [editingNote, setEditingNote] = useState(false)
   const [noteValue, setNoteValue] = useState(evt.note ?? '')
   const noteInputRef = useRef<HTMLInputElement>(null)
-  const dt = dayjs(evt.completed_at)
+  const at = evt.completed_at
 
   function openNoteEdit() {
     setNoteValue(evt.note ?? '')
@@ -58,9 +58,9 @@ export function CompletionRow({ evt, onDelete, onEditNote, userName, heading }: 
           <span className={heading
             ? 'text-xs text-slate-400 dark:text-slate-500'
             : 'text-sm font-medium text-slate-700 dark:text-slate-200'}>
-            {dt.format('MMM D, YYYY')}
+            {formatDate(at)}
           </span>
-          <span className="text-xs text-slate-400 dark:text-slate-500">{dt.format('h:mm A')}</span>
+          <span className="text-xs text-slate-400 dark:text-slate-500">{formatTime(at)}</span>
           {userName && (
             <span className="text-xs text-slate-400 dark:text-slate-500 bg-slate-100 dark:bg-slate-700/60 px-1.5 py-0.5 rounded">{userName}</span>
           )}

--- a/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/src/components/DateTimePicker/DateTimePicker.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from 'react'
 import { ChevronLeft, ChevronRight, Clock, CalendarDays } from 'lucide-react'
 import dayjs from 'dayjs'
+import { formatDate, formatMonthYear, weekdayMinLabels } from '@/utils/datetime'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   date: string
@@ -9,8 +11,6 @@ interface Props {
   onTimeChange: (t: string) => void
   maxDate?: string
 }
-
-const DAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
 
 type DayCell = {
   date: string
@@ -21,6 +21,10 @@ type DayCell = {
 }
 
 export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate }: Props) {
+  const { t } = useTranslation()
+  // Column headers must follow the same week order startOf('week') uses when
+  // building the grid below — Sunday-first in en, Monday-first elsewhere.
+  const dayLabels = weekdayMinLabels()
   const today = dayjs().format('YYYY-MM-DD')
   const limit = maxDate ?? today
   const [open, setOpen] = useState(false)
@@ -57,7 +61,7 @@ export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate
   }
 
   const displayLabel = date
-    ? `${dayjs(date).format('MMM D, YYYY')}${time ? ` · ${time}` : ''}`
+    ? `${formatDate(date)}${time ? ` · ${time}` : ''}`
     : null
 
   return (
@@ -76,7 +80,7 @@ export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate
         `}
       >
         <CalendarDays size={14} className={date ? 'text-green-400' : 'text-slate-400 dark:text-slate-500'} />
-        <span className="flex-1">{displayLabel ?? 'Set date…'}</span>
+        <span className="flex-1">{displayLabel ?? t('dateTimePicker.setDate')}</span>
         {date && (
           <span
             role="button"
@@ -100,7 +104,7 @@ export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate
               <ChevronLeft size={15} />
             </button>
             <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">
-              {viewDate.format('MMMM YYYY')}
+              {formatMonthYear(viewDate)}
             </span>
             <button
               onClick={() => setViewDate(v => v.add(1, 'month'))}
@@ -112,7 +116,7 @@ export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate
 
           {/* Day header */}
           <div className="grid grid-cols-7 px-3 pt-3 pb-1">
-            {DAY_LABELS.map(l => (
+            {dayLabels.map(l => (
               <div key={l} className="text-center text-xs font-medium text-slate-400 dark:text-slate-600">{l}</div>
             ))}
           </div>
@@ -149,7 +153,7 @@ export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate
           {/* Time row */}
           <div className="flex items-center gap-3 px-4 py-3 border-t border-slate-100 dark:border-slate-800">
             <Clock size={13} className="text-slate-400 dark:text-slate-500 shrink-0" />
-            <span className="text-xs text-slate-400 dark:text-slate-500">Time</span>
+            <span className="text-xs text-slate-400 dark:text-slate-500">{t('dateTimePicker.time')}</span>
             <input
               type="time"
               value={time}
@@ -163,7 +167,7 @@ export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate
                 onClick={() => onTimeChange('')}
                 className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors shrink-0"
               >
-                clear
+                {t('dateTimePicker.clearTime')}
               </button>
             )}
           </div>
@@ -174,20 +178,20 @@ export function DateTimePicker({ date, time, onDateChange, onTimeChange, maxDate
               onClick={clear}
               className="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 transition-colors"
             >
-              Clear
+              {t('dateTimePicker.clear')}
             </button>
             <button
               onClick={() => { onDateChange(today); setViewDate(dayjs()); onTimeChange('') }}
               className="text-xs text-green-500 dark:text-green-400 hover:text-green-400 dark:hover:text-green-300 transition-colors font-medium"
             >
-              Today
+              {t('dateTimePicker.today')}
             </button>
           </div>
         </div>
       )}
 
       {date && !time && open && (
-        <p className="text-xs text-slate-400 dark:text-slate-600">No time set — will use noon</p>
+        <p className="text-xs text-slate-400 dark:text-slate-600">{t('dateTimePicker.noTimeHint')}</p>
       )}
     </div>
   )

--- a/src/components/JournalModal/JournalModal.tsx
+++ b/src/components/JournalModal/JournalModal.tsx
@@ -8,6 +8,7 @@ import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { CompletionRow } from '@/components/CompletionRow/CompletionRow'
 import { ICON_REGISTRY } from '@/icons/registry'
 import { saveCsvFile } from '@/utils/exportFile'
+import { formatDayHeading, formatMonthDay } from '@/utils/datetime'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -189,7 +190,7 @@ export function JournalModal({ onClose, initialDate, onChanged }: Props) {
   function dayLabel(day: string): string {
     if (day === today) return t('journal.today')
     if (day === yesterday) return t('journal.yesterday')
-    return dayjs(day).format('dddd, MMM D, YYYY')
+    return formatDayHeading(day)
   }
 
   const hasFilters = userFilter !== 'all' || categoryFilter !== 'all' || query.trim() !== ''
@@ -313,7 +314,7 @@ export function JournalModal({ onClose, initialDate, onChanged }: Props) {
           <SummaryCell label={t('journal.statChores')} value={String(summary.chores)} />
           <SummaryCell
             label={t('journal.statBusiestDay')}
-            value={summary.busiestDay ? `${dayjs(summary.busiestDay).format('MMM D')} · ${summary.busiestCount}` : '—'}
+            value={summary.busiestDay ? `${formatMonthDay(summary.busiestDay)} · ${summary.busiestCount}` : '—'}
           />
         </div>
 

--- a/src/components/LogModal/LogModal.tsx
+++ b/src/components/LogModal/LogModal.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs'
 import type { ChoreWithLastCompletion, CompletionEvent } from '@/types'
 import { logCompletion, getCompletionHistory, deleteCompletion, updateCompletionNote } from '@/db/queries'
 import { CompletionRow } from '@/components/CompletionRow/CompletionRow'
+import { formatMonthShort, weekdayAtOffset } from '@/utils/datetime'
 import { getMeUserSyncId } from '@/multiuser/settings'
 import { useUsersContext } from '@/multiuser/UsersContext'
 import { formatElapsed } from '@/utils/cadence'
@@ -260,7 +261,14 @@ type HeatDay = { date: string; count: number; isFuture: boolean }
 function Heatmap({ weeks }: { weeks: HeatDay[][] }) {
   const today = dayjs().format('YYYY-MM-DD')
   const months = getMonthLabels(weeks)
-  const DAY_LABELS = ['', 'M', '', 'W', '', 'F', '']
+  // Rows are weekdays in the locale's own week order — Sunday-first in en,
+  // Monday-first elsewhere — because that is what startOf('week') produces
+  // below. Label every other row (Mon/Wed/Fri) wherever those land, rather
+  // than assuming fixed row indices.
+  const dayLabels = Array.from({ length: 7 }, (_, i) => {
+    const { weekday, narrow } = weekdayAtOffset(i)
+    return weekday === 1 || weekday === 3 || weekday === 5 ? narrow : ''
+  })
 
   return (
     <div className="inline-flex flex-col gap-1 select-none">
@@ -273,7 +281,7 @@ function Heatmap({ weeks }: { weeks: HeatDay[][] }) {
       </div>
       <div className="flex gap-[3px]">
         <div className="flex flex-col gap-[3px] mr-1">
-          {DAY_LABELS.map((l, i) => (
+          {dayLabels.map((l, i) => (
             <div key={i} className="h-[11px] w-3 text-[9px] text-slate-400 dark:text-slate-600 text-right leading-[11px]">{l}</div>
           ))}
         </div>
@@ -307,7 +315,7 @@ function getMonthLabels(weeks: HeatDay[][]): Map<number, string> {
   let last = -1
   weeks.forEach((week, wi) => {
     const m = dayjs(week[0].date).month()
-    if (m !== last) { labels.set(wi, dayjs(week[0].date).format('MMM')); last = m }
+    if (m !== last) { labels.set(wi, formatMonthShort(week[0].date)); last = m }
   })
   return labels
 }
@@ -340,5 +348,5 @@ function computeStats(completions: CompletionEvent[]) {
     dayjs(c.completed_at).diff(dayjs(completions[i + 1].completed_at), 'day')
   )
   const avg = Math.round(gaps.reduce((a, b) => a + b, 0) / gaps.length)
-  return { avgInterval: avg === 1 ? '1 day' : `${avg}d` }
+  return { avgInterval: `${avg}d` }
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,6 +2,13 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend from 'i18next-http-backend'
+import { applyDateLocale } from '@/utils/datetime'
+
+// Keep date handling on the same language as the UI strings. Registered before
+// .init() so this listener runs ahead of react-i18next's own — the locale is
+// already switched by the time it re-renders, so no frame paints a date in the
+// language the user just left.
+i18n.on('languageChanged', applyDateLocale)
 
 i18n
   .use(HttpBackend)
@@ -23,5 +30,10 @@ i18n
       caches: ['localStorage'],
     },
   })
+
+// Detection resolves during .init(), which can settle before the listener above
+// is reached on some paths; seed from the resolved language so the very first
+// render is already correct.
+applyDateLocale(i18n.language)
 
 export default i18n

--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import dayjs from 'dayjs'
+import {
+  applyDateLocale,
+  getActiveLocale,
+  formatDate,
+  formatTime,
+  formatDayHeading,
+  formatMonthDay,
+  formatMonthYear,
+  firstDayOfWeek,
+  weekdayMinLabels,
+  weekdayAtOffset,
+} from './datetime'
+
+// A Wednesday, deliberately in the afternoon so the 12-/24-hour split shows.
+const SAMPLE = '2026-08-12T14:05:00'
+
+afterEach(() => applyDateLocale('en'))
+
+describe('applyDateLocale', () => {
+  it('accepts the six supported languages', () => {
+    for (const lng of ['en', 'de', 'es', 'fr', 'it', 'pt']) {
+      applyDateLocale(lng)
+      expect(getActiveLocale()).toBe(lng)
+    }
+  })
+
+  it('takes the base language from a regional tag', () => {
+    applyDateLocale('pt-BR')
+    expect(getActiveLocale()).toBe('pt')
+  })
+
+  it('falls back to English for anything unsupported or absent', () => {
+    for (const lng of ['ja', 'xx-YY', '', undefined]) {
+      applyDateLocale(lng)
+      expect(getActiveLocale()).toBe('en')
+    }
+  })
+})
+
+describe('display formatting', () => {
+  it('localizes the month name and field order', () => {
+    applyDateLocale('en')
+    expect(formatDate(SAMPLE)).toBe('Aug 12, 2026')
+    applyDateLocale('fr')
+    // Day precedes month in French, and the month name is translated.
+    expect(formatDate(SAMPLE)).toMatch(/12/)
+    expect(formatDate(SAMPLE)).toMatch(/août/)
+    expect(formatDate(SAMPLE).indexOf('12')).toBeLessThan(formatDate(SAMPLE).indexOf('août'))
+  })
+
+  it('uses a 12-hour clock in English and a 24-hour clock elsewhere', () => {
+    applyDateLocale('en')
+    expect(formatTime(SAMPLE)).toMatch(/2:05\s?PM/i)
+    for (const lng of ['de', 'es', 'fr', 'it', 'pt']) {
+      applyDateLocale(lng)
+      const time = formatTime(SAMPLE)
+      expect(time).toContain('14')
+      expect(time).not.toMatch(/[AP]M/i)
+    }
+  })
+
+  it('localizes weekday and month names in the day heading', () => {
+    applyDateLocale('en')
+    expect(formatDayHeading(SAMPLE)).toMatch(/Wednesday/)
+    applyDateLocale('fr')
+    expect(formatDayHeading(SAMPLE)).toMatch(/mercredi/)
+    applyDateLocale('de')
+    expect(formatDayHeading(SAMPLE)).toMatch(/Mittwoch/)
+  })
+
+  it('orders the short month-and-day form per locale', () => {
+    applyDateLocale('en')
+    expect(formatMonthDay(SAMPLE)).toBe('Aug 12')
+    applyDateLocale('fr')
+    // "12 août", never "août 12" — the reason this does not use a fixed token.
+    expect(formatMonthDay(SAMPLE)).toMatch(/^12/)
+  })
+
+  it('localizes the month-and-year label', () => {
+    applyDateLocale('en')
+    expect(formatMonthYear(SAMPLE)).toBe('August 2026')
+    applyDateLocale('es')
+    expect(formatMonthYear(SAMPLE).toLowerCase()).toContain('agosto')
+  })
+
+  it('re-formats after a locale change rather than serving a cached formatter', () => {
+    applyDateLocale('en')
+    const english = formatDate(SAMPLE)
+    applyDateLocale('de')
+    expect(formatDate(SAMPLE)).not.toBe(english)
+    applyDateLocale('en')
+    expect(formatDate(SAMPLE)).toBe(english)
+  })
+})
+
+describe('week start', () => {
+  it('starts the week on Sunday in English and Monday in the others', () => {
+    applyDateLocale('en')
+    expect(firstDayOfWeek()).toBe(0)
+    for (const lng of ['de', 'es', 'fr', 'it', 'pt']) {
+      applyDateLocale(lng)
+      expect(firstDayOfWeek()).toBe(1)
+    }
+  })
+
+  it('moves dayjs arithmetic with it, which is what the grids are built from', () => {
+    applyDateLocale('en')
+    expect(dayjs(SAMPLE).startOf('week').day()).toBe(0)
+    applyDateLocale('fr')
+    expect(dayjs(SAMPLE).startOf('week').day()).toBe(1)
+  })
+
+  it('rotates the weekday labels to match that week order', () => {
+    applyDateLocale('en')
+    expect(weekdayMinLabels()).toHaveLength(7)
+    expect(weekdayMinLabels()[0]).toBe('Su')
+    applyDateLocale('fr')
+    const fr = weekdayMinLabels()
+    expect(fr).toHaveLength(7)
+    expect(fr[0]).toBe('lu') // Monday leads, and the label is French
+    expect(fr[6]).toBe('di')
+  })
+
+  it('reports the real weekday for a row offset, so labels land on the right rows', () => {
+    applyDateLocale('en')
+    // Sunday-start: row 1 is Monday.
+    expect(weekdayAtOffset(1).weekday).toBe(1)
+    applyDateLocale('fr')
+    // Monday-start: Monday is row 0 instead.
+    expect(weekdayAtOffset(0).weekday).toBe(1)
+    expect(weekdayAtOffset(6).weekday).toBe(0)
+  })
+})

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,144 @@
+import dayjs from 'dayjs'
+import localeData from 'dayjs/plugin/localeData'
+
+// Locales are imported statically rather than on demand. They are ~1KB each,
+// and a dynamic import would land after i18next has already told React to
+// re-render for the new language — the app would paint one frame of dates in
+// the old locale every time it changed. Synchronous switching removes the race.
+import 'dayjs/locale/de'
+import 'dayjs/locale/es'
+import 'dayjs/locale/fr'
+import 'dayjs/locale/it'
+import 'dayjs/locale/pt'
+
+dayjs.extend(localeData)
+
+/**
+ * Locale-aware date handling, split by responsibility:
+ *
+ *   • dayjs owns date *arithmetic*. Its locale decides where a week starts,
+ *     which every calendar grid and heatmap column depends on — Sunday in
+ *     en, Monday in the five others.
+ *   • Intl.DateTimeFormat owns date *display*. It is CLDR-correct in every
+ *     locale for free, including things a hand-written dayjs token cannot get
+ *     right: field order ("Aug 12" vs "12 août"), whether a comma belongs
+ *     between weekday and date, and 12- versus 24-hour time.
+ *
+ * Formatting a date anywhere in the app goes through this module, so no
+ * component has to know which locale is active.
+ */
+
+const SUPPORTED = ['de', 'es', 'fr', 'it', 'pt'] as const
+
+let activeLocale = 'en'
+
+export function getActiveLocale(): string {
+  return activeLocale
+}
+
+/**
+ * Point date handling at a language. Safe to call with anything i18next
+ * reports — a regional tag ("pt-BR"), an unsupported language, or undefined —
+ * and falls back to English rather than throwing.
+ *
+ * Synchronous by design: it must complete before React re-renders for the new
+ * language, or the first frame shows stale formatting.
+ */
+export function applyDateLocale(lng: string | undefined): void {
+  const base = (lng ?? 'en').split('-')[0].toLowerCase()
+  const supported = (SUPPORTED as readonly string[]).includes(base)
+  activeLocale = supported ? base : 'en'
+  dayjs.locale(activeLocale)
+  formatterCache.clear()
+}
+
+// Intl.DateTimeFormat construction is comparatively expensive and these run per
+// row, so formatters are memoised. Cleared whenever the locale changes.
+const formatterCache = new Map<string, Intl.DateTimeFormat>()
+
+function formatter(opts: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+  const key = JSON.stringify(opts)
+  let f = formatterCache.get(key)
+  if (!f) {
+    f = new Intl.DateTimeFormat(activeLocale, opts)
+    formatterCache.set(key, f)
+  }
+  return f
+}
+
+export type DateInput = string | number | Date | dayjs.Dayjs
+
+function toDate(value: DateInput): Date {
+  return dayjs(value).toDate()
+}
+
+/** "Aug 12, 2026" · "12 août 2026" */
+export function formatDate(value: DateInput): string {
+  return formatter({ year: 'numeric', month: 'short', day: 'numeric' }).format(toDate(value))
+}
+
+/** "2:05 PM" in en, "14:05" everywhere else — Intl picks the clock per locale. */
+export function formatTime(value: DateInput): string {
+  return formatter({ hour: 'numeric', minute: '2-digit' }).format(toDate(value))
+}
+
+/** "Aug 12, 2026, 2:05 PM" · "12 août 2026, 14:05" */
+export function formatDateTime(value: DateInput): string {
+  return formatter({
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+  }).format(toDate(value))
+}
+
+/** "Wednesday, August 12, 2026" · "mercredi 12 août 2026" (no comma in fr). */
+export function formatDayHeading(value: DateInput): string {
+  return formatter({
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+  }).format(toDate(value))
+}
+
+/** "Aug 12" · "12 août" — field order follows the locale. */
+export function formatMonthDay(value: DateInput): string {
+  return formatter({ month: 'short', day: 'numeric' }).format(toDate(value))
+}
+
+/** "August 2026" · "août 2026" */
+export function formatMonthYear(value: DateInput): string {
+  return formatter({ month: 'long', year: 'numeric' }).format(toDate(value))
+}
+
+/** "Aug" · "août" */
+export function formatMonthShort(value: DateInput): string {
+  return formatter({ month: 'short' }).format(toDate(value))
+}
+
+/** 0 for Sunday-start locales (en), 1 for Monday-start (the other five). */
+export function firstDayOfWeek(): number {
+  return dayjs.localeData().firstDayOfWeek()
+}
+
+/**
+ * Two-letter weekday initials in the active locale's week order, so a calendar
+ * header lines up with the columns dayjs's startOf('week') actually produces.
+ */
+export function weekdayMinLabels(): string[] {
+  const sundayFirst = dayjs.weekdaysMin()
+  const start = firstDayOfWeek()
+  return Array.from({ length: 7 }, (_, i) => sundayFirst[(start + i) % 7])
+}
+
+/**
+ * Single-letter initial for the weekday `offset` rows into the week, for the
+ * heatmaps' sparse row labels. `weekday` is the real day number (0 = Sunday),
+ * so a caller can ask "is this row Monday?" without assuming where the week
+ * starts.
+ */
+export function weekdayAtOffset(offset: number): { weekday: number; narrow: string } {
+  const weekday = (firstDayOfWeek() + offset) % 7
+  // A known Sunday, advanced to the weekday we want — independent of today.
+  const sunday = dayjs('2024-01-07')
+  return {
+    weekday,
+    narrow: formatter({ weekday: 'narrow' }).format(sunday.add(weekday, 'day').toDate()),
+  }
+}


### PR DESCRIPTION
dayjs had no locale configured anywhere, so it silently fell back to English. Every date read "Sunday, Aug 9, 2026" and every time "2:05 PM" even with the app in French, and the five non-English locales were shown a 12-hour clock they do not use. UI strings were already fully translated; only the dates were not.

Follows the Journal (#264), which is where the gap was most visible since dates are that view's structure.

## Approach

`src/utils/datetime.ts` centralises date handling, split by responsibility:

- **dayjs owns date arithmetic.** Its locale decides where a week starts, which the calendar grid and both heatmaps are built from — Sunday in `en`, Monday in the other five.
- **`Intl.DateTimeFormat` owns display.** It is CLDR-correct for free, including what a hand-written token cannot get right: field order (`Aug 12` vs `12 août`), whether a comma belongs between weekday and date, and 12- versus 24-hour time.

The locale is applied from an i18next `languageChanged` listener registered before `init()`, so it switches ahead of react-i18next's re-render and no frame paints a date in the language the user just left. Locales are imported statically for the same reason: at ~1KB each, a dynamic import would resolve after that render.

## The part with teeth

Both heatmaps and the date picker draw their columns from `startOf('week')`, and all three had Sunday-first day labels hardcoded. Moving the week start would have left every label pointing at the wrong row. Labels are now derived from the active locale — the picker rotates its weekday names, and the heatmaps ask which real weekday each row is rather than assuming fixed indices:

```
en  heatmap ["","M","","W","","F",""]   picker  Su Mo Tu We Th Fr Sa
fr  heatmap ["L","","M","","V","",""]   picker  lu ma me je ve sa di
```

Mon/Wed/Fri correctly move from rows 1,3,5 to rows 0,2,4.

## Deliberately left fixed

Format strings that are data rather than display: the `YYYY-MM-DD` keys used for grouping and lookups, the export filenames, and the Journal's CSV columns, which stay machine-readable so spreadsheets parse them.

## Also localised

Things the audit turned up in the same files, where fixing the dates alone would have left the surrounding UI half-translated:

- `DateTimePicker` was one of three components with no `useTranslation` at all and had six English strings ("Set date…", "Time", "clear", "Clear", "Today", "No time set — will use noon").
- `ChoreRow`'s seasonal tooltip was English.
- `LogModal`'s average-interval stat special-cased `"1 day"`.

New keys added to all six locales.

## Testing

`npm run build`, `npm run lint` and `npm test` clean — 337 tests, 13 new ones covering locale selection and fallback (including regional tags like `pt-BR`), field order, the 12/24-hour split, formatter-cache invalidation on locale change, week start, and label rotation.

Verified in a browser in all six languages. French renders `DIMANCHE 9 AOÛT 2026`, `12 août 2026 14:40`, `12 août · 1`, with 24-hour time throughout the five non-English locales, and the date picker showing `lu ma me je ve sa di` above a correctly aligned Monday-start grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x

---
_Generated by [Claude Code](https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x)_