### PR TITLE
Version 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps `package.json` to 2.3.0 ahead of the release. Only `package.json` and `package-lock.json` change: the in-app badge, the Android `versionName`/`versionCode`, and the README badge all derive from `package.json`, and nothing else in the tree hardcodes the app version (the other `2.2.0` matches are the Kotlin Gradle plugin, unrelated).

Android `versionCode` derives to **2030000**, up from 2.2.0's 2020000.

## Why minor rather than patch

Surveyed the 14 PRs merged since the `v2.2.0` tag. User-facing additions:

- **Journal** (#264): completion history with range chips, category/user/text filters, a summary strip, day grouping, CSV export and paging, reachable from the toolbar, `J`, or a heatmap day.
- **Add button, create-from-search, and category choice at creation** (#268): adding a chore no longer requires a keyboard or edit mode, and desktop/tablet gained an add affordance they never had.
- **Inbox for unfiled chores** (#267), converging the in-app add paths with where Tasker `CREATE` already put them.
- **App-drawn tooltips** (#264) replacing the native `title` across all 14 sites.
- **Dates and times follow the app language** (#265), including a 24 hour clock for the five non-English locales and correct week-start handling.
- **Backoff-aware sync settings** (#262) showing the standing retry countdown.

Fixes: vault re-link and identity-change state reset (#263), credential-halt recovery (#258). Plus uniform settings-modal headers, Journal and heatmap polish (#264, #269), and SHA-256 checksums for release artifacts (#256).

Nothing breaking, no schema migration, no data format change, nothing removed. Several additive features with a clean upgrade path is a minor release.

## Excluded from the assessment

iOS work (#254, #260, #266) is not released. Its only shared-code changes are a native-shell guard widened from `platform === 'android'` to `isNativeShell()`, which stays true on Android, and a comment, so nothing there reaches Android or web. Dependency hygiene (#259, #261) carries no behavior change.

## Release notes

Drafted separately for the GitHub Release and for Play's "What's new" field (which is capped at 500 characters). Both follow the repo's no-em-dashes rule, verified by scanning for em dash, en dash, horizontal bar, minus sign and double hyphen.

Three changes are visible enough to existing users that the notes call them out explicitly rather than leaving them to be discovered: `N` now files into the Inbox instead of the visible category, non-English locales get reformatted dates and a 24 hour clock, and tooltips look and behave differently.

## Testing

`npm run build`, `npm run lint` and `npm test` clean after the bump, 343 tests, and the build banner reports `lastglance@2.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x

---
_Generated by [Claude Code](https://claude.ai/code/session_017pFrhqFPDqqfpHfqR8Ey3x)_