### PR TITLE
Keychain-backed SecureStore for iOS

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		EA00000000000000000000C5 /* SoonListWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E5 /* SoonListWidget.swift */; };
 		EA00000000000000000000C6 /* SingleChoreWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E6 /* SingleChoreWidget.swift */; };
 		EA00000000000000000000C7 /* AddChoreWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E7 /* AddChoreWidget.swift */; };
+		EA00000000000000000000C9 /* SecureStorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E9 /* SecureStorePlugin.swift */; };
 		EB00000000000000000000C1 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000E1 /* ShareViewController.swift */; };
 		EB00000000000000000000C2 /* SharedDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F2 /* SharedDataStore.swift */; };
 		EB00000000000000000000B7 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000F9 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -102,6 +103,7 @@
 		EA00000000000000000000E5 /* SoonListWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoonListWidget.swift; sourceTree = "<group>"; };
 		EA00000000000000000000E6 /* SingleChoreWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleChoreWidget.swift; sourceTree = "<group>"; };
 		EA00000000000000000000E7 /* AddChoreWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChoreWidget.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E9 /* SecureStorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStorePlugin.swift; sourceTree = "<group>"; };
 		EB00000000000000000000E1 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		EB00000000000000000000F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EB00000000000000000000F8 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				EA00000000000000000000F3 /* WidgetBridgePlugin.swift */,
+				EA00000000000000000000E9 /* SecureStorePlugin.swift */,
 			);
 			path = plugins;
 			sourceTree = "<group>";
@@ -372,6 +375,7 @@
 				7A4E51042E3A9A0100C4F2D1 /* VaultSsePlugin.swift in Sources */,
 				EA00000000000000000000B1 /* SharedDataStore.swift in Sources */,
 				EA00000000000000000000B2 /* WidgetBridgePlugin.swift in Sources */,
+				EA00000000000000000000C9 /* SecureStorePlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/BridgeViewController.swift
+++ b/ios/App/App/BridgeViewController.swift
@@ -10,5 +10,6 @@ class BridgeViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(VaultSsePlugin())
         bridge?.registerPluginInstance(WidgetBridgePlugin())
+        bridge?.registerPluginInstance(SecureStorePlugin())
     }
 }

--- a/ios/App/App/plugins/SecureStorePlugin.swift
+++ b/ios/App/App/plugins/SecureStorePlugin.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Capacitor
+import Security
+
+// Keychain-backed secret storage for sync/vault/intents credentials — the iOS
+// counterpart of SecureStorePlugin.java (issue #210). Same JS interface
+// (src/native/secureStore.ts: get/set/delete), same contract: secrets are no
+// longer plaintext-at-rest in WebView storage, and material that cannot be
+// read on THIS device reports as absent, so the app falls back to asking for
+// credentials again rather than failing cryptically.
+//
+// Where Android builds that contract by hand (AES-GCM ciphertext in prefs, key
+// in the Android Keystore), the iOS Keychain provides it directly:
+// kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly stores the item encrypted
+// under device-bound keys, unreadable in any backup restored to different
+// hardware — the same "useless off-device" property the Android comment
+// promises. AfterFirstUnlock (not WhenUnlocked) because the app's sync can run
+// while the device is locked-but-booted, and reminders re-schedule from a
+// background refresh someday; first-unlock is the standard bar for
+// network-credential material.
+//
+// Registered in BridgeViewController.capacitorDidLoad() — app-local plugins
+// are never auto-discovered on iOS.
+@objc(SecureStorePlugin)
+public class SecureStorePlugin: CAPPlugin, CAPBridgedPlugin {
+
+    public let identifier = "SecureStorePlugin"
+    public let jsName = "SecureStore"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "get", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "set", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "delete", returnType: CAPPluginReturnPromise),
+    ]
+
+    // Same namespace the Android prefs file uses; account = the caller's key.
+    private let service = "lastglance_secure_store"
+
+    private func baseQuery(for key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+
+    @objc func get(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), !key.isEmpty else {
+            call.reject("missing key")
+            return
+        }
+        var query = baseQuery(for: key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess,
+           let data = result as? Data,
+           let value = String(data: data, encoding: .utf8) {
+            call.resolve(["value": value])
+        } else {
+            // Absent, undecodable, or unreadable on this device: all report as
+            // null — the contract's "ask for credentials again" path.
+            call.resolve(["value": NSNull()])
+        }
+    }
+
+    @objc func set(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), !key.isEmpty else {
+            call.reject("missing key")
+            return
+        }
+        guard let value = call.getString("value") else {
+            call.reject("missing value")
+            return
+        }
+        let data = Data(value.utf8)
+
+        // Update-then-add: SecItemUpdate cannot create and SecItemAdd cannot
+        // replace, so the standard upsert is a try of each.
+        let update: [String: Any] = [kSecValueData as String: data]
+        var status = SecItemUpdate(baseQuery(for: key) as CFDictionary, update as CFDictionary)
+        if status == errSecItemNotFound {
+            var add = baseQuery(for: key)
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            status = SecItemAdd(add as CFDictionary, nil)
+        }
+        if status == errSecSuccess {
+            call.resolve()
+        } else {
+            // Loud, unlike get: a write that silently vanished would strand the
+            // credentials in the localStorage the shim is migrating away from.
+            call.reject("keychain write failed (\(status))")
+        }
+    }
+
+    @objc func delete(_ call: CAPPluginCall) {
+        guard let key = call.getString("key"), !key.isEmpty else {
+            call.reject("missing key")
+            return
+        }
+        let status = SecItemDelete(baseQuery(for: key) as CFDictionary)
+        if status == errSecSuccess || status == errSecItemNotFound {
+            call.resolve()
+        } else {
+            call.reject("keychain delete failed (\(status))")
+        }
+    }
+}

--- a/src/native/secureStore.ts
+++ b/src/native/secureStore.ts
@@ -1,11 +1,16 @@
-import { Capacitor, registerPlugin } from '@capacitor/core'
+import { registerPlugin } from '@capacitor/core'
+import { isNativeShell } from './platform'
 
-// Native bridge to Keystore-backed secret storage (issue #210). Values are
-// AES-GCM ciphertext in a private SharedPreferences file with the key in the
-// Android Keystore, so secrets are no longer plaintext-at-rest in WebView
-// storage. Ciphertext restored onto a different device cannot decrypt and
-// reads as absent — the app falls back to asking for credentials again.
-// Android-only; on web/PWA and iOS callers keep their existing storage.
+// Native bridge to hardware-backed secret storage (issue #210), so secrets are
+// no longer plaintext-at-rest in WebView storage. Both shells implement the
+// same three-method interface with the same contract — material that cannot be
+// read on THIS device reports as absent, and the app falls back to asking for
+// credentials again:
+//  - Android (SecureStorePlugin.java): AES-GCM ciphertext in private prefs,
+//    key in the Android Keystore.
+//  - iOS (SecureStorePlugin.swift): Keychain items stored with
+//    AfterFirstUnlockThisDeviceOnly, encrypted under device-bound keys.
+// On web/PWA callers keep their existing storage.
 export interface SecureStorePlugin {
   // Resolve the stored value, or null when absent or undecryptable.
   get(options: { key: string }): Promise<{ value: string | null }>
@@ -17,7 +22,7 @@ const SecureStore = registerPlugin<SecureStorePlugin>('SecureStore')
 
 // The shim and key hooks must only engage where the plugin exists — anywhere
 // else the fallback is the status quo (localStorage / IndexedDB).
-export const isSecureStoreAvailable = Capacitor.getPlatform() === 'android'
+export const isSecureStoreAvailable = isNativeShell()
 
 export async function secureGet(key: string): Promise<string | null> {
   const res = await SecureStore.get({ key })


### PR DESCRIPTION
Closes the last real security gap on iOS: sync/vault/intents credentials sat plaintext in WebView localStorage because `isSecureStoreAvailable` was Android-only.

## What's in here

- **`SecureStorePlugin.swift`** — the same three-method interface as the Android Keystore implementation (get/set/delete), against the iOS Keychain. Same contract: material unreadable on *this* device reports as absent, and the app asks for credentials again. `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` gives the device-bound "useless off-device" property Android builds by hand — items are encrypted under device-bound keys and don't restore to different hardware. AfterFirstUnlock (not WhenUnlocked) because network credentials get read while the device is locked-but-booted.
- `get()` maps every unreadable case to null; `set()` **rejects loudly** — a silently vanished write would strand credentials in the localStorage the shim migrates away from.
- Registered in `BridgeViewController` (app-local plugins are never auto-discovered).
- **JS change is one line**: `isSecureStoreAvailable` now covers both shells. The shim and key hooks engage unchanged — they were written against the interface, not the platform.

## What happens on first launch

The existing `secureConfigShim` migrates stored credentials out of localStorage into the Keychain automatically — the same migration Android shipped with #210.

## Device checks

Sync still works after updating (the migration), and still works after a device restart *before first unlock isn't testable practically — just confirm normal foreground sync*. If credentials ever appear wiped after this build: that's the migration failing, tell Claude before re-entering them.

**Merge before the accessory-widgets PR** (it stacks on this branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_015XHvf3dadyFScUW6vxUQaG)_