### PR TITLE
Cap and scroll every modal so the keyboard cannot hide them

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-content makes the on-screen keyboard shrink the
+         layout viewport instead of only the visual one. Without it, edge-to-edge
+         Android (targetSdk 35+, which no longer resizes the window for the IME)
+         leaves every `fixed inset-0` overlay at full screen height behind the
+         keyboard, so the bottom of a modal sheet cannot be reached. With it,
+         svh/dvh units and fixed overlays follow the keyboard down. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta name="theme-color" content="#05081A" />
     <meta name="color-scheme" content="dark" />
     <meta name="description" content="When did you last...? A last-done tracker for the things that matter. No deadlines, no nagging, just information." />

--- a/src/components/ActivityLogModal/ActivityLogModal.tsx
+++ b/src/components/ActivityLogModal/ActivityLogModal.tsx
@@ -60,7 +60,7 @@ export function ActivityLogModal({ onClose }: Props) {
       className="fixed inset-0 z-60 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[85vh]">
+      <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[85svh]">
         <div className="flex items-center gap-3 px-6 pt-5 pb-4 shrink-0 border-b border-slate-100 dark:border-slate-700/40">
           <ScrollText size={18} className="text-green-400 shrink-0" />
           <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 flex-1">

--- a/src/components/BackupModal/BackupModal.tsx
+++ b/src/components/BackupModal/BackupModal.tsx
@@ -161,10 +161,10 @@ export function BackupModal({ engine, onClose, onImported }: Props) {
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl border border-slate-200 dark:border-slate-700/50">
+      <div className="w-full sm:max-w-sm max-h-[90svh] flex flex-col bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50">
         {/* Archive matches the toolbar button and settings-sheet row that open
             this modal; the heading follows the Journal/Help/Shortcuts pattern. */}
-        <div className="flex items-center gap-3 mb-5">
+        <div className="shrink-0 flex items-center gap-3 px-6 pt-6 pb-5">
           <Archive size={18} className="text-green-400 shrink-0" />
           <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 flex-1">{t('backup.title')}</h2>
           <button
@@ -175,6 +175,7 @@ export function BackupModal({ engine, onClose, onImported }: Props) {
           </button>
         </div>
 
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6">
         {state === 'confirm' && pending ? (
           <div className="space-y-4">
             <p className="text-sm text-slate-700 dark:text-slate-300"
@@ -341,6 +342,7 @@ export function BackupModal({ engine, onClose, onImported }: Props) {
             <input ref={fileRef} type="file" accept=".json,application/json" className="hidden" onChange={handleFileChange} />
           </div>
         )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/CategoryFormModal/CategoryFormModal.tsx
+++ b/src/components/CategoryFormModal/CategoryFormModal.tsx
@@ -77,14 +77,15 @@ export function CategoryFormModal({ category, parentCategoryId, parentIcon, root
         className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
         onClick={e => { if (e.target === e.currentTarget) onClose() }}
       >
-        <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 space-y-4 shadow-2xl border border-slate-200 dark:border-slate-700/50">
-          <div className="flex items-center justify-between">
+        <div className="w-full sm:max-w-sm max-h-[90svh] flex flex-col bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50">
+          <div className="shrink-0 flex items-center justify-between px-6 pt-6 pb-4">
             <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
             <button onClick={onClose} className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors">
               <X size={18} />
             </button>
           </div>
 
+          <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-1 space-y-4">
           <div className="flex gap-2">
             <div className="flex-1">
               <input
@@ -158,22 +159,25 @@ export function CategoryFormModal({ category, parentCategoryId, parentIcon, root
             </div>
           )}
 
-          {error && <p className="text-xs text-red-500">{error}</p>}
+          </div>
 
-          <div className="flex gap-3">
-            <button
-              onClick={onClose}
-              className="flex-1 py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
-            >
-              {t('categoryForm.cancel')}
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="flex-1 py-2.5 rounded-xl text-sm font-medium text-green-400 border border-green-400/40 hover:text-green-300 hover:bg-green-400/10 hover:border-green-400/60 disabled:opacity-50 transition-colors"
-            >
-              {saving ? t('categoryForm.saving') : isEdit ? t('categoryForm.save') : t('categoryForm.add')}
-            </button>
+          <div className="shrink-0 px-6 pt-4 pb-6 border-t border-slate-100 dark:border-slate-700/40 space-y-2">
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="flex-1 py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+              >
+                {t('categoryForm.cancel')}
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="flex-1 py-2.5 rounded-xl text-sm font-medium text-green-400 border border-green-400/40 hover:text-green-300 hover:bg-green-400/10 hover:border-green-400/60 disabled:opacity-50 transition-colors"
+              >
+                {saving ? t('categoryForm.saving') : isEdit ? t('categoryForm.save') : t('categoryForm.add')}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/ChoreFormModal/ChoreFormModal.tsx
+++ b/src/components/ChoreFormModal/ChoreFormModal.tsx
@@ -142,8 +142,13 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
         className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
         onClick={e => { if (e.target === e.currentTarget) onClose() }}
       >
-        <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 space-y-4 shadow-2xl border border-slate-200 dark:border-slate-700/50">
-          <div className="flex items-center justify-between">
+        {/* Capped and split into a pinned header, a scrolling body, and pinned
+            actions: this form is the app's tallest (every optional section open
+            it exceeds a phone screen on its own), and as a bottom sheet its
+            overflow ran off the TOP of the screen with nothing to scroll. On
+            Android the on-screen keyboard makes even the short form overflow. */}
+        <div className="w-full sm:max-w-md max-h-[90svh] flex flex-col bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50">
+          <div className="shrink-0 flex items-center justify-between px-6 pt-6 pb-4">
             <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100">
               {isEdit ? t('choreForm.editChore') : t('choreForm.addChore', { category: category.name })}
             </h2>
@@ -152,7 +157,7 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
             </button>
           </div>
 
-          <div className="space-y-3">
+          <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-1 space-y-3">
             <div className="flex gap-2">
               <div className="flex-1">
                 <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">{t('choreForm.nameLabel')}</label>
@@ -366,23 +371,28 @@ export function ChoreFormModal({ category, allCategories, chore, initialName, on
               )}
             </div>
 
-            {error && <p className="text-xs text-red-500">{error}</p>}
           </div>
 
-          <div className="flex gap-3 pt-1">
-            <button
-              onClick={onClose}
-              className="flex-1 py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
-            >
-              {t('choreForm.cancel')}
-            </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="flex-1 py-2.5 rounded-xl text-sm font-medium text-green-400 border border-green-400/40 hover:text-green-300 hover:bg-green-400/10 hover:border-green-400/60 disabled:opacity-50 transition-colors"
-            >
-              {saving ? t('choreForm.saving') : isEdit ? t('choreForm.save') : t('choreForm.add')}
-            </button>
+          {/* Errors live with the actions rather than in the scrolling body, so
+              a validation message cannot appear somewhere the user is not
+              looking after they have scrolled down to press Save. */}
+          <div className="shrink-0 px-6 pt-4 pb-6 border-t border-slate-100 dark:border-slate-700/40 space-y-2">
+            {error && <p className="text-xs text-red-500">{error}</p>}
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                className="flex-1 py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+              >
+                {t('choreForm.cancel')}
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={saving}
+                className="flex-1 py-2.5 rounded-xl text-sm font-medium text-green-400 border border-green-400/40 hover:text-green-300 hover:bg-green-400/10 hover:border-green-400/60 disabled:opacity-50 transition-colors"
+              >
+                {saving ? t('choreForm.saving') : isEdit ? t('choreForm.save') : t('choreForm.add')}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -61,7 +61,7 @@ export function HelpModal({ onClose, onOpenShortcuts }: Props) {
       className="fixed inset-0 z-60 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
+      <div className="w-full sm:max-w-sm max-h-[90svh] bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
         {/* Header */}
         <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-700/40">
           <HelpCircle size={18} className="text-green-400 shrink-0" />
@@ -76,7 +76,7 @@ export function HelpModal({ onClose, onOpenShortcuts }: Props) {
           </button>
         </div>
 
-        <div className="px-6 py-4 space-y-5">
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-5">
           {/* Contact & Issues */}
           <div className="space-y-2.5">
             <p className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider">

--- a/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
+++ b/src/components/IntegrationSettingsModal/IntegrationSettingsModal.tsx
@@ -216,7 +216,7 @@ export function IntegrationSettingsModal({ onClose, onSaved }: Props) {
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90vh]">
+      <div className="w-full sm:max-w-lg bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90svh]">
         {/* Header */}
         <div className="flex items-center gap-3 px-6 pt-6 pb-4 shrink-0">
           <Plug size={18} className="text-green-400 shrink-0" />

--- a/src/components/PassphraseModal/PassphraseModal.tsx
+++ b/src/components/PassphraseModal/PassphraseModal.tsx
@@ -41,8 +41,8 @@ export function PassphraseModal({ onSubmit, onClose }: Props) {
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl border border-slate-200 dark:border-slate-700/50">
-        <div className="flex items-center justify-between mb-5">
+      <div className="w-full sm:max-w-sm max-h-[90svh] flex flex-col bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50">
+        <div className="shrink-0 flex items-center justify-between px-6 pt-6 pb-5">
           <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{t('passphrase.title')}</h2>
           <button
             onClick={onClose}
@@ -52,6 +52,7 @@ export function PassphraseModal({ onSubmit, onClose }: Props) {
           </button>
         </div>
 
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6">
         {cryptoAvailable ? (
           <>
             <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
@@ -92,6 +93,7 @@ export function PassphraseModal({ onSubmit, onClose }: Props) {
             </p>
           </div>
         )}
+        </div>
       </div>
     </div>,
     document.body

--- a/src/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/src/components/ShortcutsModal/ShortcutsModal.tsx
@@ -46,7 +46,7 @@ export function ShortcutsModal({ onClose }: Props) {
       className="fixed inset-0 z-60 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
+      <div className="w-full sm:max-w-sm max-h-[90svh] bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col">
         {/* Header */}
         <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-slate-100 dark:border-slate-700/40">
           <Keyboard size={18} className="text-green-400 shrink-0" />
@@ -61,7 +61,7 @@ export function ShortcutsModal({ onClose }: Props) {
           </button>
         </div>
 
-        <div className="px-6 py-4 space-y-4">
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 py-4 space-y-4">
           {/* Navigation */}
           <div>
             <p className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">

--- a/src/components/SyncSettingsModal/SyncSettingsModal.tsx
+++ b/src/components/SyncSettingsModal/SyncSettingsModal.tsx
@@ -345,7 +345,7 @@ export function SyncSettingsModal({ engine, dbEngine, syncError, syncErrorCode, 
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) handleClose() }}
     >
-      <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90vh]">
+      <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90svh]">
         {/* Header */}
         <div className="flex items-center gap-3 px-6 pt-6 pb-4 shrink-0">
           <Cloud size={18} className="text-green-400 shrink-0" />

--- a/src/components/UsersModal/UsersModal.tsx
+++ b/src/components/UsersModal/UsersModal.tsx
@@ -146,7 +146,7 @@ export function UsersModal({ engine, onUserMutated, onClose }: Props) {
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose() }}
     >
-      <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90vh]">
+      <div className="w-full sm:max-w-md bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50 flex flex-col max-h-[90svh]">
         {/* Header */}
         <div className="flex items-center gap-3 px-6 pt-6 pb-4 border-b border-slate-100 dark:border-slate-700/40 shrink-0">
           <Users size={18} className="text-green-400 shrink-0" />

--- a/src/components/WelcomeModal/WelcomeModal.tsx
+++ b/src/components/WelcomeModal/WelcomeModal.tsx
@@ -25,7 +25,8 @@ export function WelcomeModal({ onGetStarted, onClearSample, clearing }: Props) {
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center app-safe-bottom bg-black/40 dark:bg-black/60 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onGetStarted() }}
     >
-      <div className="w-full sm:max-w-sm bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl border border-slate-200 dark:border-slate-700/50">
+      <div className="w-full sm:max-w-sm max-h-[90svh] flex flex-col bg-white dark:bg-slate-800 rounded-t-2xl sm:rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700/50">
+        <div className="flex-1 min-h-0 overflow-y-auto px-6 pt-6 pb-1">
         <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200 mb-1">
           {t('welcome.title')}
         </h2>
@@ -44,8 +45,9 @@ export function WelcomeModal({ onGetStarted, onClearSample, clearing }: Props) {
             </li>
           ))}
         </ul>
+        </div>
 
-        <div className="flex gap-3">
+        <div className="shrink-0 flex gap-3 px-6 pt-4 pb-6 border-t border-slate-100 dark:border-slate-700/40">
           <button
             onClick={onClearSample}
             disabled={clearing}


### PR DESCRIPTION
Reported on Android: the Edit chore modal could not be scrolled, and with the keyboard open part of it was unreachable. Two independent causes, both fixed here, plus the same latent problem cleared from every other modal.

## Cause 1: no scroll container

Measured in Chromium at 360x640 with the chore form open: panel height 559px, `max-height: none`, **zero scrollable ancestors**, overlay `overflow: visible`. Because the sheet is bottom-anchored on mobile, the overflow runs off the **top**. At 320px of usable height the panel's top sat at **-238**, putting the title, Name, Icon and most of Details above the screen edge with nothing to scroll.

The form is the app's tallest: 683px with a cadence set and Seasonal open, against a 640px phone viewport. The details field added in #273 took it from 422px to 559px, which is what turned a latent problem into a visible one.

## Cause 2: the keyboard does not shrink the page

On `targetSdkVersion = 36` the window no longer resizes for the IME, and the viewport meta asked for `viewport-fit=cover` with no `interactive-widget`, so the default `resizes-visual` applied: the layout viewport stayed full height and every `fixed inset-0` overlay sat at full screen height *behind* the keyboard.

`index.html` now asks for `interactive-widget=resizes-content`, so the keyboard shrinks the layout viewport and `svh` units and fixed overlays follow it down.

## Every other modal, while we are here

Six modals had no height cap at all. One was already failing before any of this:

- **Backup & Restore**: 340px panel against 320px of usable height, top at **-20**, no scroll container. This is a live bug in the current main, not a hypothetical.
- Category form, Help, Shortcuts, Passphrase and Welcome fit today and would have broken the first time anyone added a row.

All of them now follow the shape LogModal already had: capped at `90svh`, a pinned header, a scrolling body, and pinned actions where there are any. Category and Welcome move their buttons into a pinned footer; Help, Shortcuts, Passphrase and Backup scroll their whole body under a pinned header. Validation errors in the two forms moved next to the buttons, so a message cannot appear off-screen in the body after scrolling down to press Save.

The four modals already capped in `vh` move to `svh`, so a cap tracks the browser's own chrome and, with the new viewport meta, the keyboard.

## Verification

- `npm run lint`, `npm test` (354 passing) and `npm run build` are clean.
- All twelve modals opened in Chromium at 360x640 and 360x320: every panel now fits its viewport and carries a scroll region. At 320, Backup & Restore previously did not fit and had nothing to scroll.

**Still needs a device check.** Chromium can prove the scroll containers at a short viewport, but it cannot reproduce an edge-to-edge WebView's keyboard insets, so the `interactive-widget` half wants a sideload before release.

## Release

2.4.0 is bumped on main but not yet published, so this belongs in it rather than a 2.4.1. No version change here. The Backup & Restore fix is user-visible and worth a line in the release notes, since that one has been broken since before 2.4.0.

---
_Generated by [Claude Code](https://claude.ai/code/session_011kEbA5rQPPirCj1XdPuXW2)_