### PR TITLE
iOS Phase 2: soon-list + single-chore widgets with one-tap Done

### DIFF
--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -172,6 +172,16 @@ notification fires and its tap routes to the chore.
 The big lift. ~0% code reuse from Kotlin, but the data contract and layout design
 carry over.
 
+> **Status 2026-08: written, unbuilt.** SoonListWidget, SingleChoreWidget
+> (configurable via `AppIntentConfiguration` — no config Activity needed on iOS),
+> CompleteChoreIntent + CompletionStore mirroring the Kotlin completion contract
+> field for field (lowercase-UUID sync_id minted at tap time, millisecond-UTC
+> completedAt, optimistic snapshot fold with counts recompute and heatmap bump).
+> The optimistic fold mutates the raw JSON via JSONSerialization, NOT the Codable
+> model — the model is lenient/lossy by design and a round trip would drop fields
+> this build does not know. One divergence from Android: WidgetKit lists do not
+> scroll, so rows are capped per family with a "+N more" line instead.
+
 - **WidgetKit + SwiftUI** widgets reading the App-Group snapshot: heatmap,
   soon/overdue **list** widget, and a configurable **single-chore** widget.
   A `TimelineProvider` supplies entries; use SwiftUI relative-date text so

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -26,6 +26,12 @@
 		EA00000000000000000000B6 /* Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F6 /* Snapshot.swift */; };
 		EA00000000000000000000B8 /* LucidePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000FA /* LucidePath.swift */; };
 		EA00000000000000000000B9 /* LucideIcons.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000FB /* LucideIcons.generated.swift */; };
+		EA00000000000000000000C1 /* SnapshotProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E1 /* SnapshotProvider.swift */; };
+		EA00000000000000000000C2 /* ChoreSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E2 /* ChoreSnapshot.swift */; };
+		EA00000000000000000000C3 /* CompletionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E3 /* CompletionStore.swift */; };
+		EA00000000000000000000C4 /* CompleteChoreIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E4 /* CompleteChoreIntent.swift */; };
+		EA00000000000000000000C5 /* SoonListWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E5 /* SoonListWidget.swift */; };
+		EA00000000000000000000C6 /* SingleChoreWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E6 /* SingleChoreWidget.swift */; };
 		EA00000000000000000000B7 /* GlanceWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F9 /* GlanceWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -77,6 +83,12 @@
 		EA00000000000000000000F8 /* GlanceWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GlanceWidgets.entitlements; sourceTree = "<group>"; };
 		EA00000000000000000000FA /* LucidePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LucidePath.swift; sourceTree = "<group>"; };
 		EA00000000000000000000FB /* LucideIcons.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LucideIcons.generated.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E1 /* SnapshotProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotProvider.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E2 /* ChoreSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreSnapshot.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E3 /* CompletionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionStore.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E4 /* CompleteChoreIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteChoreIntent.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E5 /* SoonListWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoonListWidget.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E6 /* SingleChoreWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleChoreWidget.swift; sourceTree = "<group>"; };
 		EA00000000000000000000F9 /* GlanceWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GlanceWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -161,6 +173,12 @@
 				EA00000000000000000000F4 /* GlanceWidgetsBundle.swift */,
 				EA00000000000000000000F5 /* HeatmapWidget.swift */,
 				EA00000000000000000000F6 /* Snapshot.swift */,
+				EA00000000000000000000E1 /* SnapshotProvider.swift */,
+				EA00000000000000000000E2 /* ChoreSnapshot.swift */,
+				EA00000000000000000000E3 /* CompletionStore.swift */,
+				EA00000000000000000000E4 /* CompleteChoreIntent.swift */,
+				EA00000000000000000000E5 /* SoonListWidget.swift */,
+				EA00000000000000000000E6 /* SingleChoreWidget.swift */,
 				EA00000000000000000000FA /* LucidePath.swift */,
 				EA00000000000000000000FB /* LucideIcons.generated.swift */,
 				EA00000000000000000000F7 /* Info.plist */,
@@ -298,6 +316,12 @@
 				EA00000000000000000000B5 /* HeatmapWidget.swift in Sources */,
 				EA00000000000000000000B6 /* Snapshot.swift in Sources */,
 				EA00000000000000000000B3 /* SharedDataStore.swift in Sources */,
+				EA00000000000000000000C1 /* SnapshotProvider.swift in Sources */,
+				EA00000000000000000000C2 /* ChoreSnapshot.swift in Sources */,
+				EA00000000000000000000C3 /* CompletionStore.swift in Sources */,
+				EA00000000000000000000C4 /* CompleteChoreIntent.swift in Sources */,
+				EA00000000000000000000C5 /* SoonListWidget.swift in Sources */,
+				EA00000000000000000000C6 /* SingleChoreWidget.swift in Sources */,
 				EA00000000000000000000B8 /* LucidePath.swift in Sources */,
 				EA00000000000000000000B9 /* LucideIcons.generated.swift in Sources */,
 			);

--- a/ios/App/GlanceWidgets/ChoreSnapshot.swift
+++ b/ios/App/GlanceWidgets/ChoreSnapshot.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+// Chore selection and row-level formatting for the list and single-chore
+// widgets — the iOS counterpart of ChoreSnapshot in SingleChoreWidget.kt. Every
+// rule here is copied from the Kotlin deliberately: which chores qualify, how
+// ties break, what the elapsed text says, and which colours stand in when the
+// snapshot has none. The two platforms must pick the same chore and describe it
+// the same way.
+
+extension WidgetSnapshot {
+
+    // Chores aged into the amber/red zone (state soon or overdue), most-overdue
+    // first, capped at `limit`. Powers the Soon list widget.
+    func soonList(limit: Int) -> [SnapshotChore] {
+        chores
+            .filter { $0.state == .soon || $0.state == .overdue }
+            .sorted { ($0.ratio ?? 0) > ($1.ratio ?? 0) }
+            .prefix(limit)
+            .map { $0 }
+    }
+
+    // The chore with the highest elapsed/target ratio (most overdue, or closest
+    // to due). Nil when nothing has a cadence + a completion yet.
+    var mostOverdue: SnapshotChore? {
+        chores.filter { $0.ratio != nil }.max { ($0.ratio ?? -1) < ($1.ratio ?? -1) }
+    }
+
+    // The specific chore chosen for a configured single-chore widget. Nil if it
+    // is gone from the snapshot (e.g. deleted) — the widget then shows empty.
+    func chore(bySyncId syncId: String) -> SnapshotChore? {
+        chores.first { $0.syncId == syncId }
+    }
+}
+
+// The completion timestamps in the snapshot are minted by dayjs/Date on the JS
+// side and by the widget tap paths on both platforms, always in this exact
+// form. en_US_POSIX pins the format against locale settings.
+let isoMillisFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    f.timeZone = TimeZone(identifier: "UTC")
+    return f
+}()
+
+extension SnapshotChore {
+
+    // "today" / "yesterday" / "Nd ago" / "never" — the same words the app and
+    // the Android widgets use. Calendar-day boundaries off the real timestamp,
+    // so a chore done last night reads "yesterday" this morning, not "today";
+    // elapsedDays alone is a duration and gets that wrong (a 10pm→8am gap is
+    // under 24h). Falls back to the duration when the timestamp is missing.
+    var elapsedLabel: String {
+        guard elapsedDays != nil else { return "never" }
+        if let iso = lastCompletedAt, let then = isoMillisFormatter.date(from: iso) {
+            let calendar = Calendar.current
+            let days = calendar.dateComponents(
+                [.day],
+                from: calendar.startOfDay(for: then),
+                to: calendar.startOfDay(for: Date())
+            ).day ?? 0
+            switch days {
+            case ...0: return "today"
+            case 1: return "yesterday"
+            default: return "\(days)d ago"
+            }
+        }
+        let d = elapsedDays ?? 0
+        if d < 1 { return "today" }
+        return "\(Int(d.rounded()))d ago"
+    }
+
+    // The recency colour the snapshot shipped, with the same two fallbacks as
+    // Android: neutral slate when the chore has no cadence/completion yet, and
+    // the brand green when a shipped value fails to parse.
+    var recencyColor: Color {
+        Color(hexString: color ?? "#94a3b8") ?? Color(hexString: "#22c55e")!
+    }
+}
+
+extension Color {
+    // #rrggbb only — the only form the snapshot ever contains.
+    init?(hexString: String) {
+        var s = hexString
+        if s.hasPrefix("#") { s.removeFirst() }
+        guard s.count == 6, let v = UInt32(s, radix: 16) else { return nil }
+        self.init(
+            red: Double((v >> 16) & 0xFF) / 255,
+            green: Double((v >> 8) & 0xFF) / 255,
+            blue: Double(v & 0xFF) / 255
+        )
+    }
+}

--- a/ios/App/GlanceWidgets/CompleteChoreIntent.swift
+++ b/ios/App/GlanceWidgets/CompleteChoreIntent.swift
@@ -1,0 +1,28 @@
+import AppIntents
+
+// The Done button. Interactive widget buttons run their AppIntent inside the
+// widget extension process — no app launch, no WebView — which is the whole
+// reason the completion path goes through the App-Group queue instead of the
+// Capacitor bridge: there is no bridge here. The app replays the queue into
+// IndexedDB on next foreground (drainWidgetCompletions), idempotent on the
+// sync_id CompletionStore mints.
+struct CompleteChoreIntent: AppIntent {
+    static let title: LocalizedStringResource = "Mark chore done"
+    // Widget-internal plumbing, not a user-facing automation: keep it out of
+    // the Shortcuts app's action list.
+    static let isDiscoverable = false
+
+    @Parameter(title: "Chore")
+    var choreSyncId: String
+
+    init() {}
+
+    init(choreSyncId: String) {
+        self.choreSyncId = choreSyncId
+    }
+
+    func perform() async throws -> some IntentResult {
+        CompletionStore.complete(choreSyncId: choreSyncId)
+        return .result()
+    }
+}

--- a/ios/App/GlanceWidgets/CompletionStore.swift
+++ b/ios/App/GlanceWidgets/CompletionStore.swift
@@ -1,0 +1,79 @@
+import Foundation
+import WidgetKit
+
+// Record a widget completion: queue it for the app to replay into the DB, and
+// optimistically fold it into the snapshot so the widget reflects it instantly,
+// before the app ever runs. The iOS counterpart of CompletionStore in
+// SingleChoreWidget.kt, field for field:
+//
+//  - The sync_id is minted HERE (lowercase UUID). The web drain replays via
+//    logCompletion(choreId, { syncId }) which dedupes on it, so draining twice
+//    — or the event arriving from another device first — cannot double-count.
+//  - completedAt is "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" UTC, the exact shape the JS
+//    side and the Android tap path produce.
+//  - The optimistic fold mutates the RAW snapshot JSON via JSONSerialization,
+//    not through the Codable model: the model is lenient and lossy by design,
+//    and a decode→encode round trip would silently drop any field this build
+//    does not know about.
+enum CompletionStore {
+
+    static func complete(choreSyncId: String) {
+        let syncId = UUID().uuidString.lowercased()
+        let completedAt = isoMillisFormatter.string(from: Date())
+        SharedDataStore.appendPendingCompletion(
+            choreSyncId: choreSyncId, syncId: syncId, completedAt: completedAt
+        )
+
+        applyOptimistically(choreSyncId: choreSyncId, completedAt: completedAt)
+
+        // Every widget kind re-renders from the mutated snapshot: the tile and
+        // the list show the completion, the heatmap gains today's cell.
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    private static func applyOptimistically(choreSyncId: String, completedAt: String) {
+        guard let raw = SharedDataStore.readSnapshot(),
+              var root = (try? JSONSerialization.jsonObject(with: Data(raw.utf8))) as? [String: Any]
+        else { return }
+
+        if var chores = root["chores"] as? [[String: Any]] {
+            for i in chores.indices where (chores[i]["syncId"] as? String) == choreSyncId {
+                chores[i]["lastCompletedAt"] = completedAt
+                chores[i]["elapsedDays"] = 0
+                chores[i]["ratio"] = 0
+                chores[i]["color"] = "#22c55e"
+                chores[i]["state"] = "fresh"
+                break
+            }
+            var overdue = 0, soon = 0
+            for ch in chores {
+                switch ch["state"] as? String {
+                case "overdue": overdue += 1
+                case "soon": soon += 1
+                default: break
+                }
+            }
+            var counts = root["counts"] as? [String: Any] ?? [:]
+            counts["overdue"] = overdue
+            counts["soon"] = soon
+            root["counts"] = counts
+            root["chores"] = chores
+        }
+
+        // Local-day key, matching the web snapshot's dayjs().format('YYYY-MM-DD').
+        let dayFormatter = DateFormatter()
+        dayFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+        let today = dayFormatter.string(from: Date())
+        var heatmap = root["heatmap"] as? [String: Any] ?? [:]
+        heatmap[today] = (heatmap[today] as? Int ?? 0) + 1
+        root["heatmap"] = heatmap
+
+        if let data = try? JSONSerialization.data(withJSONObject: root),
+           let json = String(data: data, encoding: .utf8) {
+            SharedDataStore.writeSnapshot(json)
+        }
+        // On failure: nothing written — the completion is already queued for the
+        // DB replay, so the widget is merely stale until the next app foreground.
+    }
+}

--- a/ios/App/GlanceWidgets/GlanceWidgetsBundle.swift
+++ b/ios/App/GlanceWidgets/GlanceWidgetsBundle.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 import WidgetKit
 
-// Entry point for the WidgetKit extension. Phase 0 ships only the heatmap, which
-// exists to prove the App-Group read path end to end; the soon/overdue list and
-// the configurable single-chore widget join this bundle in Phase 2.
+// Entry point for the WidgetKit extension: the same three widget surfaces the
+// Android glance/ package ships — heatmap, soon/overdue list, and the
+// configurable single-chore tile — all rendering from the one App-Group
+// snapshot.
 @main
 struct GlanceWidgetsBundle: WidgetBundle {
     var body: some Widget {
         HeatmapWidget()
+        SoonListWidget()
+        SingleChoreWidget()
     }
 }

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -35,8 +35,6 @@ private let gapRatio = 3.0 / 14.0
 private let weekdayGutterUnits = 2.4
 private let monthStripUnits = 1.3
 
-private let brandGreen = Color(red: 0x3D / 255, green: 0xDC / 255, blue: 0x84 / 255)
-
 private func hex(_ value: UInt32) -> Color {
     Color(
         red: Double((value >> 16) & 0xFF) / 255,
@@ -127,67 +125,6 @@ private struct HeatmapStats {
             cursor = prev
         }
         streak = run
-    }
-}
-
-// MARK: - Timeline
-
-struct HeatmapEntry: TimelineEntry {
-    let date: Date
-    let snapshot: WidgetSnapshot
-    // Non-nil when there is nothing to draw and we know why. Rendered in place
-    // of the grid so the failure names itself instead of looking like a widget
-    // that never finished loading.
-    let problem: String?
-
-    init(date: Date, snapshot: WidgetSnapshot, problem: String? = nil) {
-        self.date = date
-        self.snapshot = snapshot
-        self.problem = problem
-    }
-
-    init(date: Date, load: SnapshotLoad) {
-        self.init(date: date, snapshot: load.snapshot, problem: load.problem)
-    }
-}
-
-struct HeatmapProvider: TimelineProvider {
-
-    func placeholder(in context: Context) -> HeatmapEntry {
-        HeatmapEntry(date: Date(), snapshot: WidgetSnapshot())
-    }
-
-    func getSnapshot(in context: Context, completion: @escaping (HeatmapEntry) -> Void) {
-        completion(HeatmapEntry(date: Date(), load: SnapshotLoad.read()))
-    }
-
-    func getTimeline(in context: Context, completion: @escaping (Timeline<HeatmapEntry>) -> Void) {
-        let now = Date()
-        let entry = HeatmapEntry(date: now, load: SnapshotLoad.read())
-
-        // WidgetKit is not a live process, so the only two things that can change
-        // what this widget should show are (a) the app pushing a new snapshot,
-        // which calls reloadAllTimelines directly, and (b) the date rolling over,
-        // which shifts the whole grid by one column. Only (b) needs a scheduled
-        // refresh, so ask for exactly one, at the next local midnight.
-        //
-        // Computed by adding a day to the start of today, rather than with
-        // Calendar.nextDate(after:matching:matchingPolicy:), which is what this
-        // used to call. Direct arithmetic over a search API is the smaller,
-        // clearer thing to do here and that is the whole reason it stays.
-        //
-        // It is NOT a bug fix, despite what the commit that introduced it said:
-        // the widget was blank because of a stale WidgetKit extension cache, and
-        // a device reboot fixed it. nextDate had been in this method since the
-        // widget was written and had worked fine throughout.
-        let calendar = Calendar.current
-        var refresh = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
-            ?? now.addingTimeInterval(3600)
-        // A refresh date must be in the future or WidgetKit has nothing to
-        // schedule; belt-and-braces against a DST edge or a nil from the calendar.
-        if refresh <= now { refresh = now.addingTimeInterval(3600) }
-
-        completion(Timeline(entries: [entry], policy: .after(refresh)))
     }
 }
 
@@ -385,24 +322,8 @@ private func plural(_ n: Int, _ singular: String, _ plural: String) -> String {
     n == 1 ? singular : plural
 }
 
-private struct Wordmark: View {
-    let size: Double
-
-    var body: some View {
-        HStack(spacing: 0) {
-            Text("last")
-                .font(.system(size: size, weight: .bold))
-                .foregroundStyle(.primary)
-            Text("GLANCE")
-                .font(.system(size: size, weight: .bold))
-                .italic()
-                .foregroundStyle(brandGreen)
-        }
-    }
-}
-
 struct HeatmapWidgetView: View {
-    var entry: HeatmapEntry
+    var entry: SnapshotEntry
 
     @Environment(\.widgetFamily) private var family
 
@@ -413,7 +334,7 @@ struct HeatmapWidgetView: View {
     var body: some View {
         Group {
             if let problem = entry.problem {
-                diagnostic(problem)
+                SnapshotProblemView(message: problem, large: family == .systemExtraLarge)
             } else if family == .systemExtraLarge {
                 extraLarge
             } else {
@@ -423,22 +344,6 @@ struct HeatmapWidgetView: View {
         .containerBackground(for: .widget) {
             Color(uiColor: .systemBackground)
         }
-    }
-
-    // Shown instead of an all-empty grid when the snapshot could not be read.
-    // An empty grid is a legitimate render (a user with no completions yet), so
-    // it must not double as the error state.
-    private func diagnostic(_ message: String) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Spacer(minLength: 0)
-            Wordmark(size: family == .systemExtraLarge ? 26 : 20)
-            Text(message)
-                .font(.system(size: family == .systemExtraLarge ? 15 : 13))
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // Unchanged from the original single-size widget. The half-year grid at this
@@ -525,7 +430,7 @@ struct HeatmapWidget: Widget {
     let kind = "HeatmapWidget"
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: HeatmapProvider()) { entry in
+        StaticConfiguration(kind: kind, provider: SnapshotProvider()) { entry in
             HeatmapWidgetView(entry: entry)
         }
         .configurationDisplayName("Activity")

--- a/ios/App/GlanceWidgets/SingleChoreWidget.swift
+++ b/ios/App/GlanceWidgets/SingleChoreWidget.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+import WidgetKit
+import AppIntents
+
+// Phase 2: the configurable single-chore widget — the iOS counterpart of
+// SingleChoreWidget.kt + SingleChoreConfigActivity.kt. Where Android needs a
+// whole config Activity, WidgetKit gets configuration for free from an
+// AppIntentConfiguration: long-press → Edit Widget → pick a chore. Unconfigured
+// it tracks the most-overdue chore, exactly like the Android tile's fallback.
+
+// A chore as the configuration UI sees it. The identifier is the sync_id — the
+// only name for a chore that is stable across devices and edits.
+struct ChoreEntity: AppEntity {
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Chore"
+    static let defaultQuery = ChoreEntityQuery()
+
+    let id: String
+    let name: String
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+}
+
+struct ChoreEntityQuery: EntityQuery {
+    // Both lookups read the App-Group snapshot — the configuration sheet runs in
+    // the widget extension, where the snapshot is the only data there is.
+    func entities(for identifiers: [String]) async throws -> [ChoreEntity] {
+        let snapshot = SnapshotLoad.read().snapshot
+        return identifiers.compactMap { id in
+            snapshot.chore(bySyncId: id).map { ChoreEntity(id: $0.syncId, name: $0.name) }
+        }
+    }
+
+    func suggestedEntities() async throws -> [ChoreEntity] {
+        SnapshotLoad.read().snapshot.chores
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            .map { ChoreEntity(id: $0.syncId, name: $0.name) }
+    }
+}
+
+struct SelectChoreIntent: WidgetConfigurationIntent {
+    static let title: LocalizedStringResource = "Choose chore"
+    static let description = IntentDescription("Pick the chore this widget tracks.")
+
+    // Optional on purpose: nil means "track whatever is most overdue", the same
+    // default a freshly placed Android tile has.
+    @Parameter(title: "Chore")
+    var chore: ChoreEntity?
+}
+
+struct ConfiguredChoreEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetSnapshot
+    let problem: String?
+    let configuredSyncId: String?
+}
+
+struct ConfiguredChoreProvider: AppIntentTimelineProvider {
+
+    func placeholder(in context: Context) -> ConfiguredChoreEntry {
+        ConfiguredChoreEntry(date: Date(), snapshot: WidgetSnapshot(), problem: nil, configuredSyncId: nil)
+    }
+
+    func snapshot(for configuration: SelectChoreIntent, in context: Context) async -> ConfiguredChoreEntry {
+        entry(for: configuration)
+    }
+
+    func timeline(for configuration: SelectChoreIntent, in context: Context) async -> Timeline<ConfiguredChoreEntry> {
+        // Same refresh contract as SnapshotProvider: the app's snapshot pushes
+        // reload everything, so the only scheduled refresh is the day rollover.
+        let now = Date()
+        let calendar = Calendar.current
+        var refresh = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
+            ?? now.addingTimeInterval(3600)
+        if refresh <= now { refresh = now.addingTimeInterval(3600) }
+        return Timeline(entries: [entry(for: configuration)], policy: .after(refresh))
+    }
+
+    private func entry(for configuration: SelectChoreIntent) -> ConfiguredChoreEntry {
+        let load = SnapshotLoad.read()
+        return ConfiguredChoreEntry(
+            date: Date(),
+            snapshot: load.snapshot,
+            problem: load.problem,
+            configuredSyncId: configuration.chore?.id
+        )
+    }
+}
+
+struct SingleChoreWidgetView: View {
+    var entry: ConfiguredChoreEntry
+
+    @Environment(\.widgetFamily) private var family
+
+    // A configured chore wins; else fall back to most-overdue — the Android
+    // rule. A configured chore that has vanished from the snapshot (deleted,
+    // or filtered out by multi-user "Mine") intentionally does NOT fall back:
+    // showing some other chore under a widget the user pinned to a specific
+    // one would be worse than showing the caught-up state.
+    private var chore: SnapshotChore? {
+        if let id = entry.configuredSyncId {
+            return entry.snapshot.chore(bySyncId: id)
+        }
+        return entry.snapshot.mostOverdue
+    }
+
+    var body: some View {
+        Group {
+            if let problem = entry.problem {
+                SnapshotProblemView(message: problem)
+            } else if let chore {
+                if family == .systemSmall {
+                    small(chore)
+                } else {
+                    medium(chore)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Wordmark(size: 15)
+                    Text("All caught up")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            }
+        }
+        .containerBackground(for: .widget) {
+            Color(uiColor: .systemBackground)
+        }
+    }
+
+    // The Android tile's row, at its sizes: bar 6x36 r3, icon 22, name 15 bold,
+    // elapsed 12, larger Done chip.
+    private func medium(_ chore: SnapshotChore) -> some View {
+        HStack(spacing: 10) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(chore.recencyColor)
+                .frame(width: 6, height: 36)
+            if let icon = chore.icon {
+                LucideIconView(name: icon, color: chore.recencyColor, size: 22)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+                Text(chore.name)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(chore.elapsedLabel)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            DoneButton(choreSyncId: chore.syncId, compact: false)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+
+    // systemSmall has no Android analogue (tiles have one shape); a vertical
+    // arrangement of the same parts, with Done full-width at the bottom.
+    private func small(_ chore: SnapshotChore) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(chore.recencyColor)
+                    .frame(width: 6, height: 28)
+                if let icon = chore.icon {
+                    LucideIconView(name: icon, color: chore.recencyColor, size: 22)
+                }
+                Spacer(minLength: 0)
+            }
+            Text(chore.name)
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+            Text(chore.elapsedLabel)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            Button(intent: CompleteChoreIntent(choreSyncId: chore.syncId)) {
+                Text("Done")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+                    .background(Color(hexString: "#22c55e"))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+struct SingleChoreWidget: Widget {
+    let kind = "SingleChoreWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: SelectChoreIntent.self,
+            provider: ConfiguredChoreProvider()
+        ) { entry in
+            SingleChoreWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Chore")
+        .description("One chore and how long it has been, with one-tap Done. Edit the widget to pick which.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}

--- a/ios/App/GlanceWidgets/SnapshotProvider.swift
+++ b/ios/App/GlanceWidgets/SnapshotProvider.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+import WidgetKit
+
+// The one TimelineProvider every lastGLANCE widget shares. All of them render
+// from the same App-Group snapshot and refresh on the same two signals — the
+// app pushing a new snapshot (reloadAllTimelines from the WidgetBridge plugin)
+// and the local date rolling over — so there is nothing widget-specific to
+// provide. Moved out of HeatmapWidget.swift when the Phase 2 widgets arrived.
+
+struct SnapshotEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetSnapshot
+    // Non-nil when there is nothing to draw and we know why. Rendered in place
+    // of the widget's content so the failure names itself instead of looking
+    // like a widget that never finished loading.
+    let problem: String?
+
+    init(date: Date, snapshot: WidgetSnapshot, problem: String? = nil) {
+        self.date = date
+        self.snapshot = snapshot
+        self.problem = problem
+    }
+
+    init(date: Date, load: SnapshotLoad) {
+        self.init(date: date, snapshot: load.snapshot, problem: load.problem)
+    }
+}
+
+struct SnapshotProvider: TimelineProvider {
+
+    func placeholder(in context: Context) -> SnapshotEntry {
+        SnapshotEntry(date: Date(), snapshot: WidgetSnapshot())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SnapshotEntry) -> Void) {
+        completion(SnapshotEntry(date: Date(), load: SnapshotLoad.read()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<SnapshotEntry>) -> Void) {
+        let now = Date()
+        let entry = SnapshotEntry(date: now, load: SnapshotLoad.read())
+
+        // WidgetKit is not a live process, so the only two things that can change
+        // what a widget should show are (a) the app pushing a new snapshot,
+        // which calls reloadAllTimelines directly, and (b) the date rolling over,
+        // which shifts the heatmap by a column and every "Xd ago" by a day. Only
+        // (b) needs a scheduled refresh, so ask for exactly one, at the next
+        // local midnight.
+        //
+        // Computed by adding a day to the start of today, NOT with
+        // Calendar.nextDate(after:matching:matchingPolicy:) — a search API is
+        // more machinery than "next midnight" needs, and direct arithmetic has
+        // nothing in it to go wrong.
+        let calendar = Calendar.current
+        var refresh = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
+            ?? now.addingTimeInterval(3600)
+        // A refresh date must be in the future or WidgetKit has nothing to
+        // schedule; belt-and-braces against a DST edge or a nil from the calendar.
+        if refresh <= now { refresh = now.addingTimeInterval(3600) }
+
+        completion(Timeline(entries: [entry], policy: .after(refresh)))
+    }
+}
+
+// Shown instead of a widget's content when the snapshot could not be read. An
+// empty widget is a legitimate render (a user with no data yet), so it must
+// not double as the error state.
+struct SnapshotProblemView: View {
+    let message: String
+    var large = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Spacer(minLength: 0)
+            Wordmark(size: large ? 26 : 20)
+            Text(message)
+                .font(.system(size: large ? 15 : 13))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// The lastGLANCE wordmark, shared by every widget's footer and empty state.
+struct Wordmark: View {
+    let size: Double
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text("last")
+                .font(.system(size: size, weight: .bold))
+                .foregroundStyle(.primary)
+            Text("GLANCE")
+                .font(.system(size: size, weight: .bold))
+                .italic()
+                .foregroundStyle(brandGreen)
+        }
+    }
+}
+
+let brandGreen = Color(red: 0x3D / 255, green: 0xDC / 255, blue: 0x84 / 255)

--- a/ios/App/GlanceWidgets/SoonListWidget.swift
+++ b/ios/App/GlanceWidgets/SoonListWidget.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import WidgetKit
+
+// Phase 2: the "Soon" list widget — the chores aged into the amber/red zone,
+// most-overdue first, each with one-tap Done. The iOS counterpart of
+// SoonListWidget.kt; row anatomy, colours and type sizes mirror the Glance
+// rows so the platforms read as one product.
+//
+// One structural difference from Android: Glance lists scroll, WidgetKit
+// widgets never do. So the row count is fixed per family and a "+N more" line
+// stands in for the tail rather than pretending it is not there.
+
+private func rowCapacity(_ family: WidgetFamily) -> Int {
+    family == .systemLarge ? 9 : 4
+}
+
+// The one-tap Done chip, shared by the list rows and the single-chore widget.
+// Runs CompleteChoreIntent in-process — the widget updates immediately, offline,
+// and the app replays the queued completion on next foreground.
+struct DoneButton: View {
+    let choreSyncId: String
+    var compact = true
+
+    var body: some View {
+        Button(intent: CompleteChoreIntent(choreSyncId: choreSyncId)) {
+            Text("Done")
+                .font(.system(size: compact ? 12 : 13, weight: .medium))
+                .foregroundStyle(.white)
+                .padding(.horizontal, compact ? 10 : 12)
+                .padding(.vertical, compact ? 5 : 6)
+                .background(Color(hexString: "#22c55e"))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// One chore as a list row: recency bar, tinted icon, name over elapsed text,
+// Done. Same anatomy as ChoreListRow in the Kotlin widget (bar 5x26 r2, icon
+// 18, name 14 medium, elapsed 11).
+struct ChoreRowView: View {
+    let chore: SnapshotChore
+
+    var body: some View {
+        HStack(spacing: 8) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(chore.recencyColor)
+                .frame(width: 5, height: 26)
+            if let icon = chore.icon {
+                LucideIconView(name: icon, color: chore.recencyColor, size: 18)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+                Text(chore.name)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(chore.elapsedLabel)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            DoneButton(choreSyncId: chore.syncId)
+        }
+    }
+}
+
+struct SoonListWidgetView: View {
+    var entry: SnapshotEntry
+
+    @Environment(\.widgetFamily) private var family
+
+    var body: some View {
+        Group {
+            if let problem = entry.problem {
+                SnapshotProblemView(message: problem)
+            } else {
+                content
+            }
+        }
+        .containerBackground(for: .widget) {
+            Color(uiColor: .systemBackground)
+        }
+    }
+
+    private var content: some View {
+        let capacity = rowCapacity(family)
+        let all = entry.snapshot.soonList(limit: 100)
+        let shown = Array(all.prefix(capacity))
+        let hidden = all.count - shown.count
+
+        return VStack(alignment: .leading, spacing: 0) {
+            Text("SOON")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 6)
+
+            if shown.isEmpty {
+                Spacer(minLength: 0)
+                Text("All caught up")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.primary)
+                Spacer(minLength: 0)
+                Wordmark(size: 16)
+            } else {
+                ForEach(shown, id: \.syncId) { chore in
+                    ChoreRowView(chore: chore)
+                        .padding(.vertical, 4)
+                }
+                if hidden > 0 {
+                    Text("+\(hidden) more")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 2)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+struct SoonListWidget: Widget {
+    let kind = "SoonListWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: SnapshotProvider()) { entry in
+            SoonListWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Soon")
+        .description("Chores that are due soon or overdue, with one-tap Done.")
+        .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}

--- a/src/hooks/usePendingCompletions.ts
+++ b/src/hooks/usePendingCompletions.ts
@@ -1,13 +1,14 @@
 import { useEffect } from 'react'
-import { Capacitor } from '@capacitor/core'
 import { drainWidgetCompletions } from '@/native/pendingCompletions'
+import { isNativeShell } from '@/native/platform'
 
 // Drains widget-originated completions into the DB on mount and whenever the app
 // returns to the foreground (when a widget tap may have queued one while we were
-// away). No-op off Android.
+// away). Runs in both native shells — Android widget taps and iOS AppIntent taps
+// feed the same queue shape — and no-ops on web/PWA.
 export function usePendingCompletions(): void {
   useEffect(() => {
-    if (Capacitor.getPlatform() !== 'android') return
+    if (!isNativeShell()) return
 
     drainWidgetCompletions()
     const onVisibility = () => {


### PR DESCRIPTION
**Stack 3 of 5** — targets the icons PR (#280); merge in order.

## What's in here

- **SoonListWidget** (medium/large): soon/overdue chores, most-overdue first, same row anatomy as the Glance rows. WidgetKit lists don't scroll, so rows cap per family (4/9) with a "+N more" line.
- **SingleChoreWidget** (small/medium): configurable via `AppIntentConfiguration` — long-press → Edit Widget replaces Android's entire `SingleChoreConfigActivity`. Unconfigured tracks most-overdue (Android's fallback). A configured chore that vanished shows caught-up rather than silently switching chores.
- **CompleteChoreIntent + CompletionStore** — the Done button. Runs in the widget process, mints the lowercase-UUID `sync_id` and millisecond-UTC `completedAt` exactly as the Kotlin tap path does, queues via the App Group, folds the completion into the snapshot optimistically (chore → fresh, counts recomputed, heatmap +1), reloads all timelines. The fold mutates **raw JSON** — the Codable model is lenient/lossy by design and a round trip would drop unknown fields.
- **SnapshotProvider refactor**: entry/provider/problem-view extracted from HeatmapWidget for all widgets to share.
- **JS**: `usePendingCompletions` runs in both shells — iOS taps feed the identical queue shape, and the existing drain (idempotent on `sync_id`) replays them unchanged.

## The Phase 2 exit criteria to test on device

Tap Done on the widget → updates immediately offline → reopening the app logs exactly one completion → no double-count across a sync round-trip. Requires iOS 17+ (the extension's floor).

---
_Generated by [Claude Code](https://claude.ai/code/session_015XHvf3dadyFScUW6vxUQaG)_