### PR TITLE
Lock Screen widget and Control Center control

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		EA00000000000000000000C5 /* SoonListWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E5 /* SoonListWidget.swift */; };
 		EA00000000000000000000C6 /* SingleChoreWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E6 /* SingleChoreWidget.swift */; };
 		EA00000000000000000000C7 /* AddChoreWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E7 /* AddChoreWidget.swift */; };
+		EA00000000000000000000C8 /* AccessoryWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E8 /* AccessoryWidgets.swift */; };
 		EA00000000000000000000C9 /* SecureStorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E9 /* SecureStorePlugin.swift */; };
 		EB00000000000000000000C1 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000E1 /* ShareViewController.swift */; };
 		EB00000000000000000000C2 /* SharedDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F2 /* SharedDataStore.swift */; };
@@ -103,6 +104,7 @@
 		EA00000000000000000000E5 /* SoonListWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoonListWidget.swift; sourceTree = "<group>"; };
 		EA00000000000000000000E6 /* SingleChoreWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleChoreWidget.swift; sourceTree = "<group>"; };
 		EA00000000000000000000E7 /* AddChoreWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChoreWidget.swift; sourceTree = "<group>"; };
+		EA00000000000000000000E8 /* AccessoryWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessoryWidgets.swift; sourceTree = "<group>"; };
 		EA00000000000000000000E9 /* SecureStorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStorePlugin.swift; sourceTree = "<group>"; };
 		EB00000000000000000000E1 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		EB00000000000000000000F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				EA00000000000000000000E5 /* SoonListWidget.swift */,
 				EA00000000000000000000E6 /* SingleChoreWidget.swift */,
 				EA00000000000000000000E7 /* AddChoreWidget.swift */,
+				EA00000000000000000000E8 /* AccessoryWidgets.swift */,
 				EA00000000000000000000FA /* LucidePath.swift */,
 				EA00000000000000000000FB /* LucideIcons.generated.swift */,
 				EA00000000000000000000F7 /* Info.plist */,
@@ -394,6 +397,7 @@
 				EA00000000000000000000C5 /* SoonListWidget.swift in Sources */,
 				EA00000000000000000000C6 /* SingleChoreWidget.swift in Sources */,
 				EA00000000000000000000C7 /* AddChoreWidget.swift in Sources */,
+				EA00000000000000000000C8 /* AccessoryWidgets.swift in Sources */,
 				EA00000000000000000000B8 /* LucidePath.swift in Sources */,
 				EA00000000000000000000B9 /* LucideIcons.generated.swift in Sources */,
 			);

--- a/ios/App/GlanceWidgets/AccessoryWidgets.swift
+++ b/ios/App/GlanceWidgets/AccessoryWidgets.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import WidgetKit
+import AppIntents
+
+// Lock Screen widget + Control Center control — the closest iOS analogues of
+// Android's two Quick Settings tiles (tiles/QsTiles.kt: at-a-glance status and
+// one-tap add). The plan's stretch goal.
+//
+// Accessory families render in the system's tinted/monochrome style, so there
+// are no brand colours here — hierarchy comes from type weight alone, and the
+// system applies its own vibrancy. Content stays to the counts and the top
+// chore: a Lock Screen glance earns its place by being readable in under a
+// second.
+
+// MARK: - Lock Screen widget
+
+struct AccessoryStatusView: View {
+    var entry: SnapshotEntry
+
+    @Environment(\.widgetFamily) private var family
+
+    private var overdue: Int { entry.snapshot.counts.overdue }
+    private var soon: Int { entry.snapshot.counts.soon }
+
+    var body: some View {
+        Group {
+            switch family {
+            case .accessoryCircular: circular
+            case .accessoryInline: inline
+            default: rectangular
+            }
+        }
+        .containerBackground(for: .widget) { Color.clear }
+        .widgetURL(soonURL)
+    }
+
+    // A count with a caption; AccessoryWidgetBackground gives the standard
+    // frosted disc the system uses for numeric complications.
+    private var circular: some View {
+        ZStack {
+            AccessoryWidgetBackground()
+            VStack(spacing: 0) {
+                Text("\(overdue)")
+                    .font(.system(size: 20, weight: .bold, design: .rounded))
+                Text("due")
+                    .font(.system(size: 10))
+            }
+        }
+    }
+
+    private var inline: some View {
+        // One line, no layout to control. ViewThatFits picks the longer wording
+        // when the slot allows it (above the clock the slot is generous, but
+        // its width varies by device and date length).
+        ViewThatFits {
+            Text("lastGLANCE · \(overdue) overdue, \(soon) soon")
+            Text("\(overdue) overdue · \(soon) soon")
+            Text("\(overdue) overdue")
+        }
+    }
+
+    private var rectangular: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("lastGLANCE")
+                .font(.system(size: 12, weight: .bold))
+            if let top = entry.snapshot.mostOverdue, overdue + soon > 0 {
+                Text(top.name)
+                    .font(.system(size: 14, weight: .semibold))
+                    .lineLimit(1)
+                Text("\(top.elapsedLabel) · \(overdue) overdue")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("All caught up")
+                    .font(.system(size: 14))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct AccessoryStatusWidget: Widget {
+    let kind = "AccessoryStatusWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: SnapshotProvider()) { entry in
+            AccessoryStatusView(entry: entry)
+        }
+        .configurationDisplayName("Overdue at a glance")
+        .description("How many chores need attention, on your Lock Screen.")
+        .supportedFamilies([.accessoryCircular, .accessoryRectangular, .accessoryInline])
+    }
+}
+
+// MARK: - Control Center control (iOS 18+)
+
+// Opens the app straight into the new-chore form — the Quick Settings
+// add-chore tile, relocated to where iOS puts such things. The intent writes
+// the same deep-link token every other entry point uses and lets
+// openAppWhenRun bring the app forward; the web router does the rest.
+@available(iOS 18.0, *)
+struct OpenAddChoreIntent: AppIntent {
+    static let title: LocalizedStringResource = "Add chore"
+    static let isDiscoverable = false
+    static let openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        SharedDataStore.writePendingDeepLink("action:add")
+        return .result()
+    }
+}
+
+@available(iOS 18.0, *)
+struct AddChoreControl: ControlWidget {
+    let kind = "AddChoreControl"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: kind) {
+            ControlWidgetButton(action: OpenAddChoreIntent()) {
+                Label("Add chore", systemImage: "plus.circle")
+            }
+        }
+        .displayName("Add chore")
+        .description("Open lastGLANCE ready to add a new chore.")
+    }
+}

--- a/ios/App/GlanceWidgets/GlanceWidgetsBundle.swift
+++ b/ios/App/GlanceWidgets/GlanceWidgetsBundle.swift
@@ -12,5 +12,15 @@ struct GlanceWidgetsBundle: WidgetBundle {
         SoonListWidget()
         SingleChoreWidget()
         AddChoreWidget()
+        AccessoryStatusWidget()
+        // Control Center controls are iOS 18+; the builder's
+        // limited-availability support keeps the rest of the bundle on the
+        // extension's 17.0 floor. If this if-availability form fails to
+        // compile on some toolchain, the fallback is bumping the extension
+        // target to 18.0 and dropping the check - a deliberate trade recorded
+        // in the accessory-widgets PR.
+        if #available(iOSApplicationExtension 18.0, *) {
+            AddChoreControl()
+        }
     }
 }


### PR DESCRIPTION
The plan's stretch goal — the iOS analogues of Android's Quick Settings tiles. **Stacks on the Keychain PR (#290); merge that first.**

## What's in here

- **AccessoryStatusWidget** (Lock Screen, all three faces, from the same snapshot provider as everything else):
  - *circular* — overdue count on the system's frosted disc
  - *inline* — counts on one line above the clock (`ViewThatFits` picks the longest wording the slot allows)
  - *rectangular* — top overdue chore + elapsed, or "All caught up"
  - No brand colors — accessory families render in the system's tinted style, so hierarchy is type weight only. Every face deep-links to Soon.
- **AddChoreControl** (Control Center, iOS 18+): a button whose AppIntent writes the same `action:add` token as every other entry point, with `openAppWhenRun` bringing the app to the new-chore form.

## The one compile risk

The control is gated with `if #available(iOSApplicationExtension 18.0, *)` inside the `WidgetBundle` body, relying on the builder's limited-availability support, so the rest of the bundle keeps the extension's 17.0 floor. This is the least-certain Swift in the PR. If it fails to compile, the recorded fallback is bumping the extension target to 18.0 and dropping the check — losing widgets on iOS 17 devices only.

## Device checks

1. Lock Screen → customize → add the lastGLANCE widget in circular/rectangular/inline slots; confirm counts and that tapping unlocks into the Soon view.
2. Control Center → add a control → lastGLANCE "Add chore" → tapping opens the app on the new-chore form.
3. Both should update within a foreground cycle of completing a chore (same snapshot push as the Home Screen widgets).

---
_Generated by [Claude Code](https://claude.ai/code/session_015XHvf3dadyFScUW6vxUQaG)_