### PR TITLE
iOS: XL heatmap, build-number tooling, Phase 1 overdue notifications

### DIFF
--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -276,10 +276,16 @@ out of scope; reconcile on next foreground).
   iOS.
 - `scripts/gen-lucide-drawables.mjs` — add a Swift-path-data mode for iOS icons
   (or a sibling script).
-- `scripts/sync-ios-version.mjs` — its `MARKETING_VERSION` regex is global, so it
-  already covers the extension targets. `CURRENT_PROJECT_VERSION` is **not** synced
-  and both are hardcoded to 1; App Store upload rejects an app and extension whose
-  build numbers differ, so whoever bumps one must bump all of them.
+- `scripts/sync-ios-version.mjs` — handles both version numbers, for different
+  reasons. `MARKETING_VERSION` always tracks package.json across every target.
+  `CURRENT_PROJECT_VERSION` (the build number) has to increment per **upload**,
+  not per version, so it cannot be derived from package.json and is set
+  explicitly: `IOS_BUILD=<n> npm run build:ios`. With `IOS_BUILD` unset the build
+  number is left alone but every target is checked for agreement, and the script
+  **fails the build** if they disagree — an app and its extensions must ship the
+  same `CFBundleVersion` or App Store Connect rejects the upload, and Xcode's
+  General tab edits only the selected target, so bumping by hand moves App and
+  silently leaves GlanceWidgets behind.
 
 **To stay iOS-friendly going forward:** keep decision logic in JS behind the
 plugin boundary; route every new entry point through the shared `lastglance://`

--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -172,11 +172,14 @@ carry over.
   an `AppIntent` that writes `{ choreSyncId, syncId, completedAt }` to the
   App-Group completion queue and optimistically mutates the snapshot entry. JS
   drains on next foreground through the **existing** `pendingCompletions` path.
-  Decide the minimum iOS version; pre-17 devices fall back to tap-to-open.
-- **Chore icons**: the Lucide *Android vector drawables* do not port. Rasterize
-  the Lucide SVGs to PNGs into the App Group (adapt
-  `scripts/gen-lucide-drawables.mjs` to emit PNG assets), tinted to the recency
-  color. Decide this up front; it blocks icon parity.
+  The deployment target is settled (see section 4): the extension is 17.0, so
+  there is **no pre-17 fallback path to build**.
+- **Chore icons**: the Lucide *Android vector drawables* do not port. Settled
+  approach is a generated Swift file of Lucide path data plus a small
+  SVG-path-to-`SwiftUI.Path` parser — see section 4 for why rasterising to
+  App-Group PNGs was rejected. **This blocks the list and single-chore widgets**,
+  which are icon-bearing; the heatmap needed no icons, which is why it shipped
+  first.
 - Style to read as the same family as the in-app `ChoreRow` (recency color bar +
   elapsed text), matching the Android "clearly same family" posture.
 
@@ -204,8 +207,14 @@ sync round-trip.
   consumed on foreground by the existing `consumeSharedChore` to open the
   new-chore form pre-filled. This is the direct analog of the Android share
   target and reuses the same web prefill.
+- **Add-chore widget**: Android ships `glance/AddChoreWidget.kt`, a static
+  one-tap surface with no snapshot dependency. Earlier drafts of this plan had no
+  iOS counterpart — an oversight, not a decision. On iOS it is a `systemSmall`
+  widget whose only job is a `widgetURL` of `action:add`, so it belongs here with
+  the other entry points rather than in Phase 2 with the data-bearing widgets.
 - **Stretch:** Lock Screen / Control Center widgets (WidgetKit accessory families)
-  are the closest analog to the Android Quick Settings tiles; optional.
+  are the closest analog to the Android Quick Settings tiles (`tiles/QsTiles.kt`,
+  add-chore and soon); optional.
 
 There is **no iOS analog planned for background CRDT sync** (same as Android:
 out of scope; reconcile on next foreground).

--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -158,6 +158,16 @@ carry over.
   soon/overdue **list** widget, and a configurable **single-chore** widget.
   A `TimelineProvider` supplies entries; use SwiftUI relative-date text so
   "Xd ago" stays honest between snapshot pushes without a background runtime.
+- **Heatmap families (decided 2026-08, verified on device):** `systemMedium` is
+  26 weeks, bare grid; `systemExtraLarge` is 52 weeks with month/weekday labels
+  and a Less→More legend. **`systemLarge` is deliberately unsupported.** A 52x7
+  grid of square cells is ~7.4:1, so in a square family it renders as a band with
+  two thirds of the height empty and nothing worth putting there; extra-large is
+  ~2:1 and carries it. Cell size works out at ~10.9pt on extra-large versus
+  ~10.1pt for medium's 26 weeks, so the full year is *more* legible, not less.
+  Note extra-large is **iPad-only** — WidgetKit has never offered it on iPhone,
+  so iPhone gets medium alone. Android stays at 26 weeks; the split is accepted
+  (its heatmap has no extra-large analogue to diverge from).
 - **Interactive tap-to-complete via AppIntents (iOS 17+)**: the Done button runs
   an `AppIntent` that writes `{ choreSyncId, syncId, completedAt }` to the
   App-Group completion queue and optimistically mutates the snapshot entry. JS

--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -135,12 +135,30 @@ persisted App-Group snapshot).
 win. The Android plan estimates it ~70-80% portable.
 
 - Relax the Android-only guards in `useReminders.ts` / `reminders.ts` /
-  `useNotifications.ts` to include iOS.
+  `useNotifications.ts` to include iOS. **Done 2026-08** (untested on device).
+  The scheduling model is shared; four things are platform-conditional, all of
+  them inside `reminders.ts`:
+  - `ensureChannel` — Android-only; channels have no iOS equivalent.
+  - `maybePromptExactAlarm` — Android-only; iOS has no exact-alarm permission.
+  - the per-build force-reschedule — Android-only. The hazard is aapt2
+    reassigning drawable resource IDs between builds; iOS notifications carry no
+    resource ID, so forcing it there would churn every pending notification on
+    each build to fix a problem it cannot have.
+  - the 64-notification cap — iOS-only; see below.
+  One thing the plan expected to be a fork turned out not to be: `handleNotificationAction`
+  already notes that the plugin opens the app for **every** action on both
+  platforms, so "Mark done" was never going to run headless anywhere.
 - Handle **iOS specifics**: no exact-alarm permission prompt (drop that branch on
   iOS); the app icon is used instead of a monochrome `smallIcon`; the **64
-  pending-notification cap** (our single-shot-per-chore model stays well under it,
-  but cap defensively); actions declared as `UNNotificationCategory` (the plugin
-  abstracts this) with the same "Mark done" / "Send to dayGLANCE" verbs.
+  pending-notification cap**; actions declared as `UNNotificationCategory` (the
+  plugin abstracts this) with the same "Mark done" / "Send to dayGLANCE" verbs.
+- On the cap: implemented as `soonest(all, 56)`, not 64. The limit is **per app,
+  not per feature**, so scheduling right up to it would make some future
+  notification of another kind the one iOS silently discards. When the cap bites,
+  the reminders kept are the nearest-firing — everything dropped is further out
+  than everything kept, and each later sync (foreground, completion, sync-apply)
+  pulls the next tranche in as the near ones fire. No `smallIcon` handling was
+  needed: it is set in `capacitor.config.ts` and simply ignored on iOS.
 - Delivery timing note: iOS has no `setExactAndAllowWhileIdle` equivalent; the
   system may batch delivery. This fits the "information, not guilt" single-shot
   model, but timing is inherently less precise than Android exact alarms. Accept

--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -221,6 +221,18 @@ out of scope; reconcile on next foreground).
   there is no arbitrary background execution. The snapshot-read model fits, but
   freshness of relative time ("Xd ago") relies on TimelineProvider entries and/or
   SwiftUI relative-date formatting rather than polling.
+- **⚠ Reboot the device before believing a widget bug (learned the hard way,
+  2026-08).** WidgetKit caches extension state aggressively and a stale cache
+  survives reinstalls, including fresh TestFlight installs. The symptom that cost
+  most of a day: the widget rendered perfectly in the gallery, with live data, and
+  rendered *nothing at all* once placed on the home screen — not even static text.
+  It was not a crash (no `.ips`), not a memory kill (the extension peaked at 3 MB
+  against a ~30 MB budget and was never jetsammed), and not a code fault. **A
+  reboot fixed it.** Suspect the cache first whenever the gallery and the placed
+  widget disagree, especially right after changing `supportedFamilies`, the widget
+  `kind`, or the set of widgets in the bundle — changes to a widget's *identity*
+  are exactly what the cache gets wrong. Diagnose from the device before changing
+  code: a gallery/placed split is a WidgetKit state problem until proven otherwise.
 - **AppIntents interactivity is iOS 17+.** Decided 2026-07: the **app target stays
   at iOS 15.0** and the **widget extension targets 17.0**. An extension may set a
   higher floor than its host, so no existing app user is dropped and there is only

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -449,7 +449,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 2.4.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -473,7 +473,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
@@ -499,7 +499,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance.GlanceWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -528,7 +528,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.12.0;
+				MARKETING_VERSION = 2.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.lastglance.GlanceWidgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,7 +11,11 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.0"),
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.5.0"),
+        .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
+        .package(name: "CapacitorLocalNotifications", path: "../../../node_modules/@capacitor/local-notifications"),
+        .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
         .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar")
     ],
     targets: [
@@ -20,6 +24,10 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorApp", package: "CapacitorApp"),
+                .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
+                .product(name: "CapacitorLocalNotifications", package: "CapacitorLocalNotifications"),
+                .product(name: "CapacitorShare", package: "CapacitorShare"),
                 .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar")
             ]
         )

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -135,6 +135,20 @@ private struct HeatmapStats {
 struct HeatmapEntry: TimelineEntry {
     let date: Date
     let snapshot: WidgetSnapshot
+    // Non-nil when there is nothing to draw and we know why. Rendered in place
+    // of the grid so the failure names itself instead of looking like a widget
+    // that never finished loading.
+    let problem: String?
+
+    init(date: Date, snapshot: WidgetSnapshot, problem: String? = nil) {
+        self.date = date
+        self.snapshot = snapshot
+        self.problem = problem
+    }
+
+    init(date: Date, load: SnapshotLoad) {
+        self.init(date: date, snapshot: load.snapshot, problem: load.problem)
+    }
 }
 
 struct HeatmapProvider: TimelineProvider {
@@ -144,11 +158,11 @@ struct HeatmapProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (HeatmapEntry) -> Void) {
-        completion(HeatmapEntry(date: Date(), snapshot: WidgetSnapshot.load()))
+        completion(HeatmapEntry(date: Date(), load: SnapshotLoad.read()))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<HeatmapEntry>) -> Void) {
-        let entry = HeatmapEntry(date: Date(), snapshot: WidgetSnapshot.load())
+        let entry = HeatmapEntry(date: Date(), load: SnapshotLoad.read())
         // WidgetKit is not a live process, so the only two things that can change
         // what this widget should show are (a) the app pushing a new snapshot,
         // which calls reloadAllTimelines directly, and (b) the date rolling over,
@@ -379,7 +393,9 @@ struct HeatmapWidgetView: View {
 
     var body: some View {
         Group {
-            if family == .systemExtraLarge {
+            if let problem = entry.problem {
+                diagnostic(problem)
+            } else if family == .systemExtraLarge {
                 extraLarge
             } else {
                 medium
@@ -388,6 +404,22 @@ struct HeatmapWidgetView: View {
         .containerBackground(for: .widget) {
             Color(uiColor: .systemBackground)
         }
+    }
+
+    // Shown instead of an all-empty grid when the snapshot could not be read.
+    // An empty grid is a legitimate render (a user with no completions yet), so
+    // it must not double as the error state.
+    private func diagnostic(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Spacer(minLength: 0)
+            Wordmark(size: family == .systemExtraLarge ? 26 : 20)
+            Text(message)
+                .font(.system(size: family == .systemExtraLarge ? 15 : 13))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // Unchanged from the original single-size widget. The half-year grid at this

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -162,18 +162,31 @@ struct HeatmapProvider: TimelineProvider {
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<HeatmapEntry>) -> Void) {
-        let entry = HeatmapEntry(date: Date(), load: SnapshotLoad.read())
+        let now = Date()
+        let entry = HeatmapEntry(date: now, load: SnapshotLoad.read())
+
         // WidgetKit is not a live process, so the only two things that can change
         // what this widget should show are (a) the app pushing a new snapshot,
         // which calls reloadAllTimelines directly, and (b) the date rolling over,
         // which shifts the whole grid by one column. Only (b) needs a scheduled
         // refresh, so ask for exactly one, at the next local midnight.
-        let midnight = Calendar.current.nextDate(
-            after: Date(),
-            matching: DateComponents(hour: 0, minute: 0, second: 0),
-            matchingPolicy: .nextTime
-        ) ?? Date().addingTimeInterval(3600)
-        completion(Timeline(entries: [entry], policy: .after(midnight)))
+        //
+        // Computed by adding a day to the start of today, NOT by
+        // Calendar.nextDate(after:matching:matchingPolicy:). That API searches
+        // for a matching date rather than calculating one, and anything that
+        // stalls in here means completion() is never called — WidgetKit then has
+        // no timeline to render and the widget stays completely blank, with no
+        // crash and nothing in the log to explain it. The gallery kept working
+        // throughout because getSnapshot never took this path. Direct arithmetic
+        // has no search to go wrong.
+        let calendar = Calendar.current
+        var refresh = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
+            ?? now.addingTimeInterval(3600)
+        // A refresh date must be in the future or WidgetKit has nothing to
+        // schedule; belt-and-braces against a DST edge or a nil from the calendar.
+        if refresh <= now { refresh = now.addingTimeInterval(3600) }
+
+        completion(Timeline(entries: [entry], policy: .after(refresh)))
     }
 }
 

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -171,14 +171,15 @@ struct HeatmapProvider: TimelineProvider {
         // which shifts the whole grid by one column. Only (b) needs a scheduled
         // refresh, so ask for exactly one, at the next local midnight.
         //
-        // Computed by adding a day to the start of today, NOT by
-        // Calendar.nextDate(after:matching:matchingPolicy:). That API searches
-        // for a matching date rather than calculating one, and anything that
-        // stalls in here means completion() is never called — WidgetKit then has
-        // no timeline to render and the widget stays completely blank, with no
-        // crash and nothing in the log to explain it. The gallery kept working
-        // throughout because getSnapshot never took this path. Direct arithmetic
-        // has no search to go wrong.
+        // Computed by adding a day to the start of today, rather than with
+        // Calendar.nextDate(after:matching:matchingPolicy:), which is what this
+        // used to call. Direct arithmetic over a search API is the smaller,
+        // clearer thing to do here and that is the whole reason it stays.
+        //
+        // It is NOT a bug fix, despite what the commit that introduced it said:
+        // the widget was blank because of a stale WidgetKit extension cache, and
+        // a device reboot fixed it. nextDate had been in this method since the
+        // widget was written and had worked fine throughout.
         let calendar = Calendar.current
         var refresh = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
             ?? now.addingTimeInterval(3600)

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -5,22 +5,35 @@ import WidgetKit
 // of glance/HeatmapWidget.kt. Renders purely from the App-Group snapshot the web
 // app pushes; it never touches the database.
 //
-// Geometry, colour scale and bucket thresholds are copied from the Android widget
-// on purpose: the two platforms should read as the same product, and the buckets
-// are part of how the data is understood, not a styling choice.
+// Colour scale and bucket thresholds are copied from the Android widget on
+// purpose: the two platforms should read as the same product, and the buckets are
+// part of how the data is understood, not a styling choice.
+//
+// Two sizes, two jobs:
+//   - systemMedium    26 weeks, bare grid. The half-year "am I keeping up" view.
+//   - systemExtraLarge 52 weeks, with month/weekday labels and a legend. The
+//                     full-year review. iPad only — WidgetKit has never offered
+//                     an extra-large family on iPhone.
+//
+// systemLarge is deliberately absent. A 52x7 grid of square cells is ~7.4:1, so
+// in a square widget it renders as a band with two thirds of the height empty,
+// with nothing worth putting there. Extra-large is ~2:1 and carries it.
 
-private let weeks = 26
 private let daysPerWeek = 7
 
-// Cell 11pt on a 3pt gap, as on Android. Expressed as ratios so the grid can be
-// scaled to whatever width the widget family gives us instead of being pinned to
-// Android's density-derived pixel sizes.
+private let mediumWeeks = 26
+private let extraLargeWeeks = 52
+
+// Cell 11pt on a 3pt gap, as on Android. Expressed as ratios so the grid scales
+// to whatever width the family gives us instead of being pinned to Android's
+// density-derived pixel sizes. One "unit" is cell + gap.
 private let cellRatio = 11.0 / 14.0
 private let gapRatio = 3.0 / 14.0
 
-// Width and height in "units" (one unit = cell + gap), minus the trailing gap.
-private let gridAspect =
-    (Double(weeks) - gapRatio) / (Double(daysPerWeek) - gapRatio)
+// Label gutters, also in units, so they scale with the cells. The left gutter
+// holds "Mon"/"Wed"/"Fri"; the top strip holds month abbreviations.
+private let weekdayGutterUnits = 2.4
+private let monthStripUnits = 1.3
 
 private let brandGreen = Color(red: 0x3D / 255, green: 0xDC / 255, blue: 0x84 / 255)
 
@@ -31,6 +44,22 @@ private func hex(_ value: UInt32) -> Color {
         blue: Double(value & 0xFF) / 255
     )
 }
+
+// File scope so the grid and the legend cannot drift apart. `dark` only affects
+// the empty cell, exactly as the Android widget's UI_MODE_NIGHT branch does; the
+// filled scale is identical in both appearances.
+private func heatColor(_ count: Int, dark: Bool) -> Color {
+    switch count {
+    case ..<1: return dark ? hex(0x2D333B) : hex(0xEBEDF0)
+    case 1: return hex(0x9BE9A8)
+    case 2...3: return hex(0x40C463)
+    case 4...5: return hex(0x30A14E)
+    default: return hex(0x216E39)
+    }
+}
+
+// The five swatches the legend shows, low to high. Index 0 is the empty cell.
+private let legendCounts = [0, 1, 2, 4, 6]
 
 // MARK: - Timeline
 
@@ -68,15 +97,27 @@ struct HeatmapProvider: TimelineProvider {
 // MARK: - Grid
 
 private struct HeatmapGrid: View {
+    let weeks: Int
     let heatmap: [String: Int]
+    let showsLabels: Bool
 
     // The keys are local dates formatted by dayjs in the WebView, so the reader
     // must use the same calendar and time zone. en_US_POSIX keeps the format
     // fixed regardless of the user's locale settings.
-    private static let formatter: DateFormatter = {
+    private static let keyFormatter: DateFormatter = {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    // Month abbreviations follow the user's locale — unlike the data keys, these
+    // are read by a human. The same formatter is the source of the weekday
+    // symbols: DateFormatter.shortWeekdaySymbols is always Sunday-first, which is
+    // the row order this grid walks in.
+    private static let monthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("MMM")
         return f
     }()
 
@@ -91,60 +132,139 @@ private struct HeatmapGrid: View {
         return calendar.date(byAdding: .day, value: -(weeks - 1) * 7, to: thisSunday) ?? thisSunday
     }
 
-    private func color(for count: Int, dark: Bool) -> Color {
-        switch count {
-        case ..<1: return dark ? hex(0x2D333B) : hex(0xEBEDF0)
-        case 1: return hex(0x9BE9A8)
-        case 2...3: return hex(0x40C463)
-        case 4...5: return hex(0x30A14E)
-        default: return hex(0x216E39)
-        }
+    // Width and height in units, including the label gutters when shown, so the
+    // whole labelled block scales as one piece inside aspectRatio(_:contentMode:).
+    private var aspect: Double {
+        let across = (showsLabels ? weekdayGutterUnits : 0) + Double(weeks) - gapRatio
+        let down = (showsLabels ? monthStripUnits : 0) + Double(daysPerWeek) - gapRatio
+        return across / down
     }
 
     var body: some View {
-        // colorScheme drives the empty-cell colour the same way the Android widget
-        // reads UI_MODE_NIGHT: the filled scale is identical in both appearances,
-        // only the "nothing here" cell changes.
-        HeatmapCanvas(heatmap: heatmap, startDate: startDate, formatter: Self.formatter, color: color)
-            .aspectRatio(gridAspect, contentMode: .fit)
+        HeatmapCanvas(
+            weeks: weeks,
+            heatmap: heatmap,
+            showsLabels: showsLabels,
+            startDate: startDate,
+            keyFormatter: Self.keyFormatter,
+            monthFormatter: Self.monthFormatter
+        )
+        .aspectRatio(aspect, contentMode: .fit)
     }
 }
 
 private struct HeatmapCanvas: View {
+    let weeks: Int
     let heatmap: [String: Int]
+    let showsLabels: Bool
     let startDate: Date
-    let formatter: DateFormatter
-    let color: (Int, Bool) -> Color
+    let keyFormatter: DateFormatter
+    let monthFormatter: DateFormatter
 
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         Canvas { context, size in
             let dark = colorScheme == .dark
-            // Solve size.width = weeks*unit - gap for unit, where gap = unit*gapRatio.
-            let unit = size.width / (Double(weeks) - gapRatio)
+            let calendar = Calendar.current
+
+            // Solve size.width = gutter + weeks*unit - gap for unit, where both
+            // the gutter and the gap are themselves expressed in units.
+            let across = (showsLabels ? weekdayGutterUnits : 0) + Double(weeks) - gapRatio
+            let unit = size.width / across
             let cell = unit * cellRatio
             let gap = unit * gapRatio
             let radius = cell * 0.22
-            let calendar = Calendar.current
+            let originX = showsLabels ? weekdayGutterUnits * unit : 0
+            let originY = showsLabels ? monthStripUnits * unit : 0
 
+            // Cells. Walk day by day in column-major order, which is also the
+            // order the dates advance, so one cursor covers the whole grid.
             var day = startDate
             for col in 0..<weeks {
                 for row in 0..<daysPerWeek {
-                    let count = heatmap[formatter.string(from: day)] ?? 0
+                    let count = heatmap[keyFormatter.string(from: day)] ?? 0
                     let rect = CGRect(
-                        x: Double(col) * (cell + gap),
-                        y: Double(row) * (cell + gap),
+                        x: originX + Double(col) * (cell + gap),
+                        y: originY + Double(row) * (cell + gap),
                         width: cell,
                         height: cell
                     )
                     context.fill(
                         Path(roundedRect: rect, cornerRadius: radius),
-                        with: .color(color(count, dark))
+                        with: .color(heatColor(count, dark: dark))
                     )
                     day = calendar.date(byAdding: .day, value: 1, to: day) ?? day
                 }
             }
+
+            guard showsLabels else { return }
+            let labelFont = Font.system(size: unit * 0.78)
+
+            // Month labels: drawn at the first column of each new month, the way
+            // GitHub does it, plus the leftmost column so the oldest (partial)
+            // month is not left anonymous. Two guards keep them readable — never
+            // within three columns of the previous label, and never so close to
+            // the right edge that the text would overhang the grid.
+            var lastMonth = -1
+            var lastLabelCol = -99
+            for col in 0..<weeks {
+                guard let columnStart = calendar.date(byAdding: .day, value: col * 7, to: startDate)
+                else { continue }
+                let month = calendar.component(.month, from: columnStart)
+                defer { lastMonth = month }
+                guard month != lastMonth else { continue }
+                guard col - lastLabelCol >= 3, col <= weeks - 3 else { continue }
+                lastLabelCol = col
+                context.draw(
+                    Text(monthFormatter.string(from: columnStart))
+                        .font(labelFont)
+                        .foregroundStyle(.secondary),
+                    at: CGPoint(x: originX + Double(col) * (cell + gap), y: originY - gap),
+                    anchor: .bottomLeading
+                )
+            }
+
+            // Weekday labels on the alternating rows GitHub labels, right-aligned
+            // into the gutter so they sit just off the first column. Row 0 is
+            // Sunday (the grid starts on one) and shortWeekdaySymbols is
+            // Sunday-first, so the row index indexes the array directly.
+            let weekdayNames = monthFormatter.shortWeekdaySymbols ?? []
+            for row in [1, 3, 5] where row < weekdayNames.count {
+                let name = weekdayNames[row]
+                context.draw(
+                    Text(name)
+                        .font(labelFont)
+                        .foregroundStyle(.secondary),
+                    at: CGPoint(
+                        x: originX - gap * 2,
+                        y: originY + Double(row) * (cell + gap) + cell / 2
+                    ),
+                    anchor: .trailing
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Legend
+
+private struct HeatmapLegend: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text("Less")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            ForEach(legendCounts, id: \.self) { count in
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(heatColor(count, dark: colorScheme == .dark))
+                    .frame(width: 10, height: 10)
+            }
+            Text("More")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
         }
     }
 }
@@ -160,42 +280,91 @@ private func statText(overdue: Int, soon: Int) -> String {
     }
 }
 
+private struct Wordmark: View {
+    let size: Double
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text("last")
+                .font(.system(size: size, weight: .bold))
+                .foregroundStyle(.primary)
+            Text("GLANCE")
+                .font(.system(size: size, weight: .bold))
+                .italic()
+                .foregroundStyle(brandGreen)
+        }
+    }
+}
+
 struct HeatmapWidgetView: View {
     var entry: HeatmapEntry
 
     @Environment(\.widgetFamily) private var family
 
-    // Android drops the stat below ~340dp so the wordmark cannot clip. The
-    // WidgetKit equivalent is the family: systemSmall is far too narrow for a
-    // 26-week grid plus a stat, so it keeps the wordmark alone.
-    private var showStat: Bool { family != .systemSmall }
+    private var stat: String {
+        statText(overdue: entry.snapshot.counts.overdue, soon: entry.snapshot.counts.soon)
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HeatmapGrid(heatmap: entry.snapshot.heatmap)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-            HStack(spacing: 0) {
-                Text("last")
-                    .font(.system(size: 20, weight: .bold))
-                    .foregroundStyle(.primary)
-                Text("GLANCE")
-                    .font(.system(size: 20, weight: .bold))
-                    .italic()
-                    .foregroundStyle(brandGreen)
-                if showStat {
-                    Spacer(minLength: 8)
-                    Text(statText(overdue: entry.snapshot.counts.overdue,
-                                  soon: entry.snapshot.counts.soon))
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.8)
-                }
+        Group {
+            if family == .systemExtraLarge {
+                extraLarge
+            } else {
+                medium
             }
         }
         .containerBackground(for: .widget) {
             Color(uiColor: .systemBackground)
+        }
+    }
+
+    // Unchanged from the original single-size widget. The half-year grid at this
+    // width lands around 10pt cells and fills the family comfortably, so it gets
+    // no labels and no legend — the furniture would cost more than it explains.
+    private var medium: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HeatmapGrid(weeks: mediumWeeks, heatmap: entry.snapshot.heatmap, showsLabels: false)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            HStack(spacing: 0) {
+                Wordmark(size: 20)
+                Spacer(minLength: 8)
+                Text(stat)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+        }
+    }
+
+    // A 52-week band cannot fill this family's height on its own, so the grid is
+    // centred in the space above a pinned footer rather than stretched. The
+    // labels and legend are the same furniture GitHub uses, which is what makes
+    // the remaining whitespace read as composition instead of a gap.
+    private var extraLarge: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Spacer(minLength: 0)
+
+            HeatmapGrid(weeks: extraLargeWeeks, heatmap: entry.snapshot.heatmap, showsLabels: true)
+                .frame(maxWidth: .infinity)
+
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                HeatmapLegend()
+            }
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 0) {
+                Wordmark(size: 26)
+                Spacer(minLength: 12)
+                Text(stat)
+                    .font(.system(size: 16))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
         }
     }
 }
@@ -213,6 +382,6 @@ struct HeatmapWidget: Widget {
         // Phase 3, so a body tap falls back to WidgetKit's default of opening the
         // app. Phase 3 adds the URL and the "open Soon" routing the Android
         // widget has.
-        .supportedFamilies([.systemMedium, .systemLarge])
+        .supportedFamilies([.systemMedium, .systemExtraLarge])
     }
 }

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -278,10 +278,15 @@ private struct HeatmapCanvas: View {
             let labelFont = Font.system(size: unit * 0.78)
 
             // Month labels: drawn at the first column of each new month, the way
-            // GitHub does it, plus the leftmost column so the oldest (partial)
-            // month is not left anonymous. Two guards keep them readable — never
-            // within three columns of the previous label, and never so close to
-            // the right edge that the text would overhang the grid.
+            // GitHub does it. Two guards keep them readable — never within three
+            // columns of the previous label, and never so close to the right edge
+            // that the text would overhang the grid.
+            //
+            // Column 0 is deliberately skipped (lastMonth starts unset). It is a
+            // partial month, and labelling it costs a real one: the label at
+            // column 0 would claim the minimum-gap budget and suppress the true
+            // first month boundary a column or two later, which is exactly how
+            // September went missing on a 52-week grid.
             var lastMonth = -1
             var lastLabelCol = -99
             for col in 0..<weeks {
@@ -289,7 +294,7 @@ private struct HeatmapCanvas: View {
                 else { continue }
                 let month = calendar.component(.month, from: columnStart)
                 defer { lastMonth = month }
-                guard month != lastMonth else { continue }
+                guard month != lastMonth, lastMonth != -1 else { continue }
                 guard col - lastLabelCol >= 3, col <= weeks - 3 else { continue }
                 lastLabelCol = col
                 context.draw(
@@ -480,17 +485,25 @@ struct HeatmapWidgetView: View {
 
             // Figures describe exactly the window drawn above, not all of
             // history, so nothing here can contradict the cells on screen.
-            HStack(alignment: .top, spacing: 28) {
+            //
+            // Spread edge to edge rather than bunched at the leading edge with a
+            // trailing Spacer: the grid above spans the full width, and a stats
+            // row occupying only the left third against that made the whole
+            // composition read as unfinished. Spacers *between* the tiles and
+            // none after the last one pins the outer two to the same margins the
+            // grid uses.
+            HStack(alignment: .top, spacing: 0) {
                 StatTile(
                     value: "\(stats.completions)",
                     label: plural(stats.completions, "completion", "completions")
                 )
+                Spacer(minLength: 16)
                 StatTile(
                     value: "\(stats.activeDays)",
                     label: plural(stats.activeDays, "active day", "active days")
                 )
+                Spacer(minLength: 16)
                 StatTile(value: "\(stats.streak)", label: "day streak")
-                Spacer(minLength: 0)
             }
 
             Spacer(minLength: 0)

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -61,6 +61,75 @@ private func heatColor(_ count: Int, dark: Bool) -> Color {
 // The five swatches the legend shows, low to high. Index 0 is the empty cell.
 private let legendCounts = [0, 1, 2, 4, 6]
 
+// The snapshot's heatmap keys are local dates formatted by dayjs in the WebView,
+// so every reader here must use the same calendar and time zone. en_US_POSIX
+// keeps the format fixed regardless of the user's locale settings. Shared by the
+// grid and the stats so the two can never key the map differently.
+private let heatmapKeyFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd"
+    return f
+}()
+
+// Oldest visible day: back to this week's Sunday, then back to the first visible
+// week. Matches the Android walk exactly so both grids show the same window and
+// the same week alignment. File scope because the stats read the same window the
+// grid draws — a total that disagreed with the cells on screen would be worse
+// than no total at all.
+private func gridStartDate(weeks: Int) -> Date {
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: Date())
+    let weekday = calendar.component(.weekday, from: today) // 1 = Sunday
+    let thisSunday = calendar.date(byAdding: .day, value: -(weekday - 1), to: today) ?? today
+    return calendar.date(byAdding: .day, value: -(weeks - 1) * 7, to: thisSunday) ?? thisSunday
+}
+
+// Summary of the drawn window, for the extra-large stats row. Cheap: the heatmap
+// is a few hundred entries at most.
+private struct HeatmapStats {
+    let completions: Int
+    let activeDays: Int
+    let streak: Int
+
+    init(heatmap: [String: Int], weeks: Int) {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let start = gridStartDate(weeks: weeks)
+
+        var total = 0
+        var active = 0
+        var day = start
+        while day <= today {
+            let count = heatmap[heatmapKeyFormatter.string(from: day)] ?? 0
+            if count > 0 {
+                total += count
+                active += 1
+            }
+            guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+            day = next
+        }
+        completions = total
+        activeDays = active
+
+        // Streak counts consecutive days with at least one completion, ending
+        // today. If today is still empty the streak is measured to yesterday
+        // instead — at 9am you have not broken a streak, you just have not logged
+        // anything yet, and zeroing it then would be a lie the user would resent.
+        var cursor = today
+        if (heatmap[heatmapKeyFormatter.string(from: today)] ?? 0) == 0 {
+            cursor = calendar.date(byAdding: .day, value: -1, to: today) ?? today
+        }
+        var run = 0
+        while cursor >= start, (heatmap[heatmapKeyFormatter.string(from: cursor)] ?? 0) > 0 {
+            run += 1
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: cursor) else { break }
+            cursor = prev
+        }
+        streak = run
+    }
+}
+
 // MARK: - Timeline
 
 struct HeatmapEntry: TimelineEntry {
@@ -101,16 +170,6 @@ private struct HeatmapGrid: View {
     let heatmap: [String: Int]
     let showsLabels: Bool
 
-    // The keys are local dates formatted by dayjs in the WebView, so the reader
-    // must use the same calendar and time zone. en_US_POSIX keeps the format
-    // fixed regardless of the user's locale settings.
-    private static let keyFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "yyyy-MM-dd"
-        return f
-    }()
-
     // Month abbreviations follow the user's locale — unlike the data keys, these
     // are read by a human. The same formatter is the source of the weekday
     // symbols: DateFormatter.shortWeekdaySymbols is always Sunday-first, which is
@@ -120,17 +179,6 @@ private struct HeatmapGrid: View {
         f.setLocalizedDateFormatFromTemplate("MMM")
         return f
     }()
-
-    // Oldest visible day: back to this week's Sunday, then back to the first
-    // visible week. Matches the Android walk exactly so both grids show the same
-    // window and the same week alignment.
-    private var startDate: Date {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-        let weekday = calendar.component(.weekday, from: today) // 1 = Sunday
-        let thisSunday = calendar.date(byAdding: .day, value: -(weekday - 1), to: today) ?? today
-        return calendar.date(byAdding: .day, value: -(weeks - 1) * 7, to: thisSunday) ?? thisSunday
-    }
 
     // Width and height in units, including the label gutters when shown, so the
     // whole labelled block scales as one piece inside aspectRatio(_:contentMode:).
@@ -145,8 +193,8 @@ private struct HeatmapGrid: View {
             weeks: weeks,
             heatmap: heatmap,
             showsLabels: showsLabels,
-            startDate: startDate,
-            keyFormatter: Self.keyFormatter,
+            startDate: gridStartDate(weeks: weeks),
+            keyFormatter: heatmapKeyFormatter,
             monthFormatter: Self.monthFormatter
         )
         .aspectRatio(aspect, contentMode: .fit)
@@ -183,7 +231,7 @@ private struct HeatmapCanvas: View {
             var day = startDate
             for col in 0..<weeks {
                 for row in 0..<daysPerWeek {
-                    let count = heatmap[keyFormatter.string(from: day)] ?? 0
+                    let count = heatmap[heatmapKeyFormatter.string(from: day)] ?? 0
                     let rect = CGRect(
                         x: originX + Double(col) * (cell + gap),
                         y: originY + Double(row) * (cell + gap),
@@ -280,6 +328,30 @@ private func statText(overdue: Int, soon: Int) -> String {
     }
 }
 
+// One figure and its caption. Deliberately lastGLANCE's own idiom — system fonts
+// and semantic colours — rather than lifeGLANCE's monospaced palette, since this
+// sits directly under a grid already drawn in system colours.
+private struct StatTile: View {
+    let value: String
+    let label: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(value)
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.primary)
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+        .lineLimit(1)
+    }
+}
+
+private func plural(_ n: Int, _ singular: String, _ plural: String) -> String {
+    n == 1 ? singular : plural
+}
+
 private struct Wordmark: View {
     let size: Double
 
@@ -338,12 +410,16 @@ struct HeatmapWidgetView: View {
         }
     }
 
-    // A 52-week band cannot fill this family's height on its own, so the grid is
-    // centred in the space above a pinned footer rather than stretched. The
-    // labels and legend are the same furniture GitHub uses, which is what makes
-    // the remaining whitespace read as composition instead of a gap.
+    // A 52-week band is ~7.4:1 and this family is ~2:1, so the grid cannot fill
+    // the height by stretching — the cells have to stay square and there are
+    // exactly seven rows. Instead the leftover height carries content that only
+    // appears at this size: GitHub's own furniture (month and weekday labels, a
+    // legend) plus a summary of the window on screen. That mirrors lifeGLANCE's
+    // TimelineStripView, which likewise shows a caption row above medium.
     private var extraLarge: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        let stats = HeatmapStats(heatmap: entry.snapshot.heatmap, weeks: extraLargeWeeks)
+
+        return VStack(alignment: .leading, spacing: 12) {
             Spacer(minLength: 0)
 
             HeatmapGrid(weeks: extraLargeWeeks, heatmap: entry.snapshot.heatmap, showsLabels: true)
@@ -352,6 +428,23 @@ struct HeatmapWidgetView: View {
             HStack(spacing: 0) {
                 Spacer(minLength: 0)
                 HeatmapLegend()
+            }
+
+            Spacer(minLength: 0)
+
+            // Figures describe exactly the window drawn above, not all of
+            // history, so nothing here can contradict the cells on screen.
+            HStack(alignment: .top, spacing: 28) {
+                StatTile(
+                    value: "\(stats.completions)",
+                    label: plural(stats.completions, "completion", "completions")
+                )
+                StatTile(
+                    value: "\(stats.activeDays)",
+                    label: plural(stats.activeDays, "active day", "active days")
+                )
+                StatTile(value: "\(stats.streak)", label: "day streak")
+                Spacer(minLength: 0)
             }
 
             Spacer(minLength: 0)

--- a/ios/App/GlanceWidgets/Snapshot.swift
+++ b/ios/App/GlanceWidgets/Snapshot.swift
@@ -100,15 +100,43 @@ struct WidgetSnapshot: Decodable {
     private enum CodingKeys: String, CodingKey {
         case version, generatedAt, counts, heatmap, chores
     }
+}
 
-    // The snapshot currently in the App Group, or an empty one. Returns empty
-    // rather than nil so callers have a single render path: before the first
-    // foreground of an updated app there is genuinely no snapshot yet, and that
-    // should look like "no activity", not like an error.
-    static func load() -> WidgetSnapshot {
-        guard let raw = SharedDataStore.readSnapshot(),
-              let decoded = try? JSONDecoder().decode(WidgetSnapshot.self, from: Data(raw.utf8))
-        else { return WidgetSnapshot() }
-        return decoded
+// Why there is nothing to draw. Collapsing these into one empty snapshot made a
+// misprovisioned App Group, a never-opened app and a corrupt payload all look
+// identical on screen — a blank widget with no way to tell which. Two of the
+// three are developer errors and one is a legitimate first-run state, and they
+// want opposite responses, so the widget names which it hit.
+enum SnapshotLoad {
+    case loaded(WidgetSnapshot)
+    /// UserDefaults(suiteName:) returned nil: the entitlement is missing from
+    /// this target, or the provisioning profile does not carry the App Group.
+    case appGroupUnavailable
+    /// The container is readable but empty. Normal on a fresh install until the
+    /// app foregrounds once and pushes.
+    case noSnapshotYet
+    case undecodable
+
+    var snapshot: WidgetSnapshot {
+        if case let .loaded(s) = self { return s }
+        return WidgetSnapshot()
+    }
+
+    /// A short line to render in place of the grid, or nil when all is well.
+    var problem: String? {
+        switch self {
+        case .loaded: return nil
+        case .appGroupUnavailable: return "App Group unavailable.\nCheck the GlanceWidgets entitlement."
+        case .noSnapshotYet: return "Open lastGLANCE once to sync."
+        case .undecodable: return "Snapshot unreadable."
+        }
+    }
+
+    static func read() -> SnapshotLoad {
+        guard SharedDataStore.isAvailable else { return .appGroupUnavailable }
+        guard let raw = SharedDataStore.readSnapshot() else { return .noSnapshotYet }
+        guard let decoded = try? JSONDecoder().decode(WidgetSnapshot.self, from: Data(raw.utf8))
+        else { return .undecodable }
+        return .loaded(decoded)
     }
 }

--- a/scripts/sync-ios-version.mjs
+++ b/scripts/sync-ios-version.mjs
@@ -1,11 +1,26 @@
 #!/usr/bin/env node
-// Sync the iOS app's marketing version (CFBundleShortVersionString) with the
-// version in package.json — the iOS analogue of the package.json-derived
-// versionName in android/app/build.gradle.
+// Keep the iOS project's version settings consistent across every target.
 //
-// Marketing version only. The build number (CURRENT_PROJECT_VERSION /
-// CFBundleVersion) must increment per TestFlight/App Store upload and is left
-// for the upload step to manage.
+// Two separate jobs, because the two numbers answer different questions:
+//
+//   MARKETING_VERSION (CFBundleShortVersionString) is the version users see and
+//   tracks package.json, the iOS analogue of the package.json-derived versionName
+//   in android/app/build.gradle. Always rewritten to match.
+//
+//   CURRENT_PROJECT_VERSION (CFBundleVersion) is the build number. App Store
+//   Connect requires the (marketing version, build number) PAIR to be unique, so
+//   this has to increment per UPLOAD, not per version — which is exactly why it
+//   cannot be derived from package.json: you routinely ship several TestFlight
+//   builds of one version. Set it explicitly:
+//
+//       IOS_BUILD=7 npm run build:ios
+//
+//   With IOS_BUILD unset the build number is left alone, but every target is
+//   checked for agreement. That check is the point of this half of the script:
+//   an app and its extensions MUST ship the same CFBundleVersion or App Store
+//   Connect rejects the upload at validation, and Xcode's General tab edits only
+//   the target you happen to have selected — so bumping the build number by hand
+//   moves the App target and silently leaves GlanceWidgets behind.
 //
 // Usage: node scripts/sync-ios-version.mjs   (run from the repo root)
 
@@ -17,12 +32,73 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const version = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).version
 const pbxPath = resolve(root, 'ios/App/App.xcodeproj/project.pbxproj')
 
-const pbx = readFileSync(pbxPath, 'utf8')
-const updated = pbx.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`)
+const original = readFileSync(pbxPath, 'utf8')
+let pbx = original
 
-if (updated === pbx) {
-  console.log(`iOS MARKETING_VERSION already ${version} (no change)`)
-} else {
-  writeFileSync(pbxPath, updated)
-  console.log(`iOS MARKETING_VERSION -> ${version}`)
+// --- Marketing version: always tracks package.json -------------------------
+
+pbx = pbx.replace(/MARKETING_VERSION = [^;]+;/g, `MARKETING_VERSION = ${version};`)
+console.log(
+  pbx === original
+    ? `iOS MARKETING_VERSION already ${version} (no change)`
+    : `iOS MARKETING_VERSION -> ${version}`,
+)
+
+// --- Build number: explicit, and identical across every target -------------
+
+const found = [...pbx.matchAll(/CURRENT_PROJECT_VERSION = ([^;]+);/g)].map(m => m[1].trim())
+if (found.length === 0) {
+  console.error('error: no CURRENT_PROJECT_VERSION found in project.pbxproj')
+  process.exit(1)
 }
+
+const requested = process.env.IOS_BUILD?.trim()
+
+if (requested) {
+  // CFBundleVersion is one to three period-separated integers.
+  if (!/^\d+(\.\d+){0,2}$/.test(requested)) {
+    console.error(
+      `error: IOS_BUILD must be one to three period-separated integers, got "${requested}"`,
+    )
+    process.exit(1)
+  }
+
+  // Advisory only. A build number must increase within a marketing version, but
+  // restarting at 1 after a version bump is legitimate, so this cannot be a hard
+  // failure — it just catches the far more common "forgot to increment".
+  const current = [...new Set(found)]
+  if (
+    current.length === 1 &&
+    /^\d+$/.test(current[0]) &&
+    /^\d+$/.test(requested) &&
+    Number(requested) <= Number(current[0])
+  ) {
+    console.warn(
+      `warning: IOS_BUILD ${requested} is not greater than the current ${current[0]}. ` +
+      'App Store Connect rejects a build number it has already seen for this marketing version.',
+    )
+  }
+
+  pbx = pbx.replace(
+    /CURRENT_PROJECT_VERSION = [^;]+;/g,
+    `CURRENT_PROJECT_VERSION = ${requested};`,
+  )
+  console.log(`iOS CURRENT_PROJECT_VERSION -> ${requested} (${found.length} build configs)`)
+} else {
+  const distinct = [...new Set(found)]
+  if (distinct.length > 1) {
+    console.error(
+      `error: CURRENT_PROJECT_VERSION disagrees across targets: ${distinct.join(', ')}.\n` +
+      '       An app and its extensions must ship the same CFBundleVersion or the\n' +
+      '       App Store Connect upload is rejected. Set them all with:\n' +
+      `           IOS_BUILD=<n> npm run build:ios`,
+    )
+    process.exit(1)
+  }
+  console.log(
+    `iOS CURRENT_PROJECT_VERSION is ${distinct[0]} across ${found.length} build configs ` +
+    '(unchanged; set IOS_BUILD to bump)',
+  )
+}
+
+if (pbx !== original) writeFileSync(pbxPath, pbx)

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { getCategories, getChoresForCategory, logCompletion } from '@/db/queries'
-import { Capacitor } from '@capacitor/core'
 import { LocalNotifications } from '@capacitor/local-notifications'
+import { isNativeShell } from '@/native/platform'
 import { useToast, type ToastOptions } from '@/components/Toast/Toast'
 import { useIntents } from '@/intents/IntentsContext'
 import { emitCreateIntent } from '@/intents/emitter'
@@ -69,11 +69,12 @@ async function fireBrowserNotification(title: string, body: string) {
 }
 
 export async function requestNotificationPermission(): Promise<NotificationPermission> {
-  // On Android the WebView's Notification API is unavailable; the real permission
-  // (POST_NOTIFICATIONS) lives in the native Local Notifications plugin, which
-  // also delivers the closed-app reminders. Check/request there and map the
-  // plugin's PermissionState onto the web NotificationPermission the UI expects.
-  if (Capacitor.getPlatform() === 'android') {
+  // In both native shells the WebView's Notification API is unavailable (absent
+  // in WKWebView, unusable in Android's WebView), and the real permission lives
+  // in the native Local Notifications plugin, which also delivers the closed-app
+  // reminders. Check/request there and map the plugin's PermissionState onto the
+  // web NotificationPermission the UI expects.
+  if (isNativeShell()) {
     try {
       let status = await LocalNotifications.checkPermissions()
       if (status.display === 'prompt' || status.display === 'prompt-with-rationale') {
@@ -163,10 +164,10 @@ export function useNotifications() {
                 toastOpts.onSendToDayGlance = async () => emitCreateIntent(chore)
               }
               showToastRef.current(toastOpts)
-            } else if (Capacitor.getPlatform() !== 'android') {
-              // On Android, native exact-alarm reminders (useReminders) own
+            } else if (!isNativeShell()) {
+              // In both native shells the scheduled reminders (useReminders) own
               // closed/backgrounded delivery — skip the web notification so it
-              // isn't duplicated. Other platforms keep the in-WebView path.
+              // isn't duplicated. Web/PWA keeps the in-WebView path.
               await fireBrowserNotification(chore.name, body)
             }
 

--- a/src/hooks/useReminders.ts
+++ b/src/hooks/useReminders.ts
@@ -1,15 +1,15 @@
 import { useEffect } from 'react'
-import { Capacitor } from '@capacitor/core'
 import { LocalNotifications } from '@capacitor/local-notifications'
 import type { PluginListenerHandle } from '@capacitor/core'
 import { syncReminders, handleNotificationAction } from '@/native/reminders'
+import { isNativeShell } from '@/native/platform'
 
-// Keeps the native exact-alarm reminder set in sync with the chores, on the same
-// signals as the widget snapshot, and routes notification taps to the chore.
-// No-op off Android (syncReminders guards the platform internally).
+// Keeps the native reminder set in sync with the chores, on the same signals as
+// the widget snapshot, and routes notification taps to the chore. Runs in both
+// native shells; no-op on web/PWA (syncReminders also guards internally).
 export function useReminders(): void {
   useEffect(() => {
-    if (Capacitor.getPlatform() !== 'android') return
+    if (!isNativeShell()) return
 
     syncReminders()
 

--- a/src/native/reminders.test.ts
+++ b/src/native/reminders.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// reminders.ts pulls in the DB and the intents stack at module scope; stub the
+// Capacitor surface so the pure helpers can be exercised under node.
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { getPlatform: () => 'web', isNativePlatform: () => false },
+  CapacitorHttp: { request: vi.fn() },
+  registerPlugin: () => ({}),
+}))
+vi.mock('@capacitor/local-notifications', () => ({ LocalNotifications: {} }))
+
+import { reminderIdFor, soonest } from './reminders'
+
+describe('reminderIdFor', () => {
+  it('is deterministic, so rescheduling replaces an alarm instead of stacking one', () => {
+    const id = reminderIdFor('3f2b1c8e-0000-4000-8000-000000000001')
+    expect(reminderIdFor('3f2b1c8e-0000-4000-8000-000000000001')).toBe(id)
+  })
+
+  it('stays inside the positive 31-bit range both platforms require for ids', () => {
+    for (let i = 0; i < 500; i++) {
+      const id = reminderIdFor(`chore-${i}-${'x'.repeat(i % 40)}`)
+      expect(Number.isInteger(id)).toBe(true)
+      expect(id).toBeGreaterThan(0)
+      expect(id).toBeLessThanOrEqual(0x7fffffff)
+    }
+  })
+
+  it('never returns 0, which is not a usable notification id', () => {
+    // The `|| 1` fallback exists for inputs that hash to exactly 0.
+    expect(reminderIdFor('')).toBe(1)
+  })
+})
+
+describe('soonest', () => {
+  const at = (n: number) => ({ triggerAtMillis: n })
+
+  it('returns the input untouched when it is already within the cap', () => {
+    const items = [at(3), at(1), at(2)]
+    expect(soonest(items, 5)).toBe(items)
+  })
+
+  it('keeps the nearest-firing items when the cap bites', () => {
+    const items = [at(500), at(100), at(400), at(200), at(300)]
+    expect(soonest(items, 3).map(i => i.triggerAtMillis)).toEqual([100, 200, 300])
+  })
+
+  it('does not mutate or reorder the caller array', () => {
+    // syncReminders diffs `desired` against the pending set afterwards, so a
+    // sort in place here would be an invisible side effect on the caller.
+    const items = [at(3), at(1), at(2)]
+    soonest(items, 2)
+    expect(items.map(i => i.triggerAtMillis)).toEqual([3, 1, 2])
+  })
+
+  it('handles an exact-boundary set without dropping anything', () => {
+    const items = Array.from({ length: 56 }, (_, i) => at(i))
+    expect(soonest(items, 56)).toHaveLength(56)
+  })
+
+  it('drops only the furthest-out when one over the cap', () => {
+    const items = Array.from({ length: 57 }, (_, i) => at(i))
+    const kept = soonest(items, 56)
+    expect(kept).toHaveLength(56)
+    expect(kept.map(i => i.triggerAtMillis)).not.toContain(56)
+  })
+
+  it('copes with an empty set', () => {
+    expect(soonest([], 56)).toEqual([])
+  })
+})

--- a/src/native/reminders.ts
+++ b/src/native/reminders.ts
@@ -1,5 +1,5 @@
-import { Capacitor } from '@capacitor/core'
 import { LocalNotifications } from '@capacitor/local-notifications'
+import { isAndroid, isNativeShell } from './platform'
 import type { PendingLocalNotificationSchema } from '@capacitor/local-notifications'
 import { getCategories, getChoresForCategory, logCompletion } from '@/db/queries'
 import { db } from '@/db/client'
@@ -14,13 +14,21 @@ import type { ChoreWithLastCompletion } from '@/types'
 import dayjs from 'dayjs'
 
 // Phase 1: closed-app overdue notifications. The web app pre-computes each
-// chore's next-overdue instant (last completion + cadence) and registers it as
-// an exact Android alarm via @capacitor/local-notifications, so notifications
-// fire when the app is closed — replacing the in-WebView timer that only ran
-// while the app was alive. Native owns closed-app delivery; the in-app toast in
-// useNotifications.ts still covers the foreground case.
+// chore's next-overdue instant (last completion + cadence) and registers it with
+// @capacitor/local-notifications, so notifications fire when the app is closed —
+// replacing the in-WebView timer that only ran while the app was alive. Native
+// owns closed-app delivery; the in-app toast in useNotifications.ts still covers
+// the foreground case.
 //
-// No-op anywhere but Android (the only platform wired so far).
+// Runs in both native shells; no-op on web/PWA. The scheduling model is shared,
+// with three Android-only pieces skipped on iOS (notification channels, the
+// exact-alarm permission prompt, and the per-build force-reschedule) and one
+// iOS-only piece added (the 64-notification cap). Each is marked below.
+//
+// Timing differs by platform and that is accepted: Android schedules an exact
+// alarm, iOS has no equivalent and the system may batch delivery. Fine for a
+// single-shot "it's been N days" nudge; do not build anything time-critical on
+// top of it.
 
 const CHANNEL_ID = 'overdue'
 const EXACT_PROMPTED_KEY = 'lg_exact_alarm_prompted'
@@ -36,6 +44,24 @@ const BUILD_TOKEN_KEY = 'lg_reminders_build_token'
 // time via actionTypeId, and refreshes whenever syncReminders re-runs.
 const ACTION_TYPE = 'OVERDUE'
 const ACTION_TYPE_DG = 'OVERDUE_DG'
+
+// iOS keeps at most 64 pending local notifications per app and silently discards
+// the rest — no error, the reminder simply never arrives. Our model is one
+// single-shot notification per eligible chore, so a heavy user with a lot of
+// cadenced chores can plausibly reach that, unlike on Android where there is no
+// such limit. Cap below 64 rather than at it: the ceiling is per-app, not
+// per-feature, so leaving headroom keeps a future notification of any other kind
+// from being the one that gets dropped.
+const IOS_PENDING_LIMIT = 56
+
+// The soonest `n` by trigger time. When the cap bites, the reminders worth
+// keeping are the ones about to fire: everything dropped here is further out
+// than everything kept, and each later sync (foreground, completion, sync-apply)
+// re-runs this and pulls the next tranche in as the near ones fire.
+export function soonest<T extends { triggerAtMillis: number }>(items: T[], n: number): T[] {
+  if (items.length <= n) return items
+  return [...items].sort((a, b) => a.triggerAtMillis - b.triggerAtMillis).slice(0, n)
+}
 
 interface ReminderDescriptor {
   id: number // stable numeric id derived from choreSyncId
@@ -79,9 +105,12 @@ async function ensureActionTypes(): Promise<void> {
   }
 }
 
+// Android-only: notification channels have no iOS equivalent, and the plugin's
+// createChannel is a no-op there. Guarded explicitly rather than left to fail
+// quietly, so the Android-only-ness is visible at the call site.
 let channelReady = false
 async function ensureChannel(): Promise<void> {
-  if (channelReady) return
+  if (channelReady || !isAndroid()) return
   try {
     await LocalNotifications.createChannel({
       id: CHANNEL_ID,
@@ -101,7 +130,11 @@ async function ensureChannel(): Promise<void> {
 // the classic "late when closed" failure. Prompt once, lazily, and only when we
 // actually have something to schedule, so users who never opt a chore into
 // reminders are never sent to Settings.
+//
+// Android-only: iOS has no exact-alarm concept and no such permission, so there
+// is nothing to ask for and no Settings screen to send anyone to.
 async function maybePromptExactAlarm(): Promise<void> {
+  if (!isAndroid()) return
   if (localStorage.getItem(EXACT_PROMPTED_KEY)) return
   try {
     const status = await LocalNotifications.checkExactNotificationSetting()
@@ -157,7 +190,7 @@ async function buildReminders(dgEnabled: boolean): Promise<ReminderDescriptor[]>
 // schedule only what's new or changed. Avoids a blanket cancel-all that could
 // drop an alarm in the window before it's re-registered.
 export async function syncReminders(): Promise<void> {
-  if (Capacitor.getPlatform() !== 'android') return
+  if (!isNativeShell()) return
   try {
     let perm = await LocalNotifications.checkPermissions()
     if (perm.display !== 'granted') {
@@ -171,7 +204,9 @@ export async function syncReminders(): Promise<void> {
     // GLANCEvault DB transport — mirroring IntentsContext.isConfigured. Checking
     // WebDAV alone hid the action on vault-only setups.
     const dgEnabled = isIntentsConfigured(getIntentsConfig()) || isDbIntentsEnabled()
-    const desired = await buildReminders(dgEnabled)
+    const all = await buildReminders(dgEnabled)
+    // iOS-only cap. On Android the full set is scheduled; there is no limit.
+    const desired = isAndroid() ? all : soonest(all, IOS_PENDING_LIMIT)
     if (desired.length > 0) await maybePromptExactAlarm()
 
     // Android bakes each scheduled notification — including its small-icon
@@ -187,8 +222,13 @@ export async function syncReminders(): Promise<void> {
     // The token is the build timestamp, not the version name: IDs churn per build,
     // and same-version rebuilds (internal-test builds that bump only versionCode)
     // would slip past a versionName check and keep firing the stale icon.
+    //
+    // Android-only. The whole hazard is aapt2 reassigning drawable resource IDs
+    // between builds; iOS notifications carry no resource ID, so forcing a full
+    // reschedule there would churn every pending notification on each new build
+    // to fix a problem it cannot have.
     const buildToken = typeof __BUILD_TIME__ !== 'undefined' ? __BUILD_TIME__ : 'dev'
-    const force = localStorage.getItem(BUILD_TOKEN_KEY) !== buildToken
+    const force = isAndroid() && localStorage.getItem(BUILD_TOKEN_KEY) !== buildToken
 
     const desiredById = new Map(desired.map(r => [r.id, r]))
     const pending: PendingLocalNotificationSchema[] =

--- a/src/native/snapshot.ts
+++ b/src/native/snapshot.ts
@@ -6,8 +6,15 @@ import { pushWidgetSnapshot } from './widgetBridge'
 import dayjs from 'dayjs'
 
 // How many days of completion history to ship to the heatmap widget.
-// ~27 weeks, so the 26-week widget grid is fully covered (with week alignment).
-const HEATMAP_DAYS = 190
+// 53 weeks, so the widest grid we render (the 52-week iOS extra-large widget) is
+// fully covered even after the alignment walk back to the oldest visible Sunday.
+// Android's 26-week grid and the iOS medium widget read the same map and simply
+// ignore the older half.
+//
+// Cost is bounded by activity, not by the window: only days that actually have
+// completions are serialized, so this grows the snapshot by however many extra
+// active days a user has, not by 181 entries.
+const HEATMAP_DAYS = 371
 
 export type ChoreState = 'fresh' | 'soon' | 'overdue' | 'none'
 


### PR DESCRIPTION
The base of the iOS feature stack — everything already device-verified or JS-verified from the interactive sessions.

## What's in here

- **52-week extra-large heatmap widget** (verified on your iPad), `systemLarge` dropped, month/weekday labels + legend + stats row, September-label fix, stats spread edge to edge
- **`HEATMAP_DAYS` 190 → 371** so the year view has data behind it
- **Snapshot diagnostics**: a widget that can't read the App Group now says why instead of rendering blank
- **Timeline arithmetic simplification** (with the honest record that the blank-widget bug was WidgetKit cache, not code)
- **`sync-ios-version.mjs` manages `CURRENT_PROJECT_VERSION`** across all targets via `IOS_BUILD=<n>`, and fails the build if app/extension build numbers drift
- **Committed the regenerated `Package.swift`** (was missing four plugin bridges on fresh clones)
- **Phase 1: overdue notifications on iOS** — guards relaxed in `reminders.ts` / `useReminders` / `useNotifications`; Android-only pieces (channels, exact-alarm prompt, per-build force-reschedule) explicitly gated; iOS-only 56-of-64 pending cap keeping nearest-firing reminders; 9 new tests

## Merge order

This PR is the base of a stack. Merge first, then in order: #icons → #widgets → #entrypoints → #share-ext (each PR targets its predecessor).

## Needs device verification

Phase 1 notifications: first-launch permission prompt, delivery timing (iOS may batch — expected), notification actions opening the app.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XHvf3dadyFScUW6vxUQaG)_