### PR TITLE
Fold theme, backup, and language into a desktop overflow menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,9 @@ function AppInner() {
   const [showJournal, setShowJournal] = useState(false)
   const [journalDate, setJournalDate] = useState<string | null>(null)
   const [showSettingsSheet, setShowSettingsSheet] = useState(false)
+  // Desktop overflow menu: theme, backup, and language — the rarely-clicked
+  // controls, folded behind one button so the icon row stays short.
+  const [showDesktopMenu, setShowDesktopMenu] = useState(false)
   const [ribbonKey, setRibbonKey] = useState(0)
   const [heatmapWeeks, setHeatmapWeeks] = useState<HeatDay[][]>([])
   const [waveKey, setWaveKey] = useState(0)
@@ -612,21 +615,48 @@ function AppInner() {
               <button onClick={() => setShowIntegration(true)} className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors" aria-label={t('app.dayglanceIntegration')} data-tooltip={t('app.dayglanceIntegration')}><Plug size={15} /></button>
               <button onClick={() => setShowUsers(true)} className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors" aria-label={t('app.users')} data-tooltip={t('app.users')}><Users size={15} /></button>
               <button onClick={() => openJournal(null)} className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors" aria-label={t('app.journal')} data-tooltip={t('app.journalTooltip')}><NotebookText size={15} /></button>
-              <button
-                onClick={toggleTheme}
-                className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors"
-                aria-label={t('app.toggleTheme')}
-                data-tooltip={isDark ? t('app.lightMode') : t('app.darkMode')}
-              >
-                {isDark ? <Sun size={15} /> : <Moon size={15} />}
-              </button>
-              <button onClick={() => setShowBackup(true)} className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors" aria-label={t('app.backupRestore')} data-tooltip={t('app.backupRestore')}><Archive size={15} /></button>
               <button onClick={() => setShowHelp(true)} className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors" aria-label={t('app.helpFeedback')} data-tooltip={t('app.helpFeedback')}><HelpCircle size={15} /></button>
-              <label className="flex items-center gap-1.5 p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors cursor-pointer" data-tooltip={t('app.language')}>
-                <Languages size={15} className="shrink-0" />
-                <span className="sr-only">{t('app.language')}</span>
-                <LanguagePicker className="bg-transparent text-sm text-slate-500 dark:text-slate-400 focus:outline-none cursor-pointer max-w-28" />
-              </label>
+              {/* Overflow: theme, backup, language — set-and-forget controls
+                  folded behind one button, same card pattern as the mobile
+                  settings sheet. Theme also stays a keyboard shortcut away. */}
+              <div className="relative">
+                <button
+                  onClick={() => setShowDesktopMenu(m => !m)}
+                  className={`p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-200 dark:border-slate-700 transition-colors ${showDesktopMenu ? 'text-slate-700 dark:text-slate-200 bg-slate-100 dark:bg-slate-800' : 'text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-200'}`}
+                  aria-label={t('app.settings')}
+                  aria-expanded={showDesktopMenu}
+                  data-tooltip={t('app.settings')}
+                >
+                  <Settings size={15} />
+                </button>
+                {showDesktopMenu && (
+                  <>
+                    {/* backdrop */}
+                    <div className="fixed inset-0 z-40" onClick={() => setShowDesktopMenu(false)} />
+                    <div className="absolute right-0 top-full mt-2 z-50 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-xl p-3 flex flex-col gap-1 min-w-[190px]">
+                      <button
+                        onClick={() => { toggleTheme(); setShowDesktopMenu(false) }}
+                        className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-left w-full transition-colors hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300"
+                      >
+                        {isDark ? <Sun size={15} /> : <Moon size={15} />}
+                        {isDark ? t('app.lightMode') : t('app.darkMode')}
+                      </button>
+                      <button
+                        onClick={() => { setShowBackup(true); setShowDesktopMenu(false) }}
+                        className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm text-left w-full transition-colors hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300"
+                      >
+                        <Archive size={15} />
+                        {t('app.backupRestore')}
+                      </button>
+                      <label className="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm w-full text-slate-600 dark:text-slate-300">
+                        <Languages size={15} className="shrink-0" />
+                        <span className="sr-only">{t('app.language')}</span>
+                        <LanguagePicker className="flex-1 min-w-0 bg-transparent text-sm text-slate-600 dark:text-slate-300 focus:outline-none" />
+                      </label>
+                    </div>
+                  </>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/components/LanguagePicker/LanguagePicker.tsx
+++ b/src/components/LanguagePicker/LanguagePicker.tsx
@@ -4,8 +4,8 @@ import { nativeLanguageName } from './nativeLanguageName'
 
 /**
  * One picker for every surface that offers a language choice, so the desktop
- * header and the mobile settings sheet cannot drift apart. Persistence is
- * i18next's own localStorage cache — changeLanguage writes it, the detector
+ * overflow menu and the mobile settings sheet cannot drift apart. Persistence
+ * is i18next's own localStorage cache — changeLanguage writes it, the detector
  * reads it back on the next launch.
  */
 export function LanguagePicker({ className, id }: { className?: string; id?: string }) {


### PR DESCRIPTION
Follow-up to #294: on desktop/tablet the language picker rendered as a full-width text select in the header icon row — far too much room, and with "Português (Portugal)" selected it got worse. The icon row itself was also already the widest element in the header with everything enabled.

## The fix

Rather than only shrinking the picker, the three set-and-forget controls — **theme toggle, Backup & Restore, and language** — fold behind one gear button at the end of the icon row, opening the same card pattern the mobile settings sheet uses:

- Row 2 drops from **seven icons to six** (cloud, integration, users, journal, help, gear).
- The language picker gets a labeled row inside the menu with room to breathe — same shared `LanguagePicker` as the mobile sheet, so the two surfaces still cannot drift.
- Theme and backup become two clicks, accepted as set-and-forget controls; the theme toggle also stays reachable via its existing keyboard shortcut.
- Future settings have a natural desktop home instead of another header icon.

An icon-only picker variant (invisible native select over a glyph, right of Edit) was built and verified first, but folding the rarely-used controls into one menu addresses the underlying header-density problem rather than just this control; it lives in this branch's history if ever wanted.

## Verification

- `npm run lint` clean, tests green (36 files, 465 tests), `npm run build` passes.
- **Real browser (Chromium), all 12 checks passing:** menu opens and closes (backdrop, and after each action); the theme row toggles the theme; the backup row opens the BackupModal; switching language from inside the menu re-renders the whole app — including the open menu and the gear's own aria-label — without closing it, and persists across reload; no stray select renders until the menu opens.

No locale-file changes; all labels reuse existing keys (`app.settings`, `app.lightMode`/`darkMode`, `app.backupRestore`, `app.language`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_