### PR TITLE
Localize Android widget strings and the elapsed labels

### DIFF
--- a/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/HeatmapWidget.kt
@@ -128,9 +128,11 @@ private fun readCounts(context: Context): Pair<Int, Int> {
 }
 
 private fun statText(context: Context, overdue: Int, soon: Int): String = when {
-    overdue > 0 && soon > 0 -> "$overdue overdue · $soon soon"
-    overdue > 0 -> "$overdue overdue"
-    soon > 0 -> "$soon soon"
+    overdue > 0 && soon > 0 ->
+        context.getString(R.string.widget_count_overdue, overdue) + " · " +
+            context.getString(R.string.widget_count_soon, soon)
+    overdue > 0 -> context.getString(R.string.widget_count_overdue, overdue)
+    soon > 0 -> context.getString(R.string.widget_count_soon, soon)
     else -> context.getString(R.string.widget_all_caught_up)
 }
 

--- a/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
+++ b/android/app/src/main/java/com/lastglance/app/glance/SingleChoreWidget.kt
@@ -136,7 +136,7 @@ internal object ChoreSnapshot {
         return ChoreData(
             syncId = ch.optString("syncId"),
             name = ch.optString("name"),
-            elapsed = elapsedLabel(ch),
+            elapsed = elapsedLabel(context, ch),
             colorInt = parseColor(color),
             iconResId = resolveIcon(context, ch.optString("icon", null)),
         )
@@ -181,8 +181,8 @@ internal object ChoreSnapshot {
         return sb.toString()
     }
 
-    private fun elapsedLabel(chore: JSONObject): String {
-        if (chore.isNull("elapsedDays")) return "never"
+    private fun elapsedLabel(context: Context, chore: JSONObject): String {
+        if (chore.isNull("elapsedDays")) return context.getString(R.string.widget_never)
         // Prefer a calendar-day boundary off the real timestamp so a chore done
         // "last night" reads "yesterday", not "today" — matching the app's
         // formatElapsed(). elapsedDays alone is a duration (<24h reads "today"),
@@ -190,15 +190,15 @@ internal object ChoreSnapshot {
         val days = calendarDaysAgo(chore.optString("lastCompletedAt", ""))
         if (days != null) {
             return when {
-                days <= 0 -> "today"
-                days == 1 -> "yesterday"
-                else -> "${days}d ago"
+                days <= 0 -> context.getString(R.string.widget_today)
+                days == 1 -> context.getString(R.string.widget_yesterday)
+                else -> context.getString(R.string.widget_days_ago, days)
             }
         }
         // Fall back to the elapsed duration when the timestamp is missing.
         val d = chore.optDouble("elapsedDays", 0.0)
-        if (d < 1) return "today"
-        return "${Math.round(d)}d ago"
+        if (d < 1) return context.getString(R.string.widget_today)
+        return context.getString(R.string.widget_days_ago, Math.round(d).toInt())
     }
 
     // Whole calendar days between the completion's local day and today's local

--- a/android/app/src/main/java/com/lastglance/app/tiles/QsTiles.kt
+++ b/android/app/src/main/java/com/lastglance/app/tiles/QsTiles.kt
@@ -65,9 +65,11 @@ class SoonTileService : TileService() {
 }
 
 private fun subtitle(context: Context, overdue: Int, soon: Int): String = when {
-    overdue > 0 && soon > 0 -> "$overdue overdue · $soon soon"
-    overdue > 0 -> "$overdue overdue"
-    soon > 0 -> "$soon soon"
+    overdue > 0 && soon > 0 ->
+        context.getString(R.string.widget_count_overdue, overdue) + " · " +
+            context.getString(R.string.widget_count_soon, soon)
+    overdue > 0 -> context.getString(R.string.widget_count_overdue, overdue)
+    soon > 0 -> context.getString(R.string.widget_count_soon, soon)
     else -> context.getString(R.string.widget_all_caught_up)
 }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="heatmap_widget_description">Deine letzten Erledigungen auf einen Blick.</string>
+    <string name="single_chore_widget_description">Die Aufgabe, die am dringendsten ansteht, mit Erledigt per Tipp.</string>
+    <string name="soon_list_widget_description">Aufgaben, die bald Aufmerksamkeit brauchen, mit Erledigt per Tipp.</string>
+    <string name="soon_list_widget_title">Bald</string>
+    <string name="widget_done">Erledigt</string>
+    <string name="widget_all_caught_up">Alles erledigt</string>
+    <string name="widget_config_auto">Am längsten überfällig (automatisch)</string>
+    <string name="widget_config_title">Aufgabe auswählen</string>
+    <string name="widget_config_search">Aufgaben suchen</string>
+    <string name="widget_label_activity">lastGLANCE Heatmap</string>
+    <string name="widget_label_chore">lastGLANCE Aufgabe</string>
+    <string name="widget_label_soon">lastGLANCE Bald</string>
+    <string name="widget_label_add">lastGLANCE Hinzufügen</string>
+    <string name="add_chore_widget_description">Ein Tipp, um eine neue Aufgabe hinzuzufügen.</string>
+    <string name="widget_add_chore">Aufgabe hinzufügen</string>
+    <string name="shortcut_soon_short">Bald</string>
+    <string name="shortcut_soon_long">Was Aufmerksamkeit braucht</string>
+    <string name="shortcut_search_short">Suchen</string>
+    <string name="shortcut_search_long">Aufgaben suchen</string>
+    <string name="shortcut_add_short">Hinzufügen</string>
+    <string name="shortcut_add_long">Neue Aufgabe hinzufügen</string>
+    <string name="tile_add_chore">Aufgabe hinzufügen</string>
+    <string name="tile_soon">Bald</string>
+    <string name="widget_never">nie</string>
+    <string name="widget_today">heute</string>
+    <string name="widget_yesterday">gestern</string>
+    <string name="widget_days_ago">vor %1$d T.</string>
+    <string name="widget_count_overdue">%1$d überfällig</string>
+    <string name="widget_count_soon">%1$d bald fällig</string>
+</resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="heatmap_widget_description">Tu actividad reciente de un vistazo.</string>
+    <string name="single_chore_widget_description">La tarea que más atención necesita, con Hecho en un toque.</string>
+    <string name="soon_list_widget_description">Tareas que pronto necesitan atención, con Hecho en un toque.</string>
+    <string name="soon_list_widget_title">Pronto</string>
+    <string name="widget_done">Hecho</string>
+    <string name="widget_all_caught_up">Todo al día</string>
+    <string name="widget_config_auto">La más atrasada (automático)</string>
+    <string name="widget_config_title">Elige una tarea</string>
+    <string name="widget_config_search">Buscar tareas</string>
+    <string name="widget_label_activity">lastGLANCE Actividad</string>
+    <string name="widget_label_chore">lastGLANCE Tarea</string>
+    <string name="widget_label_soon">lastGLANCE Pronto</string>
+    <string name="widget_label_add">lastGLANCE Añadir</string>
+    <string name="add_chore_widget_description">Un toque para añadir una nueva tarea.</string>
+    <string name="widget_add_chore">Añadir tarea</string>
+    <string name="shortcut_soon_short">Pronto</string>
+    <string name="shortcut_soon_long">Lo que necesita atención</string>
+    <string name="shortcut_search_short">Buscar</string>
+    <string name="shortcut_search_long">Buscar tareas</string>
+    <string name="shortcut_add_short">Añadir</string>
+    <string name="shortcut_add_long">Añadir una nueva tarea</string>
+    <string name="tile_add_chore">Añadir tarea</string>
+    <string name="tile_soon">Pronto</string>
+    <string name="widget_never">nunca</string>
+    <string name="widget_today">hoy</string>
+    <string name="widget_yesterday">ayer</string>
+    <string name="widget_days_ago">hace %1$d d</string>
+    <string name="widget_count_overdue">%1$d vencidas</string>
+    <string name="widget_count_soon">%1$d por vencer</string>
+</resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="heatmap_widget_description">Votre activité récente en un coup d\'œil.</string>
+    <string name="single_chore_widget_description">La tâche la plus urgente, avec Fait en un geste.</string>
+    <string name="soon_list_widget_description">Les tâches qui demanderont bientôt de l\'attention, avec Fait en un geste.</string>
+    <string name="soon_list_widget_title">Bientôt</string>
+    <string name="widget_done">Fait</string>
+    <string name="widget_all_caught_up">Tout est à jour</string>
+    <string name="widget_config_auto">La plus en retard (automatique)</string>
+    <string name="widget_config_title">Choisir une tâche</string>
+    <string name="widget_config_search">Rechercher des tâches</string>
+    <string name="widget_label_activity">lastGLANCE Activité</string>
+    <string name="widget_label_chore">lastGLANCE Tâche</string>
+    <string name="widget_label_soon">lastGLANCE Bientôt</string>
+    <string name="widget_label_add">lastGLANCE Ajouter</string>
+    <string name="add_chore_widget_description">Un geste pour ajouter une nouvelle tâche.</string>
+    <string name="widget_add_chore">Ajouter une tâche</string>
+    <string name="shortcut_soon_short">Bientôt</string>
+    <string name="shortcut_soon_long">Ce qui demande de l\'attention</string>
+    <string name="shortcut_search_short">Rechercher</string>
+    <string name="shortcut_search_long">Rechercher des tâches</string>
+    <string name="shortcut_add_short">Ajouter</string>
+    <string name="shortcut_add_long">Ajouter une nouvelle tâche</string>
+    <string name="tile_add_chore">Ajouter une tâche</string>
+    <string name="tile_soon">Bientôt</string>
+    <string name="widget_never">jamais</string>
+    <string name="widget_today">aujourd\'hui</string>
+    <string name="widget_yesterday">hier</string>
+    <string name="widget_days_ago">il y a %1$d j</string>
+    <string name="widget_count_overdue">%1$d en retard</string>
+    <string name="widget_count_soon">%1$d bientôt</string>
+</resources>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="heatmap_widget_description">La tua attività recente a colpo d\'occhio.</string>
+    <string name="single_chore_widget_description">L\'attività che ha più bisogno di attenzione, con Fatto in un tocco.</string>
+    <string name="soon_list_widget_description">Le attività che presto avranno bisogno di attenzione, con Fatto in un tocco.</string>
+    <string name="soon_list_widget_title">Presto</string>
+    <string name="widget_done">Fatto</string>
+    <string name="widget_all_caught_up">Tutto fatto</string>
+    <string name="widget_config_auto">La più in ritardo (automatico)</string>
+    <string name="widget_config_title">Scegli un\'attività</string>
+    <string name="widget_config_search">Cerca attività</string>
+    <string name="widget_label_activity">lastGLANCE Heatmap</string>
+    <string name="widget_label_chore">lastGLANCE Attività</string>
+    <string name="widget_label_soon">lastGLANCE Presto</string>
+    <string name="widget_label_add">lastGLANCE Aggiungi</string>
+    <string name="add_chore_widget_description">Un tocco per aggiungere una nuova attività.</string>
+    <string name="widget_add_chore">Aggiungi attività</string>
+    <string name="shortcut_soon_short">Presto</string>
+    <string name="shortcut_soon_long">Cosa ha bisogno di attenzione</string>
+    <string name="shortcut_search_short">Cerca</string>
+    <string name="shortcut_search_long">Cerca attività</string>
+    <string name="shortcut_add_short">Aggiungi</string>
+    <string name="shortcut_add_long">Aggiungi una nuova attività</string>
+    <string name="tile_add_chore">Aggiungi attività</string>
+    <string name="tile_soon">Presto</string>
+    <string name="widget_never">mai</string>
+    <string name="widget_today">oggi</string>
+    <string name="widget_yesterday">ieri</string>
+    <string name="widget_days_ago">%1$d g fa</string>
+    <string name="widget_count_overdue">%1$d in ritardo</string>
+    <string name="widget_count_soon">%1$d in scadenza</string>
+</resources>

--- a/android/app/src/main/res/values-pt/strings.xml
+++ b/android/app/src/main/res/values-pt/strings.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="heatmap_widget_description">A sua atividade recente num relance.</string>
+    <string name="single_chore_widget_description">A tarefa que mais precisa de atenção, com Feito num toque.</string>
+    <string name="soon_list_widget_description">Tarefas que em breve precisam de atenção, com Feito num toque.</string>
+    <string name="soon_list_widget_title">Em breve</string>
+    <string name="widget_done">Feito</string>
+    <string name="widget_all_caught_up">Tudo em dia</string>
+    <string name="widget_config_auto">A mais atrasada (automático)</string>
+    <string name="widget_config_title">Escolher uma tarefa</string>
+    <string name="widget_config_search">Pesquisar tarefas</string>
+    <string name="widget_label_activity">lastGLANCE Atividade</string>
+    <string name="widget_label_chore">lastGLANCE Tarefa</string>
+    <string name="widget_label_soon">lastGLANCE Em breve</string>
+    <string name="widget_label_add">lastGLANCE Adicionar</string>
+    <string name="add_chore_widget_description">Um toque para adicionar uma nova tarefa.</string>
+    <string name="widget_add_chore">Adicionar tarefa</string>
+    <string name="shortcut_soon_short">Em breve</string>
+    <string name="shortcut_soon_long">O que precisa de atenção</string>
+    <string name="shortcut_search_short">Pesquisar</string>
+    <string name="shortcut_search_long">Pesquisar tarefas</string>
+    <string name="shortcut_add_short">Adicionar</string>
+    <string name="shortcut_add_long">Adicionar uma nova tarefa</string>
+    <string name="tile_add_chore">Adicionar tarefa</string>
+    <string name="tile_soon">Em breve</string>
+    <string name="widget_never">nunca</string>
+    <string name="widget_today">hoje</string>
+    <string name="widget_yesterday">ontem</string>
+    <string name="widget_days_ago">há %1$d d</string>
+    <string name="widget_count_overdue">%1$d atrasadas</string>
+    <string name="widget_count_soon">%1$d a vencer</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -29,4 +29,11 @@
     <!-- Quick Settings tiles -->
     <string name="tile_add_chore">Add chore</string>
     <string name="tile_soon">Soon</string>
+    <!-- Widget/tile display fragments previously hardcoded in Kotlin -->
+    <string name="widget_never">never</string>
+    <string name="widget_today">today</string>
+    <string name="widget_yesterday">yesterday</string>
+    <string name="widget_days_ago">%1$dd ago</string>
+    <string name="widget_count_overdue">%1$d overdue</string>
+    <string name="widget_count_soon">%1$d soon</string>
 </resources>

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -169,6 +169,14 @@
     "today": "Heute",
     "noTimeHint": "Keine Uhrzeit — es wird 12 Uhr verwendet"
   },
+  "elapsed": {
+    "never": "nie",
+    "justNow": "gerade eben",
+    "minutesAgo": "vor {{count}} Min.",
+    "hoursAgo": "vor {{count}} Std.",
+    "yesterday": "gestern",
+    "daysAgo": "vor {{count}} T."
+  },
   "heatmap": {
     "completions_one": "{{count}} Erledigung",
     "completions_other": "{{count}} Erledigungen",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -169,6 +169,14 @@
     "today": "Today",
     "noTimeHint": "No time set — will use noon"
   },
+  "elapsed": {
+    "never": "never",
+    "justNow": "just now",
+    "minutesAgo": "{{count}}m ago",
+    "hoursAgo": "{{count}}h ago",
+    "yesterday": "yesterday",
+    "daysAgo": "{{count}}d ago"
+  },
   "heatmap": {
     "completions_one": "{{count}} completion",
     "completions_other": "{{count}} completions",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -169,6 +169,14 @@
     "today": "Hoy",
     "noTimeHint": "Sin hora — se usará el mediodía"
   },
+  "elapsed": {
+    "never": "nunca",
+    "justNow": "ahora mismo",
+    "minutesAgo": "hace {{count}} min",
+    "hoursAgo": "hace {{count}} h",
+    "yesterday": "ayer",
+    "daysAgo": "hace {{count}} d"
+  },
   "heatmap": {
     "completions_one": "{{count}} completada",
     "completions_other": "{{count}} completadas",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -169,6 +169,14 @@
     "today": "Aujourd'hui",
     "noTimeHint": "Aucune heure — midi sera utilisé"
   },
+  "elapsed": {
+    "never": "jamais",
+    "justNow": "à l’instant",
+    "minutesAgo": "il y a {{count}} min",
+    "hoursAgo": "il y a {{count}} h",
+    "yesterday": "hier",
+    "daysAgo": "il y a {{count}} j"
+  },
   "heatmap": {
     "completions_one": "{{count}} réalisation",
     "completions_other": "{{count}} réalisations",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -169,6 +169,14 @@
     "today": "Oggi",
     "noTimeHint": "Nessun orario — verrà usato mezzogiorno"
   },
+  "elapsed": {
+    "never": "mai",
+    "justNow": "proprio ora",
+    "minutesAgo": "{{count}} min fa",
+    "hoursAgo": "{{count}} h fa",
+    "yesterday": "ieri",
+    "daysAgo": "{{count}} g fa"
+  },
   "heatmap": {
     "completions_one": "{{count}} completamento",
     "completions_other": "{{count}} completamenti",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -169,6 +169,14 @@
     "today": "Hoje",
     "noTimeHint": "Sem hora — será usado o meio-dia"
   },
+  "elapsed": {
+    "never": "nunca",
+    "justNow": "agora mesmo",
+    "minutesAgo": "há {{count}} min",
+    "hoursAgo": "há {{count}} h",
+    "yesterday": "ontem",
+    "daysAgo": "há {{count}} d"
+  },
   "heatmap": {
     "completions_one": "{{count}} conclusão",
     "completions_other": "{{count}} conclusões",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -169,6 +169,14 @@
     "today": "Hoje",
     "noTimeHint": "Sem hora — será usado o meio-dia"
   },
+  "elapsed": {
+    "never": "nunca",
+    "justNow": "agora mesmo",
+    "minutesAgo": "há {{count}} min",
+    "hoursAgo": "há {{count}} h",
+    "yesterday": "ontem",
+    "daysAgo": "há {{count}} d"
+  },
   "heatmap": {
     "completions_one": "{{count}} conclusão",
     "completions_other": "{{count}} conclusões",

--- a/src/androidStrings.test.ts
+++ b/src/androidStrings.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * CI cannot compile the Android app, but the string resources are plain XML —
+ * so the mistakes that would break the next local build (or silently ship
+ * English) are checked here instead: a locale carrying a key the base file
+ * doesn't have (aapt error), a %1$d placeholder dropped in translation
+ * (runtime crash on getString with args), an unescaped apostrophe (aapt
+ * error), or a translatable key missing from a locale (silently English).
+ */
+const RES = join(__dirname, '../android/app/src/main/res')
+
+// Brand and configuration values, deliberately base-only.
+const UNTRANSLATED = new Set(['app_name', 'title_activity_main', 'package_name', 'custom_url_scheme'])
+
+function parseStrings(path: string): Map<string, string> {
+  const xml = readFileSync(path, 'utf8')
+  const out = new Map<string, string>()
+  for (const m of xml.matchAll(/<string name="([^"]+)">([\s\S]*?)<\/string>/g)) {
+    out.set(m[1], m[2])
+  }
+  return out
+}
+
+const base = parseStrings(join(RES, 'values/strings.xml'))
+const locales = readdirSync(RES).filter((d) => /^values-[a-z]{2}(-r[A-Z]{2})?$/.test(d))
+const placeholders = (v: string) => (v.match(/%\d\$[sd]/g) ?? []).sort().join(',')
+
+describe('Android string resources', () => {
+  it('found the locale directories', () => {
+    expect(locales.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it.each(locales)('%s carries no keys absent from the base file', (loc) => {
+    const strings = parseStrings(join(RES, loc, 'strings.xml'))
+    expect(strings.size).toBeGreaterThan(0)
+    const extra = [...strings.keys()].filter((k) => !base.has(k))
+    expect(extra, `${loc} has keys aapt would reject`).toEqual([])
+  })
+
+  it.each(locales)('%s translates every translatable key', (loc) => {
+    const strings = parseStrings(join(RES, loc, 'strings.xml'))
+    const missing = [...base.keys()].filter((k) => !UNTRANSLATED.has(k) && !strings.has(k))
+    expect(missing, `${loc} would silently render these in English`).toEqual([])
+  })
+
+  it.each(locales)('%s keeps every format placeholder', (loc) => {
+    const strings = parseStrings(join(RES, loc, 'strings.xml'))
+    const mismatched = [...strings]
+      .filter(([k, v]) => placeholders(v) !== placeholders(base.get(k) ?? ''))
+      .map(([k]) => k)
+    expect(mismatched, `${loc} placeholder mismatches crash getString at runtime`).toEqual([])
+  })
+
+  it.each(locales)('%s escapes apostrophes for aapt', (loc) => {
+    const strings = parseStrings(join(RES, loc, 'strings.xml'))
+    const bad = [...strings].filter(([, v]) => /(^|[^\\])'/.test(v)).map(([k]) => k)
+    expect(bad, `${loc} unescaped apostrophes fail the resource compile`).toEqual([])
+  })
+})

--- a/src/components/ChoreRow/ChoreRow.tsx
+++ b/src/components/ChoreRow/ChoreRow.tsx
@@ -37,7 +37,7 @@ export function ChoreRow({ chore, editMode, onTap, onEdit, onDelete, onRefresh, 
     : null
   const fillColor = ratio !== null ? getCadenceColor(ratio) : '#64748b'
   const fillWidth = ratio !== null ? `${Math.min(ratio * 100, 100)}%` : '0%'
-  const elapsedText = formatElapsed(chore.elapsed_days, chore.last_completed_at)
+  const elapsedText = formatElapsed(t, chore.elapsed_days, chore.last_completed_at)
 
   const ChoreIcon = chore.icon ? ICON_REGISTRY[chore.icon] : null
 

--- a/src/components/LogModal/LogModal.tsx
+++ b/src/components/LogModal/LogModal.tsx
@@ -84,7 +84,7 @@ export function LogModal({ chore, onClose, onLogged }: Props) {
     }
   }
 
-  const elapsedText = formatElapsed(chore.elapsed_days, chore.last_completed_at)
+  const elapsedText = formatElapsed(t, chore.elapsed_days, chore.last_completed_at)
   const stats = computeStats(completions)
   const heatmap = buildHeatmap(completions)
 

--- a/src/utils/cadence.ts
+++ b/src/utils/cadence.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs'
+import type { TFunction } from 'i18next'
 import relativeTime from 'dayjs/plugin/relativeTime'
 
 dayjs.extend(relativeTime)
@@ -73,16 +74,16 @@ function interpolateHex(a: string, b: string, t: number): string {
   return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${bv.toString(16).padStart(2, '0')}`
 }
 
-export function formatElapsed(elapsedDays: number | null, lastCompletedAt: string | null): string {
-  if (elapsedDays === null || lastCompletedAt === null) return 'never'
+export function formatElapsed(t: TFunction, elapsedDays: number | null, lastCompletedAt: string | null): string {
+  if (elapsedDays === null || lastCompletedAt === null) return t('elapsed.never')
   const diffMinutes = dayjs().diff(dayjs(lastCompletedAt), 'minute')
-  if (diffMinutes < 1) return 'just now'
-  if (diffMinutes < 60) return `${diffMinutes}m ago`
+  if (diffMinutes < 1) return t('elapsed.justNow')
+  if (diffMinutes < 60) return t('elapsed.minutesAgo', { count: diffMinutes })
   if (elapsedDays < 1) {
     const diffHours = Math.floor(diffMinutes / 60)
-    return `${diffHours}h ago`
+    return t('elapsed.hoursAgo', { count: diffHours })
   }
   const calendarDaysAgo = dayjs().startOf('day').diff(dayjs(lastCompletedAt).startOf('day'), 'day')
-  if (calendarDaysAgo === 1) return 'yesterday'
-  return `${calendarDaysAgo}d ago`
+  if (calendarDaysAgo === 1) return t('elapsed.yesterday')
+  return t('elapsed.daysAgo', { count: calendarDaysAgo })
 }


### PR DESCRIPTION
First of the native-strings PRs (lastGLANCE Android; iOS and the dayGLANCE pair follow). Android's native surfaces shipped English-only regardless of device language.

## Android

- **`values-de` / `-es` / `-fr` / `-it` / `-pt`** now carry the 29 translatable strings: widget picker labels and descriptions, the Soon-list title, Done buttons, "All caught up", the single-chore config dialog, launcher shortcuts, and Quick Settings tiles. `app_name` and config values stay base-only. Translations anchor on the web glossary (de *Bald/Erledigt/Aufgaben*, es *Pronto/Hecho/tareas*, fr *Bientôt/Fait/tâches*, it *Presto/Fatto/attività*, pt *Em breve/Feito/tarefas*).
- **One `values-pt` serves every Portuguese device**: all of these strings are common to the European and Brazilian standards, so pt, pt-PT, and pt-BR devices resolve to the same correct file. `values-pt-rBR` gets added the day a string diverges.
- **Kotlin display literals moved to resources**: the chore rows' `never`/`today`/`yesterday`/`Nd ago` (`elapsedLabel`, now taking `context`) and the `N overdue · N soon` subtitle shared by the heatmap widget and the Soon tile. All other Kotlin already used `getString`.
- Native surfaces follow the **OS language**, not the in-app picker — inherent to widgets, same as every app.

## The web app had the same bug

`formatElapsed()` — the "3d ago" / "never" under every chore in the main list — was hardcoded English and survived the localization port. It now takes `t` and reads a new `elapsed` section in all seven locales (pt-BR via the transform), with vocabulary matching the Android resources exactly, so the widget and the list finally agree in every language.

## Verification

- New `src/androidStrings.test.ts` (21 tests) guards the resources **in CI**, since CI can't compile Android: locale keys must exist in base (aapt would reject extras), every translatable key must be present in every locale (missing = silent English), format placeholders must survive translation (dropped `%1$d` = runtime crash), apostrophes must be escaped (aapt compile error).
- `npm run lint` clean, tests green (37 files, 486 tests), `npm run build` passes; web parity/placeholder/variant-purity tests enforce the new `elapsed` keys.
- **Not compiled here** — this environment has no Android SDK. The Kotlin diff is minimal (getString swaps plus one threaded `context` parameter), but run `./build-android.sh` locally before shipping. The elapsed labels in the web UI are verifiable in any browser; the widget rendering needs a device.

**Translation quality:** no native-speaker review; register and glossary match the existing localized web strings, from which most of these are drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_