### PR TITLE
Release 2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release. The functional change already landed in #277 (`@glance-apps/billing` 0.2.1 to 0.2.2); this bumps the app version so it can go out.

## Version

- versionName: 2.4.0 to 2.4.1
- versionCode: 2040000 to 2040100 (derived, and clear of the 2040001-2040099 pre-release band)

Patch rather than minor: everything in this release is a bug fix, with no new user-facing functionality. The new transitive WorkManager dependency is not a feature.

## What ships

Two Play Billing defects that were live in shipped lastGLANCE, both fixed inside the package's native module:

- **BillingClient lifecycle.** The client was torn down on every background, and a BillingClient cannot be reused after `endConnection()`. After the first background/foreground cycle every billing operation in the process silently no-opped: restores reported success from a stale cache, purchases failed as not-ready, and entitlement refresh stopped running.
- **Acknowledgement retry.** A failed acknowledgement was fire and forget. Play auto-refunds any purchase not acknowledged within three days, so a user whose ack failed and who did not reopen the app inside 72 hours was silently refunded and lost access they paid for. Failures are now persisted and retried on WorkManager until they succeed, prove terminal, or age past the window.

Verified on device: compiles, installs, and the fix confirmed through logcat.

## Dependency pins

All three `@glance-apps` packages are exact pins (no ranges) and match the latest published versions:

| package | package.json | lockfile | npm latest |
|---|---|---|---|
| `@glance-apps/intents` | 1.4.0 | 1.4.0 | 1.4.0 |
| `@glance-apps/sync` | 1.10.0 | 1.10.0 | 1.10.0 |
| `@glance-apps/billing` | 0.2.2 | 0.2.2 | 0.2.2 |

## Notes

- iOS `MARKETING_VERSION` is still 2.4.0. It syncs on `npm run build:ios` (or `npm run sync:ios-version`) and was deliberately left alone here, since this is an Android release and the `.pbxproj` is tracked.
- Two report items from the 0.2.2 bump were consciously skipped: the merged manifest permission diff and the APK size delta. The merged manifest was inspected and carries nine permissions; whether `ACCESS_NETWORK_STATE` and `FOREGROUND_SERVICE` are new with WorkManager or were already present was not settled, since that needs a pre-bump build to compare against. Both are normal-level with no runtime prompt, and nothing in this app starts a foreground service.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1fqNydtYvUVfVzPGKD52m)_