### PR TITLE
Share sheet: show what will be saved, and say Add instead of Post

### DIFF
--- a/ios/App/ShareExtension/ShareViewController.swift
+++ b/ios/App/ShareExtension/ShareViewController.swift
@@ -9,24 +9,97 @@ import UniformTypeIdentifiers
 // of MainActivity.captureSharedText, with the same preference order: a title
 // over the raw text/URL, because a page title makes a better chore name.
 //
+// The compose box is ALWAYS populated before the user acts. Text shares arrive
+// with contentText pre-filled by the system; page/URL shares arrive with an
+// empty box and only a URL attachment, so viewDidLoad walks the attachments and
+// puts the title (or URL) into the box itself. First shipped without that, and
+// a page share showed an empty sheet that saved something invisible on Post —
+// technically correct and terrible: the whole point of the sheet is seeing and
+// editing what will be saved.
+//
 // One deliberate UX difference from Android: an Android share launches the app
 // immediately; an iOS share extension cannot reliably open its containing app,
-// so the sheet's Post saves the name and the pre-filled form appears the next
-// time the app opens. The compose sheet is what makes that acceptable — the
-// user sees and can edit exactly what will be saved.
+// so confirming saves the name and the pre-filled form appears the next time
+// the app opens.
 class ShareViewController: SLComposeServiceViewController {
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        placeholder = "Chore name"
+        prefillFromAttachmentsIfEmpty()
+    }
+
+    override func presentationAnimationDidFinish() {
+        super.presentationAnimationDidFinish()
+        renamePostButton()
+    }
+
+    // The sheet's confirm button says "Post" — SLComposeServiceViewController
+    // was built for social feeds and offers no API to change it. The button is
+    // an ordinary bar item on the sheet's internal navigation bar, so retitle
+    // it there. Best-effort by design: if an iOS release rearranges the
+    // internals, the title quietly stays "Post" instead of anything breaking.
+    private func renamePostButton() {
+        let bars = children.compactMap { ($0 as? UINavigationController)?.navigationBar }
+            + (navigationController.map { [$0.navigationBar] } ?? [])
+        for bar in bars {
+            bar.topItem?.rightBarButtonItem?.title = "Add"
+        }
+    }
+
+    // Page/URL shares put nothing in the compose box. Fetch the same value
+    // didSelectPost would fall back to — title first, then URL — and make it
+    // visible and editable up front.
+    private func prefillFromAttachmentsIfEmpty() {
+        guard (contentText ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return }
+
+        let items = (extensionContext?.inputItems as? [NSExtensionItem]) ?? []
+
+        for item in items {
+            if let title = item.attributedTitle?.string.trimmingCharacters(in: .whitespacesAndNewlines),
+               !title.isEmpty {
+                setComposeText(title)
+                return
+            }
+        }
+
+        for item in items {
+            for provider in item.attachments ?? []
+            where provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
+                provider.loadItem(forTypeIdentifier: UTType.url.identifier) { [weak self] value, _ in
+                    let url = (value as? URL)?.absoluteString
+                        ?? (value as? Data).flatMap { String(data: $0, encoding: .utf8) }
+                    guard let url, !url.isEmpty else { return }
+                    DispatchQueue.main.async {
+                        self?.setComposeText(url)
+                    }
+                }
+                return
+            }
+        }
+    }
+
+    private func setComposeText(_ text: String) {
+        // Never clobber something the user has started typing in the meantime.
+        guard (contentText ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return }
+        textView.text = text
+        validateContent()
+    }
+
     override func isContentValid() -> Bool {
-        // Posting nothing is fine: the URL attachment may still supply the name.
+        // Confirming an empty box is allowed: a late-arriving URL attachment may
+        // still supply the name in didSelectPost's fallback walk.
         true
     }
 
     override func didSelectPost() {
         let typed = contentText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
-        // The user's edited text wins outright — it is literally what they asked
-        // to save. The attachment walk is only for shares that arrive with an
-        // empty compose box (Safari URL shares commonly do).
+        // The visible text wins outright — after the prefill above it is
+        // literally what the user saw and approved. The walk below only matters
+        // when the async URL prefill had not landed before they confirmed.
         if !typed.isEmpty {
             finish(with: typed)
             return
@@ -34,8 +107,6 @@ class ShareViewController: SLComposeServiceViewController {
 
         let items = (extensionContext?.inputItems as? [NSExtensionItem]) ?? []
 
-        // A provided title beats a raw URL, mirroring Android's EXTRA_SUBJECT
-        // preference.
         for item in items {
             if let title = item.attributedTitle?.string.trimmingCharacters(in: .whitespacesAndNewlines),
                !title.isEmpty {
@@ -44,7 +115,6 @@ class ShareViewController: SLComposeServiceViewController {
             }
         }
 
-        // Fall back to the first URL attachment's absolute string.
         for item in items {
             for provider in item.attachments ?? []
             where provider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
@@ -70,7 +140,7 @@ class ShareViewController: SLComposeServiceViewController {
     }
 
     override func configurationItems() -> [Any]! {
-        // No options below the compose box; the sheet is just text + Post.
+        // No options below the compose box; the sheet is just text + confirm.
         []
     }
 }


### PR DESCRIPTION
From the first device test of the share extension: sharing a web page produced an empty compose sheet that nonetheless saved the URL invisibly on confirm. Worked, but wrongly.

## What changed

- **Prefill up front.** Text shares already arrive with the box filled by the system; page/URL shares arrive empty with only a URL attachment. `viewDidLoad` now walks the attachments and puts the page title (or URL) into the box — visible and editable — instead of capturing it invisibly at Post time. A guard ensures the async prefill never clobbers text the user started typing; the Post-time fallback stays for the confirm-before-load race.
- **"Post" → "Add"** (best-effort). The word is baked into `SLComposeServiceViewController` with no API to change it, but the button is an ordinary bar item on the sheet's internal navigation bar and is retitled there. If an iOS release rearranges the internals, it quietly stays "Post" rather than breaking.
- **Placeholder "Chore name"** so the sheet is self-describing either way.

## Device check

Share a page from Brave/Safari → the box should now show the page title (or URL) already filled in, editable → Add → open lastGLANCE → form pre-filled with exactly what the sheet showed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XHvf3dadyFScUW6vxUQaG)_