### PR TITLE
Journal day headings and heatmap tooltips

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -159,6 +159,11 @@
     "today": "Heute",
     "noTimeHint": "Keine Uhrzeit — es wird 12 Uhr verwendet"
   },
+  "heatmap": {
+    "completions_one": "{{count}} Erledigung",
+    "completions_other": "{{count}} Erledigungen",
+    "noCompletions": "Keine Erledigungen"
+  },
   "help": {
     "title": "Hilfe & Feedback",
     "contactIssues": "Kontakt & Probleme",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -164,6 +164,11 @@
     "today": "Today",
     "noTimeHint": "No time set — will use noon"
   },
+  "heatmap": {
+    "completions_one": "{{count}} completion",
+    "completions_other": "{{count}} completions",
+    "noCompletions": "No completions"
+  },
   "help": {
     "title": "Help & Feedback",
     "contactIssues": "Contact & Issues",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -159,6 +159,11 @@
     "today": "Hoy",
     "noTimeHint": "Sin hora — se usará el mediodía"
   },
+  "heatmap": {
+    "completions_one": "{{count}} completada",
+    "completions_other": "{{count}} completadas",
+    "noCompletions": "Ninguna completada"
+  },
   "help": {
     "title": "Ayuda y comentarios",
     "contactIssues": "Contacto y problemas",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -159,6 +159,11 @@
     "today": "Aujourd'hui",
     "noTimeHint": "Aucune heure — midi sera utilisé"
   },
+  "heatmap": {
+    "completions_one": "{{count}} réalisation",
+    "completions_other": "{{count}} réalisations",
+    "noCompletions": "Aucune réalisation"
+  },
   "help": {
     "title": "Aide & Retours",
     "contactIssues": "Contact & Problèmes",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -159,6 +159,11 @@
     "today": "Oggi",
     "noTimeHint": "Nessun orario — verrà usato mezzogiorno"
   },
+  "heatmap": {
+    "completions_one": "{{count}} completamento",
+    "completions_other": "{{count}} completamenti",
+    "noCompletions": "Nessun completamento"
+  },
   "help": {
     "title": "Aiuto e feedback",
     "contactIssues": "Contatti e problemi",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -159,6 +159,11 @@
     "today": "Hoje",
     "noTimeHint": "Sem hora — será usado o meio-dia"
   },
+  "heatmap": {
+    "completions_one": "{{count}} conclusão",
+    "completions_other": "{{count}} conclusões",
+    "noCompletions": "Nenhuma conclusão"
+  },
   "help": {
     "title": "Ajuda e feedback",
     "contactIssues": "Contacto e problemas",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,8 @@ import { useAndroidIntentBridge } from '@/hooks/useAndroidIntentBridge'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
+import { formatDate } from '@/utils/datetime'
+import { completionsLabel } from '@/utils/completionsLabel'
 import { createEngine, initSessionKey, setupEncryptionKey, runAutoBackups, ensureSyncFolder, CRYPTO_CONFIG, DB_CRYPTO_CONFIG, getSyncWebdavConfig } from '@/sync/engine'
 import { createDbEngine } from '@/sync/dbEngine'
 import { registerDbEngine } from '@/sync/dirtyTracker'
@@ -90,6 +92,7 @@ function getWaveColor(wi: number, di: number, day: HeatDay, wavePos: number): st
 }
 
 function HeaderHeatmap({ weeks, onSelectDay }: { weeks: HeatDay[][]; onSelectDay: (date: string) => void }) {
+  const { t } = useTranslation()
   const [wavePos, setWavePos] = useState(-WAVE_WIDTH)
 
   useEffect(() => {
@@ -117,8 +120,9 @@ function HeaderHeatmap({ weeks, onSelectDay }: { weeks: HeatDay[][]; onSelectDay
               type="button"
               disabled={day.isFuture}
               onClick={() => onSelectDay(day.date)}
-              data-tooltip={day.isFuture ? undefined : `${day.date}${day.count > 0 ? ` · ${day.count}` : ''}`}
-              aria-label={day.date}
+              data-tooltip={day.isFuture ? undefined : formatDate(day.date)}
+              data-tooltip-detail={day.isFuture ? undefined : completionsLabel(t, day.count)}
+              aria-label={`${formatDate(day.date)}, ${completionsLabel(t, day.count)}`}
               className="w-[9px] h-[9px] rounded-[2px] transition-transform hover:scale-150 disabled:cursor-default disabled:hover:scale-100"
               style={{ backgroundColor: getWaveColor(wi, di, day, wavePos) }}
             />

--- a/src/components/JournalModal/JournalModal.tsx
+++ b/src/components/JournalModal/JournalModal.tsx
@@ -341,7 +341,12 @@ export function JournalModal({ onClose, initialDate, onChanged }: Props) {
             <>
               {groups.map(group => (
                 <div key={group.day}>
-                  <div className="sticky top-0 z-10 flex items-baseline justify-between gap-3 py-2 bg-slate-50 dark:bg-slate-900/95 backdrop-blur-sm">
+                  {/* The tint bleeds out to the modal edges (-mx cancels the
+                      scroller's padding) and the text is padded back in, so the
+                      band reads as a full-width divider with its label inset
+                      rather than as a bar with the text jammed against its
+                      ends — while the label stays aligned with the rows below. */}
+                  <div className="sticky top-0 z-10 -mx-5 sm:-mx-6 px-5 sm:px-6 flex items-baseline justify-between gap-3 py-2 bg-slate-50 dark:bg-slate-900/95 backdrop-blur-sm">
                     <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500 truncate">
                       {dayLabel(group.day)}
                     </p>

--- a/src/components/LogModal/LogModal.tsx
+++ b/src/components/LogModal/LogModal.tsx
@@ -4,7 +4,8 @@ import dayjs from 'dayjs'
 import type { ChoreWithLastCompletion, CompletionEvent } from '@/types'
 import { logCompletion, getCompletionHistory, deleteCompletion, updateCompletionNote } from '@/db/queries'
 import { CompletionRow } from '@/components/CompletionRow/CompletionRow'
-import { formatMonthShort, weekdayAtOffset } from '@/utils/datetime'
+import { formatDate, formatMonthShort, weekdayAtOffset } from '@/utils/datetime'
+import { completionsLabel } from '@/utils/completionsLabel'
 import { getMeUserSyncId } from '@/multiuser/settings'
 import { useUsersContext } from '@/multiuser/UsersContext'
 import { formatElapsed } from '@/utils/cadence'
@@ -259,6 +260,7 @@ function GapMarker({ days, target }: { days: number; target: number | null }) {
 type HeatDay = { date: string; count: number; isFuture: boolean }
 
 function Heatmap({ weeks }: { weeks: HeatDay[][] }) {
+  const { t } = useTranslation()
   const today = dayjs().format('YYYY-MM-DD')
   const months = getMonthLabels(weeks)
   // Rows are weekdays in the locale's own week order — Sunday-first in en,
@@ -290,7 +292,8 @@ function Heatmap({ weeks }: { weeks: HeatDay[][] }) {
             {week.map((day, di) => (
               <div
                 key={di}
-                data-tooltip={day.isFuture ? undefined : `${day.date}${day.count > 0 ? ` · ${day.count}` : ''}`}
+                data-tooltip={day.isFuture ? undefined : formatDate(day.date)}
+                data-tooltip-detail={day.isFuture ? undefined : completionsLabel(t, day.count)}
                 className="w-[11px] h-[11px] rounded-[2px]"
                 style={{ backgroundColor: cellColor(day, today) }}
               />

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -11,7 +11,8 @@ import { createPortal } from 'react-dom'
  * hover state, so there is nothing to reveal; the element's aria-label still
  * carries the meaning for assistive tech).
  *
- * Usage is a single attribute — `data-tooltip="…"` on any element, anywhere.
+ * Usage is an attribute — `data-tooltip="…"` on any element, anywhere, with an
+ * optional `data-tooltip-detail="…"` for a quieter second line beneath it.
  * <TooltipHost/> is mounted once at the app root and delegates from `document`,
  * so one set of listeners serves every surface, including modals that portal
  * out of the React tree and grids of hundreds of cells (the heatmaps, the icon
@@ -25,7 +26,7 @@ const SHOW_DELAY = 120
 const GAP = 8
 const MARGIN = 6
 
-interface Anchor { rect: DOMRect; label: string }
+interface Anchor { rect: DOMRect; label: string; detail?: string }
 
 function TooltipBubble({ anchor }: { anchor: Anchor }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -59,7 +60,7 @@ function TooltipBubble({ anchor }: { anchor: Anchor }) {
       aria-hidden="true"
       className={`
         fixed z-[70] pointer-events-none max-w-[16rem] px-2 py-1 rounded-md
-        text-xs font-medium leading-snug
+        text-xs font-medium leading-snug text-center
         bg-slate-800 text-slate-100 dark:bg-slate-700 dark:text-slate-100
         border border-slate-700 dark:border-slate-600 shadow-lg
         transition-opacity duration-100 ${pos ? 'opacity-100' : 'opacity-0'}
@@ -67,6 +68,11 @@ function TooltipBubble({ anchor }: { anchor: Anchor }) {
       style={{ left: pos?.left ?? 0, top: pos?.top ?? 0 }}
     >
       {anchor.label}
+      {anchor.detail && (
+        <span className="block font-normal text-slate-400 dark:text-slate-400">
+          {anchor.detail}
+        </span>
+      )}
     </div>,
     document.body,
   )
@@ -89,11 +95,12 @@ export function TooltipHost() {
 
   const hide = useCallback(() => { clear(); setAnchor(null) }, [clear])
 
-  const show = useCallback((el: Element, label: string, delay: number) => {
+  const show = useCallback((el: HTMLElement, label: string, delay: number) => {
     if (!label) { hide(); return }
     clear()
+    const detail = el.dataset.tooltipDetail || undefined
     timer.current = window.setTimeout(
-      () => setAnchor({ rect: el.getBoundingClientRect(), label }),
+      () => setAnchor({ rect: el.getBoundingClientRect(), label, detail }),
       delay,
     )
   }, [clear, hide])

--- a/src/utils/completionsLabel.ts
+++ b/src/utils/completionsLabel.ts
@@ -1,0 +1,17 @@
+import type { TFunction } from 'i18next'
+
+/**
+ * "3 completions" / "1 completion" / "No completions" for a heatmap cell.
+ *
+ * Zero takes its own key rather than a `_zero` plural suffix: none of the six
+ * supported languages has a CLDR zero plural category, so a count of 0 would
+ * fall through to the `_other` form and read as "0 completions".
+ *
+ * Shared by both heatmaps — the header one and the per-chore one in LogModal —
+ * so their cells describe themselves identically.
+ */
+export function completionsLabel(t: TFunction, count: number): string {
+  return count === 0
+    ? t('heatmap.noCompletions')
+    : t('heatmap.completions', { count })
+}


### PR DESCRIPTION
Two small presentation fixes from reviewing the Journal in use.

## Day headings sat flush against their own band

The sticky day heading was the same width as the scroller's content, so its date and entry count pressed right up against the ends of its tinted band and read as cramped.

The tint now bleeds out to the modal edges — a negative margin cancelling the scroller's padding — with the text padded back in. The band reads as a full-width divider with an inset label, and the label stays aligned with the entries beneath it rather than being indented away from them. Simply padding the text inward would have fixed the crowding but broken that alignment.

Because the negative margin cancels the padding exactly, the scroller gains no horizontal overflow. Checked at both breakpoints in light and dark (`scrollWidth > clientWidth` is false).

## Heatmap cells now say what the number means

A cell read `2026-08-11 · 3`: a raw ISO date and a bare number you had to already know the meaning of. It is now two lines — the date, then the count spelled out:

```
Aug 11, 2026        11 août 2026
3 completions       3 réalisations
```

Tooltips gained an optional `data-tooltip-detail` for the second line rather than smuggling a newline through the existing attribute. That keeps the two lines styleable apart — the detail renders quieter than the date — and the bubble centres them. Reusable anywhere else a two-line tooltip is wanted.

Two details worth flagging for review:

- **The date is now localised.** It was raw ISO; it goes through the shared formatter so it matches every other date in the app.
- **Zero gets its own key, not a `_zero` plural suffix.** None of the six supported languages has a CLDR zero plural category, so a count of 0 would fall through to `_other` and read "0 completions" rather than "No completions".

Both heatmaps use it — the header one and the per-chore one in `LogModal` — through a single helper, so their cells can't drift apart. The header cells are buttons, so their accessible name now carries the count as well, instead of just the bare date.

## Testing

`npm run build`, `npm run lint` and `npm test` clean — 343 tests. New strings in all six locales.

Verified in a browser across languages and themes, sampling cells with different counts:

```
en/dark    Aug 11, 2026 // 3 completions
           Aug 8, 2026  // 1 completion
           Aug 5, 2026  // No completions

fr/light   11 août 2026 // 3 réalisations
           8 août 2026  // 1 réalisation
           5 août 2026  // Aucune réalisation
```

Day heading band, measured against the modal card: label inset 24px at `sm` and above, 20px below, count mirrored on the right, no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x

---
_Generated by [Claude Code](https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x)_