### PR TITLE
Add a language picker with an explicit override

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -22,6 +22,7 @@
     "done": "Fertig",
     "edit": "Bearbeiten",
     "settings": "Einstellungen",
+    "language": "Sprache",
     "subscription": "Abo"
   },
   "activityLog": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -22,6 +22,7 @@
     "done": "Done",
     "edit": "Edit",
     "settings": "Settings",
+    "language": "Language",
     "subscription": "Subscription"
   },
   "activityLog": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -22,6 +22,7 @@
     "done": "Listo",
     "edit": "Editar",
     "settings": "Ajustes",
+    "language": "Idioma",
     "subscription": "Suscripción"
   },
   "activityLog": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -22,6 +22,7 @@
     "done": "Terminer",
     "edit": "Modifier",
     "settings": "Paramètres",
+    "language": "Langue",
     "subscription": "Abonnement"
   },
   "activityLog": {

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -22,6 +22,7 @@
     "done": "Fine",
     "edit": "Modifica",
     "settings": "Impostazioni",
+    "language": "Lingua",
     "subscription": "Abbonamento"
   },
   "activityLog": {

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -22,6 +22,7 @@
     "done": "Concluído",
     "edit": "Editar",
     "settings": "Definições",
+    "language": "Idioma",
     "subscription": "Subscrição"
   },
   "activityLog": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Pencil, Check, Sun, Moon, Archive, Plug, Cloud, CloudOff, RefreshCw, HelpCircle, Users, Settings, UserCircle, Clock, BadgeCheck, NotebookText } from 'lucide-react'
+import { Pencil, Check, Sun, Moon, Archive, Plug, Cloud, CloudOff, RefreshCw, HelpCircle, Users, Settings, UserCircle, Clock, BadgeCheck, NotebookText, Languages } from 'lucide-react'
 import { Ribbon } from '@/components/Ribbon/Ribbon'
 import { BackupModal } from '@/components/BackupModal/BackupModal'
 import { WelcomeModal } from '@/components/WelcomeModal/WelcomeModal'
@@ -8,6 +8,7 @@ import { IntegrationSettingsModal } from '@/components/IntegrationSettingsModal/
 import { SyncSettingsModal } from '@/components/SyncSettingsModal/SyncSettingsModal'
 import { PassphraseModal } from '@/components/PassphraseModal/PassphraseModal'
 import { HelpModal } from '@/components/HelpModal/HelpModal'
+import { LanguagePicker } from '@/components/LanguagePicker/LanguagePicker'
 import { ShortcutsModal } from '@/components/ShortcutsModal/ShortcutsModal'
 import { ActivityLogModal } from '@/components/ActivityLogModal/ActivityLogModal'
 import { JournalModal } from '@/components/JournalModal/JournalModal'
@@ -537,6 +538,11 @@ function AppInner() {
                         {item.label}
                       </button>
                     ))}
+                    <label className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm w-full text-slate-600 dark:text-slate-300">
+                      <Languages size={15} className="shrink-0" />
+                      <span className="sr-only">{t('app.language')}</span>
+                      <LanguagePicker className="flex-1 min-w-0 bg-transparent text-sm text-slate-600 dark:text-slate-300 focus:outline-none" />
+                    </label>
                   </div>
                 </>
               )}
@@ -616,6 +622,11 @@ function AppInner() {
               </button>
               <button onClick={() => setShowBackup(true)} className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors" aria-label={t('app.backupRestore')} data-tooltip={t('app.backupRestore')}><Archive size={15} /></button>
               <button onClick={() => setShowHelp(true)} className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors" aria-label={t('app.helpFeedback')} data-tooltip={t('app.helpFeedback')}><HelpCircle size={15} /></button>
+              <label className="flex items-center gap-1.5 p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors cursor-pointer" data-tooltip={t('app.language')}>
+                <Languages size={15} className="shrink-0" />
+                <span className="sr-only">{t('app.language')}</span>
+                <LanguagePicker className="bg-transparent text-sm text-slate-500 dark:text-slate-400 focus:outline-none cursor-pointer max-w-28" />
+              </label>
             </div>
           </div>
 

--- a/src/components/LanguagePicker/LanguagePicker.test.ts
+++ b/src/components/LanguagePicker/LanguagePicker.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { nativeLanguageName } from './nativeLanguageName'
+import { languages } from '@/locales'
+
+describe('nativeLanguageName', () => {
+  // The point of the picker: someone who cannot read the current UI language
+  // has to recognise their own. Each name is therefore in its own language,
+  // not the active one.
+  it.each([
+    ['de', 'Deutsch'],
+    ['en', 'English'],
+    ['es', 'Español'],
+    ['fr', 'Français'],
+    ['it', 'Italiano'],
+    ['pt', 'Português'],
+  ])('names %s in its own language', (tag, expected) => {
+    expect(nativeLanguageName(tag)).toBe(expected)
+  })
+
+  it('covers every shipped language', () => {
+    for (const lng of languages) {
+      const name = nativeLanguageName(lng)
+      expect(name, `${lng} has no display name`).toBeTypeOf('string')
+      expect(name, `${lng} fell back to the raw tag`).not.toBe(lng)
+    }
+  })
+
+  it('falls back to the tag rather than throwing on an unknown one', () => {
+    expect(nativeLanguageName('zz')).toBe('zz')
+  })
+})

--- a/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/src/components/LanguagePicker/LanguagePicker.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next'
+import { languages, resolveLanguage } from '@/locales'
+import { nativeLanguageName } from './nativeLanguageName'
+
+/**
+ * One picker for every surface that offers a language choice, so the desktop
+ * header and the mobile settings sheet cannot drift apart. Persistence is
+ * i18next's own localStorage cache — changeLanguage writes it, the detector
+ * reads it back on the next launch.
+ */
+export function LanguagePicker({ className, id }: { className?: string; id?: string }) {
+  const { i18n } = useTranslation()
+  // Same resolver the detector uses, so the option shown always matches the
+  // language actually rendering. A select whose value matches no option
+  // silently displays its first entry instead.
+  const value = resolveLanguage(i18n.resolvedLanguage || i18n.language)
+
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={e => i18n.changeLanguage(e.target.value)}
+      className={className}
+    >
+      {languages.map(lng => (
+        <option key={lng} value={lng}>
+          {nativeLanguageName(lng)}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/src/components/LanguagePicker/nativeLanguageName.ts
+++ b/src/components/LanguagePicker/nativeLanguageName.ts
@@ -1,0 +1,22 @@
+/**
+ * The language's own name for itself, derived from the tag rather than a table
+ * that would have to be kept in step with the locale directory.
+ *
+ * Intl returns these lowercase in several languages ("français", "português"),
+ * which is right mid-sentence but reads as a typo in a standalone list, so the
+ * first letter is uppercased in the language's own casing rules.
+ */
+export function nativeLanguageName(tag: string): string {
+  try {
+    // 'standard' composes regional variants as "language (Region)" —
+    // "Português (Portugal)" — where the default 'dialect' mode picks
+    // ICU-version-dependent dialect names like "Português europeu",
+    // breaking the parenthetical pattern next to "Português (Brasil)".
+    const name = new Intl.DisplayNames([tag], { type: 'language', languageDisplay: 'standard' }).of(tag)
+    // Intl echoes the input back when it has no name for the tag.
+    if (!name || name === tag) return tag
+    return name.charAt(0).toLocaleUpperCase(tag) + name.slice(1)
+  } catch {
+    return tag
+  }
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,6 +3,7 @@ import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import HttpBackend from 'i18next-http-backend'
 import { applyDateLocale } from '@/utils/datetime'
+import { languages, resolveLanguage } from '@/locales'
 
 // Keep date handling on the same language as the UI strings. Registered before
 // .init() so this listener runs ahead of react-i18next's own — the locale is
@@ -16,7 +17,10 @@ i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
-    supportedLngs: ['en', 'fr', 'de', 'es', 'it', 'pt'],
+    // Derived from the locale files on disk (src/locales.ts) — a hand-kept
+    // list here is how sibling app dayGLANCE shipped translations no user
+    // could reach.
+    supportedLngs: languages,
     ns: ['translation'],
     defaultNS: 'translation',
     backend: {
@@ -28,6 +32,11 @@ i18n
     detection: {
       order: ['localStorage', 'navigator', 'htmlTag'],
       caches: ['localStorage'],
+      // Runs on every detection source, the localStorage cache included, so
+      // whatever tag is stored or reported is mapped onto a language that
+      // actually ships. The picker resolves its value through the same
+      // function, so the option it shows always matches what renders.
+      convertDetectedLanguage: (lng: string) => resolveLanguage(lng),
     },
   })
 

--- a/src/locales.test.ts
+++ b/src/locales.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest'
-import { languages, loaders } from './locales'
+import { languages, loaders, resolveLanguage } from './locales'
 
 // de/es/fr/it/pt sat 8 keys behind en — the backup restore confirmation and
 // the GLANCEvault intents errors rendered in English for every non-English
@@ -30,6 +30,53 @@ describe('locale bundles', () => {
 
   it('exposes every shipped language', () => {
     expect(languages).toEqual(EXPECTED)
+  })
+
+  // Shared by the detector (convertDetectedLanguage) and the picker's value —
+  // the two must agree, or the UI renders one language while the picker
+  // displays another.
+  describe('resolveLanguage', () => {
+    it('passes through a tag that is already shipped', () => {
+      expect(resolveLanguage('de')).toBe('de')
+      expect(resolveLanguage('pt')).toBe('pt')
+    })
+
+    it('matches a shipped tag regardless of case', () => {
+      expect(resolveLanguage('DE')).toBe('de')
+      expect(resolveLanguage('Fr')).toBe('fr')
+    })
+
+    it('reduces a regional tag to a base language that is shipped', () => {
+      expect(resolveLanguage('en-US')).toBe('en')
+      expect(resolveLanguage('de-AT')).toBe('de')
+      expect(resolveLanguage('pt-BR')).toBe('pt')
+    })
+
+    it('falls back to en for a language that is not shipped', () => {
+      expect(resolveLanguage('ja')).toBe('en')
+      expect(resolveLanguage('zz-ZZ')).toBe('en')
+    })
+
+    it('handles a missing or non-string value', () => {
+      expect(resolveLanguage(undefined)).toBe('en')
+      expect(resolveLanguage(null)).toBe('en')
+      expect(resolveLanguage('')).toBe('en')
+      expect(resolveLanguage(42)).toBe('en')
+    })
+
+    it('prefers any variant of the right language over English', () => {
+      expect(resolveLanguage('pt', ['en', 'pt-BR'])).toBe('pt-BR')
+    })
+
+    it('falls back to the first option when en is not shipped', () => {
+      expect(resolveLanguage('ja', ['de', 'fr'])).toBe('de')
+    })
+
+    it('always returns something the picker can render', () => {
+      for (const reported of ['en', 'pt', 'de-AT', 'zz', '', undefined]) {
+        expect(languages).toContain(resolveLanguage(reported))
+      }
+    })
   })
 
   it.each(EXPECTED)('%s resolves to a non-empty bundle', (lng) => {

--- a/src/locales.ts
+++ b/src/locales.ts
@@ -30,3 +30,41 @@ export const loaders: Record<string, () => Promise<Record<string, unknown>>> =
 // Sorted so the value is stable across platforms — glob key order follows the
 // filesystem, which is not guaranteed to match between a dev machine and CI.
 export const languages = Object.keys(loaders).sort()
+
+/**
+ * Which regional variant a bare language tag means when more than one ships.
+ * Empty while every shipped locale is a bare tag; a split like pt → pt-PT and
+ * pt-BR adds its entry here so existing users keep the standard they had.
+ */
+const REGIONAL_DEFAULTS: Record<string, string> = {}
+
+/**
+ * Map any language tag onto one this app actually ships.
+ *
+ * Used in two places that must agree: the detector, so a stored or browser tag
+ * resolves before i18next sees it, and the picker, so the select always has a
+ * matching option. If they disagreed, the UI would render one language while
+ * the picker displayed another — a select whose value matches no option
+ * silently displays its first entry.
+ */
+export function resolveLanguage(reported: unknown, available: string[] = languages): string {
+  const fallback = available.includes('en') ? 'en' : available[0]
+  if (!reported || typeof reported !== 'string') return fallback
+
+  if (available.includes(reported)) return reported
+
+  // "pt-br" from a browser that lower-cases the region.
+  const exact = available.find((l) => l.toLowerCase() === reported.toLowerCase())
+  if (exact) return exact
+
+  const base = reported.split('-')[0].toLowerCase()
+  if (available.includes(base)) return base
+
+  const preferred = REGIONAL_DEFAULTS[base]
+  if (preferred && available.includes(preferred)) return preferred
+
+  // A regional tag for a language we ship only regionally, with no default
+  // declared — any variant beats falling through to English.
+  const sameLanguage = available.find((l) => l.split('-')[0].toLowerCase() === base)
+  return sameLanguage ?? fallback
+}


### PR DESCRIPTION
Ports the language-picker half of dayGLANCE #1396. Second of four localization PRs; **stacked on #292** (base is its branch, so this diff shows only the picker — retarget to `main` once #292 merges).

## What was missing

Language was browser-detected only, with no override: someone whose OS is set to one language but who wants the app in another had no recourse.

## Design (ported from dayGLANCE)

- **One shared `LanguagePicker`** rendered on both surfaces — the desktop header icon row and the mobile settings sheet — so they cannot drift apart.
- **Names come from `Intl.DisplayNames` keyed on the tag** — no hand-kept table. Each language is listed in its own language (Deutsch, Español, Français…), because the person who needs the picker may not read the currently active language. First letter uppercased under that language's own casing rules (`toLocaleUpperCase(tag)`), since Intl returns lowercase names in several languages. `languageDisplay: 'standard'` so future regional variants compose as "Português (Portugal)" / "(Brasil)" rather than ICU-version-dependent dialect names.
- **The select's value resolves through `resolveLanguage`, the same function the detector now runs** via `convertDetectedLanguage`. A `<select>` whose value matches no option silently renders its first entry — which would show "Deutsch" to an English user whose browser reported `en-US`. `resolveLanguage` (ported from dayGLANCE, `REGIONAL_DEFAULTS` empty until the pt split) lives in `src/locales.ts` next to the glob-derived language list.
- `i18n.ts` now takes `supportedLngs` from that glob-derived list instead of a second hand-kept copy.
- **Persistence is i18next's existing localStorage cache** — `changeLanguage` writes it, the detector reads it back; no new storage.
- New key `app.language` added to all six locales (parity test from #292 enforces this).

Side effect worth noting: because the app now imports `src/locales.ts`, Vite emits the six locale JSONs as lazy chunks (~130 KB added to the PWA precache). The runtime never fetches them (i18next-http-backend still serves `/locales/...`); they are the price of a glob-derived language list, and mirror dayGLANCE's per-language chunks.

## Verification

- `npm run lint` clean, tests green (35 files, 411 tests — resolver + native-name units added), `npm run build` passes
- **Real browser (Chromium via Playwright), all passing:**
  - en-US browser → select shows "English", not the first option (the silent-first-entry pitfall)
  - options render `Deutsch / English / Español / Français / Italiano / Português`
  - switching to fr re-renders the UI immediately, writes `i18nextLng=fr`, and survives reload
  - de-DE browser with no stored choice → UI renders German and the select shows Deutsch
  - mobile settings sheet renders the picker

**Translation quality:** the six `app.language` names are the only new strings; no native-speaker review was available (they are single common words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_