### PR TITLE
Localize notification and toast text

### DIFF
--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -297,6 +297,20 @@
     "delete": "Löschen",
     "viaDayglance": "via dayGLANCE"
   },
+  "notifications": {
+    "itsBeenDays_one": "Es ist {{count}} Tag her",
+    "itsBeenDays_other": "Es sind {{count}} Tage her",
+    "daysOverdue_one": "{{count}} Tag überfällig",
+    "daysOverdue_other": "{{count}} Tage überfällig",
+    "dueToday": "Heute fällig",
+    "markDone": "Als erledigt markieren",
+    "sendToDayglance": "An dayGLANCE senden",
+    "channelName": "Überfällige Aufgaben",
+    "channelDescription": "Erinnert dich, wenn eine Aufgabe ihren Rhythmus überschreitet.",
+    "rowsSkippedTitle_one": "{{count}} Eintrag konnte nicht gelesen werden",
+    "rowsSkippedTitle_other": "{{count}} Einträge konnten nicht gelesen werden",
+    "rowsSkippedBody": "Einige synchronisierte Daten konnten nicht entschlüsselt werden. Überprüfe die Cloud-Sync-Einstellungen."
+  },
   "passphrase": {
     "title": "Sync entsperren",
     "description": "Verschlüsselungspassphrase eingeben, um die Synchronisierung fortzusetzen.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -297,6 +297,20 @@
     "delete": "Delete",
     "viaDayglance": "via dayGLANCE"
   },
+  "notifications": {
+    "itsBeenDays_one": "It's been {{count}} day",
+    "itsBeenDays_other": "It's been {{count}} days",
+    "daysOverdue_one": "{{count}} day overdue",
+    "daysOverdue_other": "{{count}} days overdue",
+    "dueToday": "Due today",
+    "markDone": "Mark done",
+    "sendToDayglance": "Send to dayGLANCE",
+    "channelName": "Overdue chores",
+    "channelDescription": "Reminds you when a chore passes its cadence.",
+    "rowsSkippedTitle_one": "{{count}} item couldn’t be read",
+    "rowsSkippedTitle_other": "{{count}} items couldn’t be read",
+    "rowsSkippedBody": "Some synced rows couldn’t be decrypted. Check Cloud Sync settings."
+  },
   "passphrase": {
     "title": "Unlock Sync",
     "description": "Enter your encryption passphrase to resume syncing.",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -297,6 +297,20 @@
     "delete": "Eliminar",
     "viaDayglance": "vía dayGLANCE"
   },
+  "notifications": {
+    "itsBeenDays_one": "Ha pasado {{count}} día",
+    "itsBeenDays_other": "Han pasado {{count}} días",
+    "daysOverdue_one": "{{count}} día de retraso",
+    "daysOverdue_other": "{{count}} días de retraso",
+    "dueToday": "Vence hoy",
+    "markDone": "Marcar como hecha",
+    "sendToDayglance": "Enviar a dayGLANCE",
+    "channelName": "Tareas atrasadas",
+    "channelDescription": "Te avisa cuando una tarea supera su frecuencia.",
+    "rowsSkippedTitle_one": "No se pudo leer {{count}} elemento",
+    "rowsSkippedTitle_other": "No se pudieron leer {{count}} elementos",
+    "rowsSkippedBody": "Algunos datos sincronizados no se pudieron descifrar. Comprueba los ajustes de sincronización en la nube."
+  },
   "passphrase": {
     "title": "Desbloquear sincronización",
     "description": "Introduce tu contraseña de cifrado para reanudar la sincronización.",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -297,6 +297,20 @@
     "delete": "Supprimer",
     "viaDayglance": "via dayGLANCE"
   },
+  "notifications": {
+    "itsBeenDays_one": "Cela fait {{count}} jour",
+    "itsBeenDays_other": "Cela fait {{count}} jours",
+    "daysOverdue_one": "{{count}} jour de retard",
+    "daysOverdue_other": "{{count}} jours de retard",
+    "dueToday": "Échéance aujourd’hui",
+    "markDone": "Marquer comme fait",
+    "sendToDayglance": "Envoyer à dayGLANCE",
+    "channelName": "Tâches en retard",
+    "channelDescription": "Vous rappelle quand une tâche dépasse sa fréquence.",
+    "rowsSkippedTitle_one": "{{count}} élément n’a pas pu être lu",
+    "rowsSkippedTitle_other": "{{count}} éléments n’ont pas pu être lus",
+    "rowsSkippedBody": "Certaines données synchronisées n’ont pas pu être déchiffrées. Vérifiez les réglages de Sync cloud."
+  },
   "passphrase": {
     "title": "Déverrouiller la sync",
     "description": "Entrez votre phrase secrète de chiffrement pour reprendre la synchronisation.",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -297,6 +297,20 @@
     "delete": "Elimina",
     "viaDayglance": "via dayGLANCE"
   },
+  "notifications": {
+    "itsBeenDays_one": "È passato {{count}} giorno",
+    "itsBeenDays_other": "Sono passati {{count}} giorni",
+    "daysOverdue_one": "{{count}} giorno di ritardo",
+    "daysOverdue_other": "{{count}} giorni di ritardo",
+    "dueToday": "Scade oggi",
+    "markDone": "Segna come fatta",
+    "sendToDayglance": "Invia a dayGLANCE",
+    "channelName": "Attività in ritardo",
+    "channelDescription": "Ti avvisa quando un’attività supera la sua frequenza.",
+    "rowsSkippedTitle_one": "Impossibile leggere {{count}} elemento",
+    "rowsSkippedTitle_other": "Impossibile leggere {{count}} elementi",
+    "rowsSkippedBody": "Alcuni dati sincronizzati non sono stati decifrati. Controlla le impostazioni di sincronizzazione cloud."
+  },
   "passphrase": {
     "title": "Sblocca sincronizzazione",
     "description": "Inserisci la tua passphrase di crittografia per riprendere la sincronizzazione.",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -297,6 +297,20 @@
     "delete": "Excluir",
     "viaDayglance": "via dayGLANCE"
   },
+  "notifications": {
+    "itsBeenDays_one": "Passou {{count}} dia",
+    "itsBeenDays_other": "Passaram {{count}} dias",
+    "daysOverdue_one": "{{count}} dia de atraso",
+    "daysOverdue_other": "{{count}} dias de atraso",
+    "dueToday": "Vence hoje",
+    "markDone": "Marcar como concluída",
+    "sendToDayglance": "Enviar para dayGLANCE",
+    "channelName": "Tarefas atrasadas",
+    "channelDescription": "Avisa quando uma tarefa ultrapassa a sua frequência.",
+    "rowsSkippedTitle_one": "Não foi possível ler {{count}} item",
+    "rowsSkippedTitle_other": "Não foi possível ler {{count}} itens",
+    "rowsSkippedBody": "Alguns dados sincronizados não puderam ser decifrados. Verifique as configurações de sincronização na nuvem."
+  },
   "passphrase": {
     "title": "Desbloquear sincronização",
     "description": "Digite a sua frase de criptografia para retomar a sincronização.",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -297,6 +297,20 @@
     "delete": "Eliminar",
     "viaDayglance": "via dayGLANCE"
   },
+  "notifications": {
+    "itsBeenDays_one": "Passou {{count}} dia",
+    "itsBeenDays_other": "Passaram {{count}} dias",
+    "daysOverdue_one": "{{count}} dia de atraso",
+    "daysOverdue_other": "{{count}} dias de atraso",
+    "dueToday": "Vence hoje",
+    "markDone": "Marcar como concluída",
+    "sendToDayglance": "Enviar para dayGLANCE",
+    "channelName": "Tarefas atrasadas",
+    "channelDescription": "Avisa quando uma tarefa ultrapassa a sua frequência.",
+    "rowsSkippedTitle_one": "Não foi possível ler {{count}} item",
+    "rowsSkippedTitle_other": "Não foi possível ler {{count}} itens",
+    "rowsSkippedBody": "Alguns dados sincronizados não puderam ser decifrados. Verifique as definições de sincronização na nuvem."
+  },
   "passphrase": {
     "title": "Desbloquear sincronização",
     "description": "Introduza a sua frase-passe de encriptação para retomar a sincronização.",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ import type { SyncEngine, SyncStatus, DbSyncEngine, SyncErrorCode } from '@glanc
 import { syncSharedUsers } from '@/multiuser/sharedUsers'
 import { getUsersPath, getMultiUserEnabled } from '@/multiuser/settings'
 import dayjs from 'dayjs'
+import i18n from 'i18next'
 import { useTranslation } from 'react-i18next'
 
 // ── Header heatmap ─────────────────────────────────────────────────────────────
@@ -295,8 +296,8 @@ function AppInner() {
         setVaultSkipped(count)
         // Transient: nudge the user toward the settings where the count lives.
         showToastRef.current({
-          title: `${count} ${count === 1 ? 'item' : 'items'} couldn’t be read`,
-          body: 'Some synced rows couldn’t be decrypted. Check Cloud Sync settings.',
+          title: i18n.t('notifications.rowsSkippedTitle', { count }),
+          body: i18n.t('notifications.rowsSkippedBody'),
         })
       },
     })

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import i18n from 'i18next'
 import { getCategories, getChoresForCategory, logCompletion } from '@/db/queries'
 import { LocalNotifications } from '@capacitor/local-notifications'
 import { isNativeShell } from '@/native/platform'
@@ -139,8 +140,8 @@ export function useNotifications() {
           if (localStorage.getItem(STORAGE_KEY(chore.id!)) !== today) {
             const overdue = Math.floor(chore.elapsed_days! - chore.target_cadence_days!)
             const body = overdue > 0
-              ? `${overdue} day${overdue > 1 ? 's' : ''} overdue`
-              : 'Due today'
+              ? i18n.t('notifications.daysOverdue', { count: overdue })
+              : i18n.t('notifications.dueToday')
 
             if (document.visibilityState === 'visible') {
               const choreId = chore.id!

--- a/src/hooks/useReminders.ts
+++ b/src/hooks/useReminders.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { LocalNotifications } from '@capacitor/local-notifications'
 import type { PluginListenerHandle } from '@capacitor/core'
+import i18n from 'i18next'
 import { syncReminders, handleNotificationAction } from '@/native/reminders'
 import { isNativeShell } from '@/native/platform'
 
@@ -16,6 +17,11 @@ export function useReminders(): void {
     const onChange = () => { syncReminders() }
     window.addEventListener('lg:chore-logged', onChange)
     window.addEventListener('lg:sync-applied', onChange)
+    // Notification text is baked at schedule time, so a language switch must
+    // re-run the sync: the body diff in syncReminders then re-bakes every
+    // pending reminder (and the channel/action labels re-register) in the new
+    // language.
+    i18n.on('languageChanged', onChange)
 
     const onVisibility = () => {
       if (document.visibilityState === 'visible') syncReminders()
@@ -30,6 +36,7 @@ export function useReminders(): void {
     return () => {
       window.removeEventListener('lg:chore-logged', onChange)
       window.removeEventListener('lg:sync-applied', onChange)
+      i18n.off('languageChanged', onChange)
       document.removeEventListener('visibilitychange', onVisibility)
       tapHandle?.remove()
     }

--- a/src/native/reminders.ts
+++ b/src/native/reminders.ts
@@ -1,4 +1,9 @@
 import { LocalNotifications } from '@capacitor/local-notifications'
+// The bare singleton, not '@/i18n': that module boots the detector and HTTP
+// backend as an import side effect, which node-side tests must not inherit.
+// main.tsx imports '@/i18n' before anything schedules, so by the time these
+// t() calls run the instance is initialized.
+import i18n from 'i18next'
 import { isAndroid, isNativeShell } from './platform'
 import type { PendingLocalNotificationSchema } from '@capacitor/local-notifications'
 import { getCategories, getChoresForCategory, logCompletion } from '@/db/queries'
@@ -83,18 +88,30 @@ export function reminderIdFor(syncId: string): number {
   return (h & 0x7fffffff) || 1
 }
 
+// Action-button titles and the Android channel are registered once per app run
+// — but they carry localized text, so a language switch invalidates them. The
+// memo flags reset on languageChanged and the next syncReminders re-registers
+// both (createChannel with an existing id updates its name in place). Pending
+// notification BODIES re-bake through the body diff in syncReminders, which
+// useReminders triggers on the same event.
 let actionTypesReady = false
+let channelReady = false
+i18n.on('languageChanged', () => {
+  actionTypesReady = false
+  channelReady = false
+})
+
 async function ensureActionTypes(): Promise<void> {
   if (actionTypesReady) return
   try {
     await LocalNotifications.registerActionTypes({
       types: [
-        { id: ACTION_TYPE, actions: [{ id: 'mark_done', title: 'Mark done' }] },
+        { id: ACTION_TYPE, actions: [{ id: 'mark_done', title: i18n.t('notifications.markDone') }] },
         {
           id: ACTION_TYPE_DG,
           actions: [
-            { id: 'mark_done', title: 'Mark done' },
-            { id: 'send_dg', title: 'Send to dayGLANCE' },
+            { id: 'mark_done', title: i18n.t('notifications.markDone') },
+            { id: 'send_dg', title: i18n.t('notifications.sendToDayglance') },
           ],
         },
       ],
@@ -108,14 +125,13 @@ async function ensureActionTypes(): Promise<void> {
 // Android-only: notification channels have no iOS equivalent, and the plugin's
 // createChannel is a no-op there. Guarded explicitly rather than left to fail
 // quietly, so the Android-only-ness is visible at the call site.
-let channelReady = false
 async function ensureChannel(): Promise<void> {
   if (channelReady || !isAndroid()) return
   try {
     await LocalNotifications.createChannel({
       id: CHANNEL_ID,
-      name: 'Overdue chores',
-      description: 'Reminds you when a chore passes its cadence.',
+      name: i18n.t('notifications.channelName'),
+      description: i18n.t('notifications.channelDescription'),
       importance: 4, // HIGH — heads-up
       visibility: 1, // public
     })
@@ -172,12 +188,13 @@ async function buildReminders(dgEnabled: boolean): Promise<ReminderDescriptor[]>
       // future crossings (a past `at` would fire immediately on every sync).
       if (triggerAtMillis <= now) continue
 
-      const days = ch.target_cadence_days
       out.push({
         id: reminderIdFor(ch.sync_id),
         choreSyncId: ch.sync_id,
         title: ch.name,
-        body: `It's been ${days} ${days === 1 ? 'day' : 'days'}`,
+        // Baked in the language active at schedule time; a language switch
+        // re-bakes it via the body diff in syncReminders (see useReminders).
+        body: i18n.t('notifications.itsBeenDays', { count: ch.target_cadence_days }),
         triggerAtMillis,
         dgEnabled,
       })


### PR DESCRIPTION
Follow-up to the localization stack (#292–#296): the notification family was the last hardcoded-English surface in the web layer. A dayGLANCE counterpart PR follows.

## What was hardcoded

- **`src/native/reminders.ts`** — every scheduled overdue notification baked in "It's been N days", the **Mark done** / **Send to dayGLANCE** action buttons, and the Android channel name ("Overdue chores") + description.
- **`src/hooks/useNotifications.ts`** — the foreground toast and the web browser notification built "N days overdue" / "Due today".
- **`src/App.tsx`** — the skipped-rows toast ("N items couldn't be read" / "Some synced rows couldn't be decrypted…").

## The fix

All of it goes through i18next under a new `notifications` section, present in **all seven locales** — pt-BR via the deterministic transform, which correctly mapped *definições* → *configurações* in the new body on its own. Plurals use i18next `_one`/`_other` with `count`, so the existing key-parity and `{{placeholder}}` tests cover every language with no new test scaffolding.

Two wiring details worth knowing:

- **Language switches re-bake pending notifications.** Text is baked at schedule time, so `reminders.ts` resets its channel/action-type memo flags on `languageChanged` and `useReminders` re-runs `syncReminders` on the same event — the existing body diff then cancels/reschedules every pending reminder in the new language (Android `createChannel` with an existing id updates its name in place).
- Imports use the bare `i18next` singleton rather than `@/i18n`, so node-side tests don't inherit the detector/HTTP-backend boot side effects. `main.tsx` imports `@/i18n` before anything schedules, so the instance is always initialized by the time these `t()` calls run.

Translations match each locale's register and existing glossary (de *Rhythmus* for cadence, es *frecuencia*, fr *fréquence*, it *frequenza*, pt *frequência*; "Marcar como concluída" agrees with pt's *Concluído*; verbs of address follow each file's convention: *Überprüfe*, *Comprueba*, *Vérifiez*, *Controlla*, *Verifique*).

## Verification

- `npm run lint` clean, tests green (36 files, 465 tests — parity + placeholder + variant purity + pt-BR freshness all enforce the new keys), `npm run build` passes.
- Not verified on a device: actually seeing a scheduled system notification fire requires a native shell; the string wiring is covered by the tests above and by inspection. Worth a glance on the next Android internal build.

**Translation quality:** no native-speaker review was available; register/glossary consistency is verified against the existing files, naturalness is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_