### PR TITLE
Start the week where the user's region starts it

### DIFF
--- a/src/utils/datetime.test.ts
+++ b/src/utils/datetime.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import dayjs from 'dayjs'
 import {
   applyDateLocale,
@@ -16,7 +16,10 @@ import {
 // A Wednesday, deliberately in the afternoon so the 12-/24-hour split shows.
 const SAMPLE = '2026-08-12T14:05:00'
 
-afterEach(() => applyDateLocale('en'))
+afterEach(() => {
+  vi.unstubAllGlobals()
+  applyDateLocale('en')
+})
 
 describe('applyDateLocale', () => {
   it('accepts the six supported languages', () => {
@@ -96,37 +99,95 @@ describe('display formatting', () => {
 })
 
 describe('week start', () => {
-  it('starts the week on Sunday in English and Monday in the others', () => {
+  // The region the browser reports, which is what actually decides this.
+  function inRegion(tag: string | undefined): void {
+    vi.stubGlobal('navigator', tag === undefined ? {} : { languages: [tag], language: tag })
+  }
+
+  it('follows the region, not the UI language (issue #272)', () => {
+    // English UI in a Monday-first country: the reported case.
+    inRegion('en-DE')
+    applyDateLocale('en')
+    expect(firstDayOfWeek()).toBe(1)
+
+    // And the inverse: Spanish UI in a Sunday-first country.
+    inRegion('es-MX')
+    applyDateLocale('es')
+    expect(firstDayOfWeek()).toBe(0)
+  })
+
+  it('keeps the familiar answer where region and language agree', () => {
+    inRegion('en-US')
     applyDateLocale('en')
     expect(firstDayOfWeek()).toBe(0)
-    for (const lng of ['de', 'es', 'fr', 'it', 'pt']) {
-      applyDateLocale(lng)
-      expect(firstDayOfWeek()).toBe(1)
-    }
+    inRegion('de-DE')
+    applyDateLocale('de')
+    expect(firstDayOfWeek()).toBe(1)
+  })
+
+  it('falls back to the language default when the tag carries no region', () => {
+    inRegion('de')
+    applyDateLocale('de')
+    expect(firstDayOfWeek()).toBe(1)
+    inRegion('en')
+    applyDateLocale('en')
+    expect(firstDayOfWeek()).toBe(0)
+  })
+
+  it('falls back to the language default when the platform reports nothing at all', () => {
+    inRegion(undefined)
+    applyDateLocale('fr')
+    expect(firstDayOfWeek()).toBe(1)
+    applyDateLocale('en')
+    expect(firstDayOfWeek()).toBe(0)
+  })
+
+  it('does not let one region leak into the next locale switch', () => {
+    // updateLocale mutates the shared locale object, so a Sunday-first region
+    // must not still be in force after moving to a locale it never applied to.
+    inRegion('en-US')
+    applyDateLocale('fr')
+    expect(firstDayOfWeek()).toBe(0)
+    inRegion(undefined)
+    applyDateLocale('fr')
+    expect(firstDayOfWeek()).toBe(1)
   })
 
   it('moves dayjs arithmetic with it, which is what the grids are built from', () => {
+    inRegion('en-US')
     applyDateLocale('en')
     expect(dayjs(SAMPLE).startOf('week').day()).toBe(0)
+    inRegion('fr-FR')
     applyDateLocale('fr')
     expect(dayjs(SAMPLE).startOf('week').day()).toBe(1)
   })
 
   it('rotates the weekday labels to match that week order', () => {
+    inRegion('en-US')
     applyDateLocale('en')
     expect(weekdayMinLabels()).toHaveLength(7)
     expect(weekdayMinLabels()[0]).toBe('Su')
+    inRegion('fr-FR')
     applyDateLocale('fr')
     const fr = weekdayMinLabels()
     expect(fr).toHaveLength(7)
     expect(fr[0]).toBe('lu') // Monday leads, and the label is French
     expect(fr[6]).toBe('di')
+
+    // The English labels rotate too when the region says Monday — the header
+    // has to line up with the grid, whatever language it is written in.
+    inRegion('en-GB')
+    applyDateLocale('en')
+    expect(weekdayMinLabels()[0]).toBe('Mo')
+    expect(weekdayMinLabels()[6]).toBe('Su')
   })
 
   it('reports the real weekday for a row offset, so labels land on the right rows', () => {
+    inRegion('en-US')
     applyDateLocale('en')
     // Sunday-start: row 1 is Monday.
     expect(weekdayAtOffset(1).weekday).toBe(1)
+    inRegion('fr-FR')
     applyDateLocale('fr')
     // Monday-start: Monday is row 0 instead.
     expect(weekdayAtOffset(0).weekday).toBe(1)

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import localeData from 'dayjs/plugin/localeData'
+import updateLocale from 'dayjs/plugin/updateLocale'
 
 // Locales are imported statically rather than on demand. They are ~1KB each,
 // and a dynamic import would land after i18next has already told React to
@@ -12,13 +13,15 @@ import 'dayjs/locale/it'
 import 'dayjs/locale/pt'
 
 dayjs.extend(localeData)
+dayjs.extend(updateLocale)
 
 /**
  * Locale-aware date handling, split by responsibility:
  *
  *   • dayjs owns date *arithmetic*. Its locale decides where a week starts,
- *     which every calendar grid and heatmap column depends on — Sunday in
- *     en, Monday in the five others.
+ *     which every calendar grid and heatmap column depends on — but the week
+ *     start itself comes from the *region*, not the language (see
+ *     regionWeekStart below), and is written into the locale on every switch.
  *   • Intl.DateTimeFormat owns date *display*. It is CLDR-correct in every
  *     locale for free, including things a hand-written dayjs token cannot get
  *     right: field order ("Aug 12" vs "12 août"), whether a comma belongs
@@ -27,6 +30,20 @@ dayjs.extend(localeData)
  * Formatting a date anywhere in the app goes through this module, so no
  * component has to know which locale is active.
  */
+
+// Week info reached ES2020's lib typings after this project's target, and the
+// two engine spellings of it are both still in the wild, so declare what we
+// probe for rather than casting at the call site.
+interface WeekInfo { firstDay: number }
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Intl {
+    interface Locale {
+      getWeekInfo?: () => WeekInfo
+      weekInfo?: WeekInfo
+    }
+  }
+}
 
 const SUPPORTED = ['de', 'es', 'fr', 'it', 'pt'] as const
 
@@ -49,7 +66,61 @@ export function applyDateLocale(lng: string | undefined): void {
   const supported = (SUPPORTED as readonly string[]).includes(base)
   activeLocale = supported ? base : 'en'
   dayjs.locale(activeLocale)
+  // Read the language's own week start before overwriting it, so the first
+  // switch into a locale always sees the pristine value.
+  const languageDefault = localeDefaultWeekStart(activeLocale)
+  // Written every time, and always to an explicit value: updateLocale mutates
+  // the shared locale object permanently, so a later switch that fell through
+  // to "leave it alone" would inherit whatever the previous one wrote.
+  dayjs.updateLocale(activeLocale, { weekStart: regionWeekStart() ?? languageDefault })
   formatterCache.clear()
+}
+
+/**
+ * Where the user's *region* starts the week, as a dayjs weekday (0 = Sunday).
+ * Null when the platform cannot say — no region in the language tag, or an
+ * engine without Intl week info — leaving the language's own default to stand.
+ *
+ * The region is what people actually mean by "my weeks start on Monday": the
+ * UI language does not decide it, and using the language as a proxy gets it
+ * wrong in both directions. Someone in Germany running the app in English was
+ * shown Sunday-first weeks (issue #272), and every es/pt user was shown
+ * Monday-first even in Mexico and Brazil, which are Sunday-first.
+ */
+function regionWeekStart(): number | null {
+  const tag = typeof navigator !== 'undefined'
+    ? (navigator.languages?.[0] ?? navigator.language)
+    : undefined
+  if (!tag) return null
+  try {
+    const locale = new Intl.Locale(tag)
+    // The region alone decides this, so a tag without one ("de", "en") has
+    // nothing to say and must not be answered from the language default —
+    // Intl would happily invent a region for it.
+    if (!locale.region) return null
+    // getWeekInfo() is the current spec; older engines (and Node) expose the
+    // same object as a `weekInfo` property.
+    const info = typeof locale.getWeekInfo === 'function' ? locale.getWeekInfo() : locale.weekInfo
+    const firstDay = info?.firstDay
+    if (typeof firstDay !== 'number') return null
+    // Intl numbers days 1 = Monday … 7 = Sunday; dayjs uses 0 = Sunday.
+    return firstDay % 7
+  } catch {
+    return null
+  }
+}
+
+// A locale's own week start, captured before anything overwrites it. Read on
+// the first switch into each locale — while dayjs still holds the pristine
+// value — so the fallback above stays truthful for the rest of the session.
+const localeDefaults = new Map<string, number>()
+
+function localeDefaultWeekStart(locale: string): number {
+  const known = localeDefaults.get(locale)
+  if (known !== undefined) return known
+  const value = dayjs.localeData().firstDayOfWeek()
+  localeDefaults.set(locale, value)
+  return value
 }
 
 // Intl.DateTimeFormat construction is comparatively expensive and these run per
@@ -112,7 +183,7 @@ export function formatMonthShort(value: DateInput): string {
   return formatter({ month: 'short' }).format(toDate(value))
 }
 
-/** 0 for Sunday-start locales (en), 1 for Monday-start (the other five). */
+/** 0 when the week starts on Sunday, 1 when it starts on Monday. */
 export function firstDayOfWeek(): number {
   return dayjs.localeData().firstDayOfWeek()
 }


### PR DESCRIPTION
Closes #272.

The date picker and both heatmaps took their week start from the UI language, so anyone running the app in English saw Sunday-first weeks no matter where they were. Language is the wrong proxy: the region decides, and there is no language picker in the app to work around it with. It was wrong in the other direction too, showing Monday-first weeks to every `es` and `pt` user including Mexico and Brazil, which start on Sunday.

## What changed

Two files: `src/utils/datetime.ts` and its test.

`applyDateLocale` now reads the region from the browser's language tag, takes `firstDay` from `Intl.Locale`'s week info, and writes it into the dayjs locale with `updateLocale`. Everything downstream follows from that single value, so no component changed:

- `startOf('week')` builds the picker grid, the LogModal heatmap, and the header heatmap.
- `firstDayOfWeek()` orders the picker's column headers and the heatmaps' row labels.

Three details worth a reviewer's attention:

- **Both engine spellings are probed**: `getWeekInfo()` (current spec) and the older `weekInfo` property. If neither exists, or the tag carries no region (`"de"`, `"en"`), it falls back to the language's own default, which is the behaviour on main today.
- **The fallback is made honest.** `updateLocale` mutates the shared locale object permanently, so each locale's original week start is captured on the first switch into it, before anything overwrites it, and an explicit value is written every time. Without that, a later fallback would silently inherit whatever the previous region wrote. There is a test pinning this.
- **Day numbering differs between the two APIs.** Intl uses 1 = Monday through 7 = Sunday; dayjs uses 0 = Sunday. Converted at the boundary.

`updateLocale` ships with dayjs, so there is no new dependency. `Intl.Locale`'s week info is not in this project's TypeScript lib target, so the two shapes are declared rather than cast at the call site.

## Verification

- `npm run lint`, `npm test` (347 passing), and `npm run build` are clean.
- The week-start test block was rewritten around the new contract, driving the region explicitly with a stubbed `navigator`: the reported `en-DE` case, the inverse `es-MX` case, region and language agreeing, both fallback paths, and a guard against one region leaking into the next locale switch.
- Driven in a real browser against the production build: with `en-DE` the picker header reads `Mo Tu We Th Fr Sa Su` and the grid lines up beneath it; with `en-US` it reads `Su Mo Tu We Th Fr Sa`.

## Note for the release notes

This also changes the week start for existing users in Sunday-first regions who run the app in Spanish or Portuguese (Mexico, Brazil and similar), from Monday to Sunday. That is the correct answer for their region, but it is a visible change they did not ask for. If that is unwelcome, the alternative is an explicit "week starts on" preference, which was considered and set aside as the larger change: the date plumbing is the same, but the app has no general preferences surface to host the control.

---
_Generated by [Claude Code](https://claude.ai/code/session_011kEbA5rQPPirCj1XdPuXW2)_