### PR TITLE
Add a chore without the keyboard or edit mode

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -292,6 +292,8 @@
     "addFirstCategory": "Erste Kategorie hinzufügen",
     "addCategory": "Kategorie hinzufügen",
     "addCategoryAriaLabel": "Kategorie hinzufügen",
+    "addChoreAriaLabel": "Aufgabe hinzufügen",
+    "addChoreTitle": "Aufgabe hinzufügen",
     "searchChoresAriaLabel": "Aufgaben suchen",
     "searchTitle": "Suchen (/)",
     "toggleMyTasksAriaLabel": "Meine Aufgaben filtern",
@@ -306,6 +308,7 @@
     "placeholder": "Aufgaben suchen…",
     "clearSearch": "Suche löschen",
     "noResults": "Keine Aufgaben gefunden",
+    "createChore": "„{{name}}“ erstellen",
     "startTyping": "Tippen, um Aufgaben zu suchen"
   },
   "shortcuts": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -300,6 +300,8 @@
     "addFirstCategory": "Add your first category",
     "addCategory": "Add category",
     "addCategoryAriaLabel": "Add category",
+    "addChoreAriaLabel": "Add a chore",
+    "addChoreTitle": "Add a chore",
     "searchChoresAriaLabel": "Search chores",
     "searchTitle": "Search (/)",
     "toggleMyTasksAriaLabel": "Toggle my tasks filter",
@@ -314,6 +316,7 @@
     "placeholder": "Search chores…",
     "clearSearch": "Clear search",
     "noResults": "No chores match",
+    "createChore": "Create “{{name}}”",
     "startTyping": "Start typing to search chores"
   },
   "shortcuts": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -292,6 +292,8 @@
     "addFirstCategory": "Añade tu primera categoría",
     "addCategory": "Añadir categoría",
     "addCategoryAriaLabel": "Añadir categoría",
+    "addChoreAriaLabel": "Añadir tarea",
+    "addChoreTitle": "Añadir tarea",
     "searchChoresAriaLabel": "Buscar tareas",
     "searchTitle": "Buscar (/)",
     "toggleMyTasksAriaLabel": "Filtrar mis tareas",
@@ -306,6 +308,7 @@
     "placeholder": "Buscar tareas…",
     "clearSearch": "Borrar búsqueda",
     "noResults": "No hay tareas que coincidan",
+    "createChore": "Crear «{{name}}»",
     "startTyping": "Escribe para buscar tareas"
   },
   "shortcuts": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -292,6 +292,8 @@
     "addFirstCategory": "Ajouter votre première catégorie",
     "addCategory": "Ajouter une catégorie",
     "addCategoryAriaLabel": "Ajouter une catégorie",
+    "addChoreAriaLabel": "Ajouter une tâche",
+    "addChoreTitle": "Ajouter une tâche",
     "searchChoresAriaLabel": "Rechercher des tâches",
     "searchTitle": "Rechercher (/)",
     "toggleMyTasksAriaLabel": "Filtrer mes tâches",
@@ -306,6 +308,7 @@
     "placeholder": "Rechercher des tâches…",
     "clearSearch": "Effacer la recherche",
     "noResults": "Aucune tâche ne correspond",
+    "createChore": "Créer « {{name}} »",
     "startTyping": "Commencez à taper pour rechercher des tâches"
   },
   "shortcuts": {

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -292,6 +292,8 @@
     "addFirstCategory": "Aggiungi la tua prima categoria",
     "addCategory": "Aggiungi categoria",
     "addCategoryAriaLabel": "Aggiungi categoria",
+    "addChoreAriaLabel": "Aggiungi attività",
+    "addChoreTitle": "Aggiungi attività",
     "searchChoresAriaLabel": "Cerca attività",
     "searchTitle": "Cerca (/)",
     "toggleMyTasksAriaLabel": "Filtra le mie attività",
@@ -306,6 +308,7 @@
     "placeholder": "Cerca attività…",
     "clearSearch": "Cancella ricerca",
     "noResults": "Nessuna attività trovata",
+    "createChore": "Crea «{{name}}»",
     "startTyping": "Inizia a digitare per cercare attività"
   },
   "shortcuts": {

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -292,6 +292,8 @@
     "addFirstCategory": "Adicione a sua primeira categoria",
     "addCategory": "Adicionar categoria",
     "addCategoryAriaLabel": "Adicionar categoria",
+    "addChoreAriaLabel": "Adicionar tarefa",
+    "addChoreTitle": "Adicionar tarefa",
     "searchChoresAriaLabel": "Pesquisar tarefas",
     "searchTitle": "Pesquisar (/)",
     "toggleMyTasksAriaLabel": "Filtrar as minhas tarefas",
@@ -306,6 +308,7 @@
     "placeholder": "Pesquisar tarefas…",
     "clearSearch": "Limpar pesquisa",
     "noResults": "Nenhuma tarefa encontrada",
+    "createChore": "Criar «{{name}}»",
     "startTyping": "Comece a escrever para pesquisar tarefas"
   },
   "shortcuts": {

--- a/src/components/ChoreFormModal/ChoreFormModal.tsx
+++ b/src/components/ChoreFormModal/ChoreFormModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X, Smile, Bell, ArrowUpRight, Leaf, Users } from 'lucide-react'
 import type { Chore, Category } from '@/types'
@@ -87,6 +87,15 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
   const [endMonth, setEndMonth] = useState(initEnd.month)
   const [endDay, setEndDay] = useState(initEnd.day)
 
+  // The category this form was opened for is always offered, even if the
+  // caller's list predates it — a just-created Inbox has not reached the
+  // ribbon's loaded data yet, and omitting it would leave the picker showing
+  // some other category while the chore silently saved into the Inbox.
+  const categoryOptions = useMemo(() => {
+    const list = allCategories ?? []
+    return list.some(c => c.id === category.id) ? list : [...list, category]
+  }, [allCategories, category])
+
   useEscapeKey(showIconPicker ? () => setShowIconPicker(false) : onClose)
 
   async function handleSave() {
@@ -105,7 +114,7 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
       } else {
         await createChore({
           name: trimmed,
-          category_id: category.id,
+          category_id: selectedCategoryId,
           target_cadence_days: cadenceDays,
           notify_when_overdue: notify,
           auto_schedule_to_dayglance: autoSchedule,
@@ -167,7 +176,7 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
               </div>
             </div>
 
-            {isEdit && allCategories && allCategories.length > 1 && (
+            {categoryOptions.length > 1 && (
               <div>
                 <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">{t('choreForm.categoryLabel')}</label>
                 <select
@@ -175,7 +184,7 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
                   onChange={e => setSelectedCategoryId(Number(e.target.value))}
                   className="w-full bg-slate-100 dark:bg-slate-700 rounded-lg px-3 py-2 text-sm text-slate-800 dark:text-slate-100 border border-slate-200 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-green-400"
                 >
-                  {sortHierarchically(allCategories).map(cat => (
+                  {sortHierarchically(categoryOptions).map(cat => (
                     <option key={cat.id} value={cat.id}>
                       {cat.parent_category_id ? `  ${cat.name}` : cat.name}
                     </option>

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -479,6 +479,9 @@ export function Ribbon({ editMode, onLogged }: Props) {
   function closeChore() { setSelectedChore(null) }
   function afterLog() { refresh(); onLogged?.() }
   function selectSearchResult(chore: ChoreWithLastCompletion) { setShowSearch(false); setSelectedChore(chore) }
+  // Hand the typed query straight to the new-chore form, pre-filled and filed
+  // into the Inbox — the same destination every other undirected add uses.
+  function createFromSearch(name: string) { setShowSearch(false); openNewChore(name) }
 
   if (loading) {
     return (
@@ -683,10 +686,18 @@ export function Ribbon({ editMode, onLogged }: Props) {
         )}
       </div>
 
-      {/* Mobile FABs — hidden on desktop, hidden in edit mode. The action FABs
-          collapse into the handle below them with a staggered fade/slide. */}
-      {!editMode && !showEmpty && (
-        <div className="min-[1060px]:hidden fixed bottom-6 right-6 z-40 flex flex-col items-center gap-3 pointer-events-none">
+      {/* Floating actions, hidden in edit mode (which has its own per-category
+          controls). Two tiers:
+            • the filter/search tools, mobile only — desktop has them in the
+              header — which collapse into the handle beneath them;
+            • Add, at every breakpoint, anchoring the stack below that handle.
+          Add sits outside the collapsible group deliberately: it creates rather
+          than filters, and the primary action should stay put — and nearest the
+          thumb — when the tools are put away. */}
+      {!editMode && (
+        <div className="fixed bottom-6 right-6 z-40 flex flex-col items-center gap-3 pointer-events-none">
+        {!showEmpty && (
+        <div className="min-[1060px]:hidden flex flex-col items-center gap-3">
           <button
             onClick={() => setAttentionOnly(!attentionOnly)}
             style={{ transitionDelay: `${fabsCollapsed ? 0 : 100}ms` }}
@@ -739,6 +750,16 @@ export function Ribbon({ editMode, onLogged }: Props) {
             {fabsCollapsed ? <ChevronUp size={18} /> : <ChevronDown size={18} />}
           </button>
         </div>
+        )}
+          <button
+            onClick={() => openNewChore()}
+            className="pointer-events-auto flex items-center justify-center w-16 h-16 rounded-full bg-green-500 dark:bg-green-600 text-white shadow-lg border border-green-400/50 hover:bg-green-400 dark:hover:bg-green-500 active:scale-95 transition-all"
+            aria-label={t('ribbon.addChoreAriaLabel')}
+            data-tooltip={t('ribbon.addChoreTitle')}
+          >
+            <Plus size={24} />
+          </button>
+        </div>
       )}
 
       {selectedChore && !editMode && (
@@ -753,6 +774,7 @@ export function Ribbon({ editMode, onLogged }: Props) {
         <SearchModal
           data={localData}
           onSelect={selectSearchResult}
+          onCreate={createFromSearch}
           onClose={() => setShowSearch(false)}
         />
       )}

--- a/src/components/SearchModal/SearchModal.tsx
+++ b/src/components/SearchModal/SearchModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { Search, X } from 'lucide-react'
+import { Search, X, Plus } from 'lucide-react'
 import type { ChoreWithLastCompletion, Category } from '@/types'
 import type { CategoryWithChores } from '@/hooks/useChores'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
@@ -15,6 +15,10 @@ interface SearchResult {
 interface Props {
   data: CategoryWithChores[]
   onSelect: (chore: ChoreWithLastCompletion) => void
+  // Searching for something that isn't there is the clearest signal that the
+  // user wants to create it, and the name is already typed — so the list always
+  // ends with a create row rather than dead-ending on "no results".
+  onCreate: (name: string) => void
   onClose: () => void
 }
 
@@ -31,7 +35,7 @@ function highlight(text: string, query: string) {
   )
 }
 
-export function SearchModal({ data, onSelect, onClose }: Props) {
+export function SearchModal({ data, onSelect, onCreate, onClose }: Props) {
   const { t } = useTranslation()
   const [query, setQuery] = useState('')
   const [activeIdx, setActiveIdx] = useState(0)
@@ -44,6 +48,8 @@ export function SearchModal({ data, onSelect, onClose }: Props) {
   }, [])
 
   const q = query.trim().toLowerCase()
+
+  useEffect(() => { setActiveIdx(0) }, [query])
 
   const results: SearchResult[] = q === ''
     ? []
@@ -64,16 +70,22 @@ export function SearchModal({ data, onSelect, onClose }: Props) {
         return a.chore.name.localeCompare(b.chore.name)
       })
 
+  // The create row is the last entry, so it is reachable by arrow keys and is
+  // what Enter picks when nothing matched.
+  const createIdx = results.length
+  const lastIdx = createIdx
+
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setActiveIdx(i => Math.min(i + 1, results.length - 1))
+      setActiveIdx(i => Math.min(i + 1, lastIdx))
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
       setActiveIdx(i => Math.max(i - 1, 0))
-    } else if (e.key === 'Enter' && results.length > 0) {
+    } else if (e.key === 'Enter' && q !== '') {
       e.preventDefault()
-      onSelect(results[activeIdx].chore)
+      if (activeIdx === createIdx) onCreate(query.trim())
+      else onSelect(results[activeIdx].chore)
     }
   }
 
@@ -115,10 +127,10 @@ export function SearchModal({ data, onSelect, onClose }: Props) {
         {/* Results */}
         {q !== '' && (
           <div className="max-h-72 overflow-y-auto">
-            {results.length === 0 ? (
-              <p className="text-center text-sm text-slate-400 dark:text-slate-500 py-8">{t('search.noResults')}</p>
-            ) : (
-              <ul ref={listRef}>
+            {results.length === 0 && (
+              <p className="text-center text-sm text-slate-400 dark:text-slate-500 pt-6 pb-2">{t('search.noResults')}</p>
+            )}
+            <ul ref={listRef}>
                 {results.map(({ chore, category }, idx) => {
                   const Icon = chore.icon ? ICON_REGISTRY[chore.icon] : null
                   return (
@@ -143,8 +155,28 @@ export function SearchModal({ data, onSelect, onClose }: Props) {
                     </li>
                   )
                 })}
+              <li>
+                <button
+                  className={`w-full text-left px-4 py-3 flex items-center gap-3 text-sm transition-colors border-t border-slate-100 dark:border-slate-700/60 ${
+                    activeIdx === createIdx
+                      ? 'bg-slate-50 dark:bg-slate-700/60'
+                      : 'hover:bg-slate-50 dark:hover:bg-slate-700/40'
+                  }`}
+                  onClick={() => onCreate(query.trim())}
+                  onMouseEnter={() => setActiveIdx(createIdx)}
+                >
+                  <Plus size={14} className="shrink-0 text-green-500 dark:text-green-400" />
+                  <span className="flex-1 min-w-0 truncate text-slate-700 dark:text-slate-200">
+                    {t('search.createChore', { name: query.trim() })}
+                  </span>
+                  {activeIdx === createIdx && (
+                    <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono text-slate-400 dark:text-slate-500 bg-slate-100 dark:bg-slate-700/60 border border-slate-200 dark:border-slate-600">
+                      ⏎
+                    </kbd>
+                  )}
+                </button>
+              </li>
               </ul>
-            )}
           </div>
         )}
 


### PR DESCRIPTION
Adding a chore needed either the `N` shortcut or a trip into edit mode for a category's `+`. On a tablet in the desktop layout that left no way to do it at all: the floating controls were mobile-only, so ≥1060px had no add affordance on screen anywhere.

Three changes that together cover capture from any device.

## A primary Add button, at every breakpoint

On mobile it anchors the existing cluster **below** the collapse handle rather than joining the filters above it:

```
[ Soon ]      ← tools: change what you're looking at, collapsible
[ Mine ]
[ Search ]
    ⌄         ← handle
[   +   ]     ← primary: creates something, always present
```

Add stays put when the tools are put away, and sits nearest the thumb. That also gives the collapsed state a purpose beyond hiding things: collapsed means "just let me add".

Solid green marks it as primary. Worth noting for review: solid green and solid amber are already in use in this cluster for *active filter* states (Mine and Soon), so the plus glyph is doing the work of keeping it from reading as a stuck toggle — no other control here is ever a plus.

Desktop gets the same button and none of the mobile-only filters, which already live in its header. A header button was the alternative, but that row is seven icons plus three controls already, and burying the app's primary action among the settings seemed worse than a conventional floating one.

## Creating from search

Searching for something absent is the clearest signal that the user wants to create it, and the name is already typed. The results list now ends with a create row instead of dead-ending on "no results":

- it is the last entry, reachable by arrow keys
- Enter picks it when nothing matched
- Enter still opens the **top match** when there is one, so the existing flow is untouched

Works by keyboard (`⌘K`, type, Enter) and by touch (Search, type, tap), with no new chrome.

## Choosing the category while creating

The picker was gated behind `isEdit`, so a new chore could only be filed after the fact — which made the Inbox default (#267) feel like a constraint rather than a smart default. It now shows whenever there is more than one category, defaulting to the Inbox, and creating honours the selection instead of the category the form was opened for.

One subtlety handled: the form always offers the category it was opened with, even when the caller's list predates it. A just-created Inbox has not reached the ribbon's loaded data yet, and omitting it would have shown some other category selected while the chore silently saved into the Inbox.

## Testing

`npm run build`, `npm run lint` and `npm test` clean — 343 tests. New strings added to all six locales.

Verified in a browser rather than by inspection:

```
desktop FAB visible          : true      (filter FABs correctly absent)
form title                   : Add chore — Inbox
category picker on create    : true | value = Inbox
picker options               : Home, Health, Vehicle, Finances, Inbox

search rows (no match)       : Create "Descale kettle"
search rows (with match)     : Mop kitchen · Home | Create "Mop"
Enter on a match             : opens Mop kitchen
ArrowDown + Enter            : opens Add chore — Inbox, name pre-filled "Mop"
create → redirect to Health  : chore landed in Health

mobile stack (y ascending)   : search 624 · chevron 700 · add 756
collapsed: search             opacity=0 pointer-events=none
collapsed: add                opacity=1 pointer-events=auto, still opens the form
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x

---
_Generated by [Claude Code](https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x)_