### PR TITLE
Bump @glance-apps/billing to 0.2.2

### DIFF
--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -15,5 +15,10 @@ ext {
     cordovaAndroidVersion = '14.0.1'
     glanceVersion = '1.1.1'
     playBillingVersion = '8.3.0'
+    // Consumed by the @glance-apps/billing module, not by app/build.gradle: it
+    // backs that module's acknowledgement retry worker. Pinned here rather than
+    // left to the module's own 2.9.1 fallback so the version is visible with the
+    // rest of the native pins.
+    workManagerVersion = '2.9.1'
     okhttpVersion = '4.12.0'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/share": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
-        "@glance-apps/billing": "0.2.1",
+        "@glance-apps/billing": "0.2.2",
         "@glance-apps/intents": "1.4.0",
         "@glance-apps/sync": "1.10.0",
         "dayjs": "^1.11.13",
@@ -2757,9 +2757,9 @@
       }
     },
     "node_modules/@glance-apps/billing": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.2.1.tgz",
-      "integrity": "sha512-JL5TC2zc0/VBnFfRWRdVucdB56Y8r4fS3FQu5oboQU/00Z6ljcnvGREvh392oQibsFN1tMoTf4/n60kP6W9Phw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@glance-apps/billing/-/billing-0.2.2.tgz",
+      "integrity": "sha512-sp10Lb5fDD4rRmIfPjxKj9tBlxG855y0UWPMVThWK7+854pT8bEzx5NWHjiWtl9suuraR0XP4/mz3OsOTXBFGA==",
       "license": "MIT",
       "peerDependencies": {
         "electron": ">=28",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/share": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
-    "@glance-apps/billing": "0.2.1",
+    "@glance-apps/billing": "0.2.2",
     "@glance-apps/intents": "1.4.0",
     "@glance-apps/sync": "1.10.0",
     "dayjs": "^1.11.13",


### PR DESCRIPTION
Bumps `@glance-apps/billing` 0.2.1 → 0.2.2 in `package.json` and the lockfile, plus a `workManagerVersion` pin in `android/variables.gradle`.

0.2.2 ports two Android billing fixes into the package's native module, which this app compiles via the `include ':glance-apps-billing'` in `android/settings.gradle`: the `BillingClient` lifecycle fix (owned construction behind a synchronized accessor, no teardown on background, `handleOnDestroy` teardown, `enableAutoServiceReconnection`) and an acknowledgement retry lane on WorkManager.

## The build did not run

**The three build-dependent answers this PR was supposed to carry are missing, and cannot be produced in the environment this was prepared in.** The session's egress policy denies `dl.google.com`, which serves both the Android SDK command-line tools and Google's Maven repo (`dl.google.com/dl/android/maven2`, which `maven.google.com` redirects to). The build fails at root project configuration, before any of this bump's code is reached:

```
> Could not resolve com.android.tools.build:gradle:8.13.0.
   > Could not GET '.../com/android/tools/build/gradle/8.13.0/gradle-8.13.0.pom'.
     Received status code 403 from server: Forbidden
```

There is no Android SDK anywhere on the image, and `sdkmanager` would download from the same blocked host. androidx artifacts are not mirrored to Maven Central (checked: 404 for `androidx/work/work-runtime/2.9.1`), so even reading WorkManager's own manifest out of its AAR is not possible there.

So all three still need a machine with an Android SDK:

- **The package's first Kotlin compile check.** Still outstanding. This bump has not proven the module compiles.
- **The merged manifest diff.** Unverified; the expectation is set out below but nothing here confirms it.
- **The APK size delta.** No before, no after.

What did run, and passed: `npm run build`, `npm run lint` (0 warnings), `npm test` (354 tests in 32 files), and `npx cap sync android`.

## Does anything in lastGLANCE need to change beyond the pin

No app code. Four things were checked:

1. **JS side.** `dist/` is byte identical between 0.2.1 and 0.2.2 (`diff -ru` reports nothing). All three consumers here (`src/billing/billing.ts`, `src/components/PaywallModal/PaywallModal.tsx`, `src/config/reviewerAccess.js`) import only from `dist`. Nothing to update.
2. **Kotlin API.** `PlayBillingCore.disconnect()` was removed and replaced by `destroy()`, and the prefs handling moved to a new `BillingStore`. None of it is reachable from this app: `MainActivity.java` only does `registerPlugin(BillingBridgePlugin.class)`, and there is no other reference to `com.glanceapps.billing` in `android/app/src`.
3. **WorkManager initialization.** The retry lane relies on WorkManager's default `androidx.startup` initialization. This app has no custom `Application` class (the `<application>` tag declares no `android:name`), no `Configuration.Provider`, and does not remove `InitializationProvider`. Default init applies, so no wiring is needed. Release builds keep `minifyEnabled false`, so WorkManager's reflective worker instantiation needs no keep rules either.
4. **`workManagerVersion`.** The one non-pin change in this PR. The module resolves `rootProject.ext.workManagerVersion` when set and falls back to `2.9.1` otherwise; `android/variables.gradle` now pins that same `2.9.1`, so nothing about what resolves changes. It just puts the version where every other native pin already lives instead of leaving it implicit in a transitive module.

## Merged manifest

**Unverified — this is the expectation, not an observation.** No manifest merge ran.

`androidx.work:work-runtime` is expected to contribute `androidx.startup.InitializationProvider` (with the `WorkManagerInitializer` meta-data), `SystemJobService`, `SystemAlarmService`, `RescheduleReceiver` and its companion receivers, plus `WAKE_LOCK` and `RECEIVE_BOOT_COMPLETED`. The billing module's own manifest adds only `com.android.vending.BILLING`, which `android/app/src/main/AndroidManifest.xml` already declares.

One correction to the expected impact, and this part **is** verified from the plugin manifests on disk:

> **`WAKE_LOCK` and `RECEIVE_BOOT_COMPLETED` are not new to this app.** `@capacitor/local-notifications` already declares both in `node_modules/@capacitor/local-notifications/android/src/main/AndroidManifest.xml`, along with `POST_NOTIFICATIONS` and a `BOOT_COMPLETED` receiver. They are already in the merged manifest today. WorkManager's copies merge into existing entries, so **the Play listing permission set does not change with this bump** and no release note about permissions is needed.

The `app/src/main/AndroidManifest.xml` comment about the notifications plugin already declaring `POST_NOTIFICATIONS` and `RECEIVE_BOOT_COMPLETED` says as much. The new merged-manifest surface is therefore the components only, not the permissions.

## One thing worth flagging upstream

The 0.2.2 KDoc justifies both `handleOnDestroy` and the application-context handling with this claim, repeated in three places:

> neither consuming app declares `android:configChanges`, so rotation, a dark-mode toggle, a locale or font-size change and multi-window resizing all destroy the activity

That is not true of lastGLANCE. `MainActivity` declares the standard Capacitor set:

```
android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|
                       smallestScreenSize|screenLayout|uiMode|navigation|density"
```

Rotation, locale change, dark-mode toggle (`uiMode`), density change and multi-window resize are all handled without recreating the activity here. `fontScale` and `layoutDirection` are not in the list, so a font-size change still recreates, and a genuine finish still does.

This does not change the fix or make it wrong: teardown belongs in `handleOnDestroy` regardless, and the leak-per-recreation it prevents is real, just far rarer in this app than the comment asserts. Nothing to do in this repo; it rides along with a 0.2.3 whenever something real triggers one.

Separately, and unresolvable without a build: the module's `build.gradle` carries its own `buildscript` block pinning AGP 8.7.2 and Kotlin 2.2.20, while this project's root pins AGP 8.13.0 and Kotlin 2.2.0. Standard Capacitor plugins ship the same shape and normally resolve through Gradle's parent-first classloading, but it is the sort of thing the first real compile settles.