### PR TITLE
Fit the Soon list to the widget instead of guessing a row count

### DIFF
--- a/docs/ios-native-features-plan.md
+++ b/docs/ios-native-features-plan.md
@@ -145,9 +145,13 @@ win. The Android plan estimates it ~70-80% portable.
     resource ID, so forcing it there would churn every pending notification on
     each build to fix a problem it cannot have.
   - the 64-notification cap — iOS-only; see below.
-  One thing the plan expected to be a fork turned out not to be: `handleNotificationAction`
-  already notes that the plugin opens the app for **every** action on both
-  platforms, so "Mark done" was never going to run headless anywhere.
+  **Device-verified 2026-08:** delivery works, and notification actions came out
+  BETTER than planned — on iOS "Mark done" does not foreground the app at all;
+  the plugin retains the action and replays it on next launch, where the
+  existing drain logs it. That is the headless completion the plan assumed was
+  impossible, courtesy of the plugin's retained-action path. Android still
+  opens the app (its plugin behavior); the divergence favours iOS and needs no
+  code.
 - Handle **iOS specifics**: no exact-alarm permission prompt (drop that branch on
   iOS); the app icon is used instead of a monochrome `smallIcon`; the **64
   pending-notification cap**; actions declared as `UNNotificationCategory` (the

--- a/ios/App/GlanceWidgets/SoonListWidget.swift
+++ b/ios/App/GlanceWidgets/SoonListWidget.swift
@@ -7,12 +7,13 @@ import WidgetKit
 // rows so the platforms read as one product.
 //
 // One structural difference from Android: Glance lists scroll, WidgetKit
-// widgets never do. So the row count is fixed per family and a "+N more" line
-// stands in for the tail rather than pretending it is not there.
-
-private func rowCapacity(_ family: WidgetFamily) -> Int {
-    family == .systemLarge ? 9 : 4
-}
+// widgets never do — a widget is a static render with tappable islands, so
+// there is no scrolling to offer. Instead the row count adapts: ViewThatFits
+// measures candidate lists from ten rows down and renders the most that
+// actually fit this family on this device, with a "+N more" line standing in
+// for the tail. Measured, not guessed — a hardcoded per-family cap overflowed
+// on the iPad mini (SwiftUI centers overflowing content, clipping both ends,
+// which read as a list stuck mid-scroll).
 
 // The one-tap Done chip, shared by the list rows and the single-chore widget.
 // Runs CompleteChoreIntent in-process — the widget updates immediately, offline,
@@ -67,8 +68,6 @@ struct ChoreRowView: View {
 struct SoonListWidgetView: View {
     var entry: SnapshotEntry
 
-    @Environment(\.widgetFamily) private var family
-
     var body: some View {
         Group {
             if let problem = entry.problem {
@@ -83,39 +82,66 @@ struct SoonListWidgetView: View {
     }
 
     private var content: some View {
-        let capacity = rowCapacity(family)
         let all = entry.snapshot.soonList(limit: 100)
-        let shown = Array(all.prefix(capacity))
-        let hidden = all.count - shown.count
 
-        return VStack(alignment: .leading, spacing: 0) {
-            Text("SOON")
-                .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(.secondary)
-                .padding(.bottom, 6)
-
-            if shown.isEmpty {
-                Spacer(minLength: 0)
-                Text("All caught up")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.primary)
-                Spacer(minLength: 0)
-                Wordmark(size: 16)
+        return Group {
+            if all.isEmpty {
+                VStack(alignment: .leading, spacing: 0) {
+                    header
+                    Spacer(minLength: 0)
+                    Text("All caught up")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.primary)
+                    Spacer(minLength: 0)
+                    Wordmark(size: 16)
+                }
             } else {
-                ForEach(shown, id: \.syncId) { chore in
-                    ChoreRowView(chore: chore)
-                        .padding(.vertical, 4)
+                // Candidates in descending order; ViewThatFits renders the first
+                // whose measured height fits, falling back to the last (a single
+                // row) when even that overflows. The candidates must contain no
+                // Spacer or flexible frame — flexible content always "fits", and
+                // the measurement would be meaningless.
+                ViewThatFits(in: .vertical) {
+                    candidate(all, 10)
+                    candidate(all, 9)
+                    candidate(all, 8)
+                    candidate(all, 7)
+                    candidate(all, 6)
+                    candidate(all, 5)
+                    candidate(all, 4)
+                    candidate(all, 3)
+                    candidate(all, 2)
+                    candidate(all, 1)
                 }
-                if hidden > 0 {
-                    Text("+\(hidden) more")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .padding(.top, 2)
-                }
-                Spacer(minLength: 0)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var header: some View {
+        Text("SOON")
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(.secondary)
+            .padding(.bottom, 6)
+    }
+
+    private func candidate(_ all: [SnapshotChore], _ count: Int) -> some View {
+        let shown = Array(all.prefix(count))
+        let hidden = all.count - shown.count
+
+        return VStack(alignment: .leading, spacing: 0) {
+            header
+            ForEach(shown, id: \.syncId) { chore in
+                ChoreRowView(chore: chore)
+                    .padding(.vertical, 4)
+            }
+            if hidden > 0 {
+                Text("+\(hidden) more")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 2)
+            }
+        }
     }
 }
 

--- a/src/native/reminders.ts
+++ b/src/native/reminders.ts
@@ -305,10 +305,14 @@ async function sendChoreToDayGlance(choreSyncId: string): Promise<void> {
   await emitCreateIntent({ ...chore, last_completed_at: null, elapsed_days: null } as ChoreWithLastCompletion)
 }
 
-// Routes a notification interaction. The plugin opens the app for every action
-// (no background actions in the official plugin), then replays this — retained
-// across a cold start, so it survives a killed app. 'tap' is the body press;
-// 'mark_done' / 'send_dg' are the action buttons.
+// Routes a notification interaction. Platform behavior differs, observed on
+// device (2026-08): on Android every action opens the app, then the plugin
+// replays this. On iOS an action button does NOT foreground the app — the
+// system runs the extension-less action in the background, the plugin retains
+// it, and it replays here on the next launch, so a "Mark done" tapped at night
+// is logged the next time the app opens. Retained across a cold start on both
+// platforms. 'tap' is the body press; 'mark_done' / 'send_dg' are the action
+// buttons.
 export function handleNotificationAction(actionId: string, extra: unknown): void {
   const choreSyncId = (extra as { choreSyncId?: string } | null)?.choreSyncId
   if (!choreSyncId) return


### PR DESCRIPTION
Fixes the on-device clipping in the Soon list widget (rows cut off top and bottom, reading as a list stuck mid-scroll).

## Cause

The hardcoded per-family row cap (4 medium / 9 large) was built on a bad estimate — a row's text stack is ~31pt, taller than the 26pt colour bar the estimate used. Nine rows overflowed the frame, and SwiftUI centres overflowing content, clipping both ends symmetrically.

## Why not scrolling

Widgets cannot scroll — WidgetKit renders a static snapshot whose only interactivity is buttons and links. Android's list scrolls because Glance widgets are live RemoteViews; that difference is structural, not an implementation gap.

## Fix

`ViewThatFits(in: .vertical)` walks candidate lists from ten rows down and renders the most that genuinely fit this family on this device, with "+N more" for the tail. Measured, not guessed — so it adapts across iPad mini / Pro / iPhone without per-device tuning. The candidates deliberately contain no Spacer/flexible frame (flexible content always "fits", which would make the measurement meaningless).

Also records the observed notification-action behaviour from the same device test: on iOS "Mark done" runs headless — the plugin retains the background action and replays it on next launch. Better than the planned open-the-app fork; comment and plan updated to match reality.

**Merge note:** after this merges I've already propagated the fix into the two open stacked PRs (#282, #283), so they will not conflict.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XHvf3dadyFScUW6vxUQaG)_