### PR TITLE
File new chores into an Inbox instead of the visible category

### DIFF
--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from 'react'
 import { Plus, GripVertical, Search, UserCircle, Clock, ChevronDown, ChevronUp } from 'lucide-react'
 import { useChores } from '@/hooks/useChores'
-import { reorderCategories } from '@/db/queries'
+import { ensureInboxCategory, reorderCategories } from '@/db/queries'
 import { CategorySection } from '@/components/CategorySection/CategorySection'
 import { LogModal } from '@/components/LogModal/LogModal'
 import { CategoryFormModal } from '@/components/CategoryFormModal/CategoryFormModal'
@@ -179,22 +179,35 @@ export function Ribbon({ editMode, onLogged }: Props) {
   const ribbonModalOpenRef = useRef(false)
   ribbonModalOpenRef.current = showSearch || selectedChore !== null || addingCategory || newChoreCategory !== null
 
-  // Launcher shortcuts / the Add widget / a share: open Search or the new-chore
-  // form (optionally pre-filled with a shared name). A new chore needs a category,
-  // which may not have loaded yet on a cold-start launch, so stash the request and
-  // open it once data arrives (mirrors pending-open).
-  const pendingNewChoreRef = useRef<{ name: string } | null>(null)
-  const openNewChore = useCallback((name = '') => {
-    const cat = viewDataRef.current[activeCategoryIndexRef.current]?.category
-      ?? viewDataRef.current[0]?.category
-    if (cat) { setNewChoreName(name); setNewChoreCategory(cat); return true }
-    return false
-  }, [])
+  // Every "add a chore" path that doesn't name a destination — the N shortcut,
+  // launcher shortcuts, the Add widget, a share, Tasker's OPEN add — files into
+  // the Inbox, the same category Tasker's CREATE uses when its payload has no
+  // `project`. The user moves it somewhere permanent afterwards. Adding from a
+  // category's own "+" button still targets that category: there the user has
+  // already said where it goes.
+  //
+  // Resolved from the DB rather than from loaded state, so a cold-start launch
+  // that fires before the Ribbon has data still lands somewhere real — which is
+  // what the old pending-request stash existed to work around.
+  const openNewChore = useCallback(async (name = '') => {
+    const { category, created } = await ensureInboxCategory()
+    setNewChoreName(name)
+    setNewChoreCategory(category)
+    // A brand new Inbox isn't in localData yet; pull it in so the form's
+    // category list and the ribbon behind it agree.
+    if (created) refresh()
+  }, [refresh])
+
+  // The keydown listener below is registered once on mount; this keeps it
+  // pointed at the live callback without re-binding.
+  const openNewChoreRef = useRef(openNewChore)
+  openNewChoreRef.current = openNewChore
+
   useEffect(() => {
     function onOpenSearch() { setShowSearch(true) }
     function onNewChore(e: Event) {
       const name = (e as CustomEvent<{ name?: string }>).detail?.name ?? ''
-      if (!openNewChore(name)) pendingNewChoreRef.current = { name }
+      openNewChore(name)
     }
     window.addEventListener('lg:open-search', onOpenSearch)
     window.addEventListener('lg:new-chore', onNewChore)
@@ -203,11 +216,6 @@ export function Ribbon({ editMode, onLogged }: Props) {
       window.removeEventListener('lg:new-chore', onNewChore)
     }
   }, [openNewChore])
-
-  useEffect(() => {
-    const pending = pendingNewChoreRef.current
-    if (pending && openNewChore(pending.name)) pendingNewChoreRef.current = null
-  }, [localData, openNewChore])
 
   // Keyboard shortcuts owned by Ribbon: search, category nav, new chore
   useEffect(() => {
@@ -230,8 +238,8 @@ export function Ribbon({ editMode, onLogged }: Props) {
         e.preventDefault()
         setActiveCategoryIndex(i => Math.min(viewDataRef.current.length - 1, i + 1))
       } else if (e.key === 'n' || e.key === 'N') {
-        const cat = viewDataRef.current[activeCategoryIndexRef.current]?.category
-        if (cat) { e.preventDefault(); setNewChoreCategory(cat) }
+        e.preventDefault()
+        openNewChoreRef.current()
       }
     }
     window.addEventListener('keydown', onKey)

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -10,6 +10,7 @@ import {
   restoreFromBackup,
   logCompletion,
   getJournalEntries,
+  ensureInboxCategory,
 } from './queries'
 import dayjs from 'dayjs'
 import type { Chore, CompletionEvent } from '@/types'
@@ -269,5 +270,46 @@ describe('getJournalEntries', () => {
     const entries = await getJournalEntries()
     expect(entries).toHaveLength(1)
     expect(entries[0].chore_name).toBe('Mop')
+  })
+})
+
+describe('ensureInboxCategory', () => {
+  it('creates the Inbox with its icon the first time one is needed', async () => {
+    const { category, created } = await ensureInboxCategory()
+
+    expect(created).toBe(true)
+    expect(category.name).toBe('Inbox')
+    // The icon is what distinguishes it in the ribbon; the Tasker path used to
+    // create this category without one.
+    expect(category.icon).toBe('Inbox')
+    expect(await db.categories.count()).toBe(1)
+  })
+
+  it('reuses the existing Inbox instead of creating a second one', async () => {
+    const first = await ensureInboxCategory()
+    const second = await ensureInboxCategory()
+
+    expect(second.created).toBe(false)
+    expect(second.category.id).toBe(first.category.id)
+    expect(await db.categories.count()).toBe(1)
+  })
+
+  it('matches an existing Inbox case-insensitively and ignoring surrounding space', async () => {
+    const existingId = await createCategory('  inbox ')
+    const { category, created } = await ensureInboxCategory()
+
+    expect(created).toBe(false)
+    expect(category.id).toBe(existingId)
+    expect(await db.categories.count()).toBe(1)
+  })
+
+  it('leaves other categories alone', async () => {
+    const homeId = await createCategory('Home')
+    const { category, created } = await ensureInboxCategory()
+
+    expect(created).toBe(true)
+    expect(category.id).not.toBe(homeId)
+    const names = (await getCategories()).map(c => c.name).sort()
+    expect(names).toEqual(['Home', 'Inbox'])
   })
 })

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -99,6 +99,38 @@ export async function updateCategory(id: number, fields: { name?: string; icon?:
   for (const sid of movedChildSyncIds) markDirty(sid)
 }
 
+// The catch-all category a chore lands in when it is created without the user
+// naming somewhere to put it — the `N` shortcut, the Add widget, a share, and
+// the Tasker CREATE action with no `project`. Matching is case-insensitive on
+// this canonical name, so all of those paths converge on one category rather
+// than each minting its own.
+export const INBOX_CATEGORY_NAME = 'Inbox'
+const INBOX_CATEGORY_ICON = 'Inbox'
+
+/**
+ * Resolve the Inbox, creating it if this is the first time anything needed one.
+ *
+ * Returns the category plus whether it had to be created, since a caller
+ * showing the category list needs to know to refresh when a new one appeared.
+ *
+ * Note the match is by name: a user who renames their Inbox gets a fresh one on
+ * the next unfiled chore. That is the same behaviour the Tasker path has always
+ * had, and the alternative — pinning a sync_id — would need to survive being
+ * synced between devices that each resolved it independently.
+ */
+export async function ensureInboxCategory(): Promise<{ category: Category; created: boolean }> {
+  const categories = await getCategories()
+  const existing = categories.find(
+    c => c.name.trim().toLowerCase() === INBOX_CATEGORY_NAME.toLowerCase()
+  )
+  if (existing) return { category: existing, created: false }
+
+  const id = await createCategory(INBOX_CATEGORY_NAME, undefined, INBOX_CATEGORY_ICON)
+  const category = await db.categories.get(id)
+  if (!category) throw new Error('failed to create Inbox category')
+  return { category, created: true }
+}
+
 export async function getAllCompletionCounts(): Promise<Map<string, number>> {
   const all = await db.completionEvents.toArray()
   const counts = new Map<string, number>()

--- a/src/intents/intentContext.ts
+++ b/src/intents/intentContext.ts
@@ -4,16 +4,13 @@
 
 import dayjs from 'dayjs'
 import { db } from '@/db/client'
-import { getCategories, createCategory, createChore as dbCreateChore, logCompletion as dbLogCompletion } from '@/db/queries'
+import { getCategories, createCategory, createChore as dbCreateChore, logCompletion as dbLogCompletion, ensureInboxCategory } from '@/db/queries'
 import { getMeUserSyncId } from '@/multiuser/settings'
 import { addActivityEntry } from './config'
 import { nativeSendNotifyBroadcast } from '@/native/intentsBridge'
 import type { IntentChore, IntentContext, OpenTarget } from './handleIntent'
 import { ACTIONS, EVENTS, SOURCE_APPS, eventId } from '@glance-apps/intents'
 
-// The category intent-created chores land in when the CREATE payload names no
-// `project` (or names one that doesn't exist and we fall through to a default).
-const INBOX_CATEGORY_NAME = 'Inbox'
 
 // Loads every chore with its computed `elapsed_days` (age since last completion),
 // the same derivation getChoresForCategory uses, but across all categories in a
@@ -40,9 +37,12 @@ async function listChores(): Promise<IntentChore[]> {
 }
 
 // Finds a category by name (case-insensitive), creating it if absent. A null
-// name (no `project` in the payload) resolves the shared Inbox category.
+// name (no `project` in the payload) resolves the shared Inbox category — the
+// same one the in-app add paths use, so a Tasker-created chore and one added
+// with `N` land together.
 async function ensureCategory(name: string | null): Promise<number> {
-  const target = (name ?? INBOX_CATEGORY_NAME).trim()
+  if (name === null) return (await ensureInboxCategory()).category.id
+  const target = name.trim()
   const categories = await getCategories()
   const existing = categories.find(c => c.name.trim().toLowerCase() === target.toLowerCase())
   if (existing) return existing.id


### PR DESCRIPTION
Pressing `N` filed the new chore into whichever category happened to be on screen. That is a guess — the category was scrolled to, not chosen — and on the desktop masonry there is no meaningful "current" category at all. Every add path that does not name a destination now goes to a shared Inbox, and the user files it from there.

## Converging with the Tasker path

This is already how the Tasker `CREATE` action behaves when its payload carries no `project`: `intentContext.ts` had its own `INBOX_CATEGORY_NAME = 'Inbox'` with case-insensitive matching. Rather than write a second implementation, that logic moves into `ensureInboxCategory()` in `queries.ts` and both paths resolve through it, so a chore added with `N` lands beside one pushed from Tasker instead of each path minting its own category.

The helper also gives the category the `Inbox` icon. The intents path never did, so a Tasker-created Inbox was previously the only iconless category in the ribbon.

## What changed, and what deliberately did not

Routed to the Inbox — every path where the user did not say where the chore goes:

- the `N` shortcut
- launcher shortcuts and the Add widget
- a share into the app
- Tasker's `OPEN add`

**Unchanged:** adding from a category's own `+` button. That control is only visible in edit mode and targets a category the user deliberately picked, which is a real choice rather than the incidental "whatever was on screen" that `N` was using.

## Incidental cleanup

Resolving the destination from the DB rather than from loaded component state retires the pending-request stash in `Ribbon`. It existed because a cold-start launch could fire `lg:new-chore` before the ribbon had categories to pick from; there is nothing to wait for now, so the ref and the effect that drained it are gone.

`N` also now goes through the same `openNewChore` callback as every other undirected add, rather than duplicating the category lookup inline — it previously skipped the shared-name handling that the widget and share paths use.

## Known behaviour

The Inbox is matched by name, so renaming it means the next unfiled chore creates a fresh one. That is the behaviour the Tasker path has always had. The alternative — pinning a `sync_id` — would have to survive two devices resolving it independently and syncing the result, which is a worse trade for a category the user can move things out of freely.

The new Inbox is appended last in category order, following `createCategory`'s default.

## Testing

`npm run build`, `npm run lint` and `npm test` clean — 343 tests, 4 new ones covering first-time creation with the icon, reuse rather than duplication, case- and whitespace-insensitive matching against an existing `  inbox `, and leaving unrelated categories alone.

Verified in a browser from the four seed categories with Home as the active tab, which is what the old behaviour would have targeted:

```
categories before : Home, Health, Vehicle, Finances
form title        : Add chore — Inbox
categories after  : Home, Health, Vehicle, Finances, Inbox(Inbox)
chore landed in   : Inbox
categories again  : unchanged — a second N reused the Inbox, no duplicate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x

---
_Generated by [Claude Code](https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x)_