### PR TITLE
Version 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps `version` in `package.json` to 2.4.0. Two files, the same footprint as the 2.3.0 bump: `package.json` and the two root entries in `package-lock.json`. Android `versionCode` derives to **2040000**; `versionName`, the in-app badge, and the README badge all read from `package.json`.

## Merge last

This bump describes work that is still in review. Merge #273 and #274 first, then this one, so main never carries a 2.4.0 that claims features it does not have.

## What 2.4.0 covers

- **#273, chore details (closes #271).** Chores carry free-text details of their own, separate from the note on a single completion: entered in the chore form, shown read-only when the chore is opened, and marked on the row. Ships a Dexie v13 migration that backfills existing rows.
- **#274, region-aware week start (closes #272).** The week now starts where the user's region starts it, so an English-language app in a Monday-first country no longer draws Sunday-first calendars.

## Why minor rather than patch

An additive feature with no breaking change, which is the same reasoning recorded for 2.3.0. The history reserves patch releases for packaging and dependency work: 2.0.1 was a multi-arch Docker re-release, 2.0.2 a billing pin and a paywall fix. #274 alone would have been 2.3.1, but the chore details feature and its schema migration carry the release to a minor.

## For the release notes

Beyond the two headline items, one change is worth calling out because nobody asked for it: users in Sunday-first regions running the app in Spanish or Portuguese (Mexico and Brazil among them) will see their week start move from Monday to Sunday. That is the correct answer for their region, but it is visible and unrequested.

---
_Generated by [Claude Code](https://claude.ai/code/session_011kEbA5rQPPirCj1XdPuXW2)_