### PR TITLE
Control Center Add chore: chain an OpenURLIntent instead of openAppWhenRun

### DIFF
--- a/ios/App/GlanceWidgets/AccessoryWidgets.swift
+++ b/ios/App/GlanceWidgets/AccessoryWidgets.swift
@@ -95,18 +95,28 @@ struct AccessoryStatusWidget: Widget {
 // MARK: - Control Center control (iOS 18+)
 
 // Opens the app straight into the new-chore form — the Quick Settings
-// add-chore tile, relocated to where iOS puts such things. The intent writes
-// the same deep-link token every other entry point uses and lets
-// openAppWhenRun bring the app forward; the web router does the rest.
+// add-chore tile, relocated to where iOS puts such things.
+//
+// The intent's ONLY job is to hand back an OpenURLIntent for the same
+// lastglance:// URL every other entry point uses; the app then receives it
+// through the AppDelegate URL path, which is device-verified. Two designs
+// that look right do not work from a control, learned the hard way:
+//  - `openAppWhenRun` alone is ignored when the intent runs in the widget
+//    extension process — which is exactly where a control button's intent
+//    runs. The tap performed, wrote its token, and nothing opened.
+//  - Writing the pending token from the intent also had a warm-open race:
+//    the app's foreground drain could run before the token landed.
+// Chaining OpenURLIntent solves both: the system opens the URL itself, and
+// the token is minted by AppDelegate on receipt, exactly as for a widget tap.
 @available(iOS 18.0, *)
 struct OpenAddChoreIntent: AppIntent {
     static let title: LocalizedStringResource = "Add chore"
     static let isDiscoverable = false
     static let openAppWhenRun = true
 
-    func perform() async throws -> some IntentResult {
-        SharedDataStore.writePendingDeepLink("action:add")
-        return .result()
+    @MainActor
+    func perform() async throws -> some IntentResult & OpensIntent {
+        .result(opensIntent: OpenURLIntent(URL(string: "lastglance://action/add")!))
     }
 }
 


### PR DESCRIPTION
Fixes the Control Center button doing nothing on tap.

## Cause

A control button's intent runs in the **widget extension process**, and `openAppWhenRun` is silently ignored there — the intent performed, wrote its pending token, and nothing was permitted to open the app. (The Lock Screen widget faces are unaffected — they use `widgetURL`, a different mechanism.)

## Fix

`perform()` now returns `.result(opensIntent: OpenURLIntent(lastglance://action/add))` — the documented composition for opening the app from a control. The system opens the URL itself, which routes through the AppDelegate URL path every widget body-tap already uses (device-verified). The token write is deleted entirely; AppDelegate mints it on URL receipt, which also removes a warm-open ordering race the old design had.

## Device check

Control Center → tap "Add chore" → app opens on the new-chore form, from both a closed and a backgrounded app. You may need to remove/re-add the control after updating if it renders stale.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XHvf3dadyFScUW6vxUQaG)_