### PR TITLE
Localize the iOS widget strings via a string catalog

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		EA00000000000000000000B2 /* WidgetBridgePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F3 /* WidgetBridgePlugin.swift */; };
 		EA00000000000000000000B3 /* SharedDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F2 /* SharedDataStore.swift */; };
 		EA00000000000000000000B4 /* GlanceWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F4 /* GlanceWidgetsBundle.swift */; };
+		EA00000000000000000000FD /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000FC /* Localizable.xcstrings */; };
 		EA00000000000000000000B5 /* HeatmapWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F5 /* HeatmapWidget.swift */; };
 		EA00000000000000000000B6 /* Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F6 /* Snapshot.swift */; };
 		EA00000000000000000000B8 /* LucidePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000FA /* LucidePath.swift */; };
@@ -95,6 +96,7 @@
 		EA00000000000000000000F6 /* Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snapshot.swift; sourceTree = "<group>"; };
 		EA00000000000000000000F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EA00000000000000000000F8 /* GlanceWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GlanceWidgets.entitlements; sourceTree = "<group>"; };
+		EA00000000000000000000FC /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		EA00000000000000000000FA /* LucidePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LucidePath.swift; sourceTree = "<group>"; };
 		EA00000000000000000000FB /* LucideIcons.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LucideIcons.generated.swift; sourceTree = "<group>"; };
 		EA00000000000000000000E1 /* SnapshotProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotProvider.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 				EA00000000000000000000FB /* LucideIcons.generated.swift */,
 				EA00000000000000000000F7 /* Info.plist */,
 				EA00000000000000000000F8 /* GlanceWidgets.entitlements */,
+				EA00000000000000000000FC /* Localizable.xcstrings */,
 			);
 			path = GlanceWidgets;
 			sourceTree = "<group>";
@@ -321,6 +324,12 @@
 			knownRegions = (
 				en,
 				Base,
+				de,
+				es,
+				fr,
+				it,
+				"pt-PT",
+				"pt-BR",
 			);
 			mainGroup = 504EC2FB1FED79650016851F;
 			packageReferences = (
@@ -355,6 +364,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA00000000000000000000FD /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/GlanceWidgets/ChoreSnapshot.swift
+++ b/ios/App/GlanceWidgets/ChoreSnapshot.swift
@@ -51,7 +51,7 @@ extension SnapshotChore {
     // elapsedDays alone is a duration and gets that wrong (a 10pm→8am gap is
     // under 24h). Falls back to the duration when the timestamp is missing.
     var elapsedLabel: String {
-        guard elapsedDays != nil else { return "never" }
+        guard elapsedDays != nil else { return String(localized: "never") }
         if let iso = lastCompletedAt, let then = isoMillisFormatter.date(from: iso) {
             let calendar = Calendar.current
             let days = calendar.dateComponents(
@@ -60,14 +60,14 @@ extension SnapshotChore {
                 to: calendar.startOfDay(for: Date())
             ).day ?? 0
             switch days {
-            case ...0: return "today"
-            case 1: return "yesterday"
-            default: return "\(days)d ago"
+            case ...0: return String(localized: "today")
+            case 1: return String(localized: "yesterday")
+            default: return String(localized: "\(days)d ago")
             }
         }
         let d = elapsedDays ?? 0
-        if d < 1 { return "today" }
-        return "\(Int(d.rounded()))d ago"
+        if d < 1 { return String(localized: "today") }
+        return String(localized: "\(Int(d.rounded()))d ago")
     }
 
     // The recency colour the snapshot shipped, with the same two fallbacks as

--- a/ios/App/GlanceWidgets/HeatmapWidget.swift
+++ b/ios/App/GlanceWidgets/HeatmapWidget.swift
@@ -404,15 +404,15 @@ struct HeatmapWidgetView: View {
             HStack(alignment: .top, spacing: 0) {
                 StatTile(
                     value: "\(stats.completions)",
-                    label: plural(stats.completions, "completion", "completions")
+                    label: plural(stats.completions, String(localized: "completion"), String(localized: "completions"))
                 )
                 Spacer(minLength: 16)
                 StatTile(
                     value: "\(stats.activeDays)",
-                    label: plural(stats.activeDays, "active day", "active days")
+                    label: plural(stats.activeDays, String(localized: "active day"), String(localized: "active days"))
                 )
                 Spacer(minLength: 16)
-                StatTile(value: "\(stats.streak)", label: "day streak")
+                StatTile(value: "\(stats.streak)", label: String(localized: "day streak"))
             }
 
             Spacer(minLength: 0)

--- a/ios/App/GlanceWidgets/Localizable.xcstrings
+++ b/ios/App/GlanceWidgets/Localizable.xcstrings
@@ -1,0 +1,1446 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "%@ · %lld overdue": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld überfällig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld vencidas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld en retard"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld in ritardo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld atrasadas"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %lld atrasadas"
+          }
+        }
+      }
+    },
+    "%lld overdue": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld überfällig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld vencidas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld en retard"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld in ritardo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld atrasadas"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld atrasadas"
+          }
+        }
+      }
+    },
+    "%lld overdue · %lld soon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld überfällig · %lld bald fällig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld vencidas · %lld por vencer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld en retard · %lld bientôt"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld in ritardo · %lld in scadenza"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld atrasadas · %lld a vencer"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld atrasadas · %lld a vencer"
+          }
+        }
+      }
+    },
+    "%lldd ago": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vor %lld T."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hace %lld d"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "il y a %lld j"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld g fa"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "há %lld d"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "há %lld d"
+          }
+        }
+      }
+    },
+    "+%lld more": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld weitere"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld más"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld de plus"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld altre"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld mais"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld mais"
+          }
+        }
+      }
+    },
+    "A one-tap shortcut to add a new chore.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine neue Aufgabe mit einem Tipp hinzufügen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un acceso de un toque para añadir una nueva tarea."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un raccourci pour ajouter une nouvelle tâche en un geste."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una scorciatoia per aggiungere una nuova attività con un tocco."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um atalho de um toque para adicionar uma nova tarefa."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um atalho de um toque para adicionar uma nova tarefa."
+          }
+        }
+      }
+    },
+    "Activity": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivität"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actividad"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activité"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attività"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atividade"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atividade"
+          }
+        }
+      }
+    },
+    "Add chore": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgabe hinzufügen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Añadir tarea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajouter une tâche"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiungi attività"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar tarefa"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adicionar tarefa"
+          }
+        }
+      }
+    },
+    "All caught up": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alles erledigt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo al día"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tout est à jour"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutto fatto"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tudo em dia"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tudo em dia"
+          }
+        }
+      }
+    },
+    "Choose chore": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgabe wählen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir tarea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir la tâche"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli attività"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolher tarefa"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolher tarefa"
+          }
+        }
+      }
+    },
+    "Chore": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgabe"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tâche"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attività"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarefa"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarefa"
+          }
+        }
+      }
+    },
+    "Chores that are due soon or overdue, with one-tap Done.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgaben, die bald fällig oder überfällig sind, mit Erledigt per Tipp."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tareas próximas a vencer o vencidas, con Hecho en un toque."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les tâches bientôt dues ou en retard, avec Fait en un geste."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attività in scadenza o in ritardo, con Fatto in un tocco."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarefas a vencer em breve ou atrasadas, com Feito num toque."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tarefas a vencer em breve ou atrasadas, com Feito num toque."
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erledigt"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hecho"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fait"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fatto"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feito"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feito"
+          }
+        }
+      }
+    },
+    "How many chores need attention, on your Lock Screen.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wie viele Aufgaben Aufmerksamkeit brauchen – auf deinem Sperrbildschirm."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuántas tareas necesitan atención, en tu pantalla de bloqueo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Combien de tâches demandent de l'attention, sur votre écran verrouillé."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quante attività hanno bisogno di attenzione, sulla schermata di blocco."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quantas tarefas precisam de atenção, no ecrã bloqueado."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quantas tarefas precisam de atenção, na tela de bloqueio."
+          }
+        }
+      }
+    },
+    "Less": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weniger"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moins"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meno"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menos"
+          }
+        }
+      }
+    },
+    "Mark chore done": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufgabe als erledigt markieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar tarea como hecha"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marquer la tâche comme faite"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Segna attività come fatta"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar tarefa como concluída"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Marcar tarefa como concluída"
+          }
+        }
+      }
+    },
+    "More": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mehr"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Más"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Più"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mais"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mais"
+          }
+        }
+      }
+    },
+    "One chore and how long it has been, with one-tap Done. Edit the widget to pick which.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine Aufgabe und wie lange es her ist, mit Erledigt per Tipp. Widget bearbeiten, um sie zu wählen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una tarea y cuánto hace de la última vez, con Hecho en un toque. Edita el widget para elegirla."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une tâche et depuis combien de temps, avec Fait en un geste. Modifiez le widget pour la choisir."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un'attività e da quanto tempo, con Fatto in un tocco. Modifica il widget per sceglierla."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma tarefa e há quanto tempo foi, com Feito num toque. Edite o widget para a escolher."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma tarefa e há quanto tempo foi, com Feito num toque. Edite o widget para escolhê-la."
+          }
+        }
+      }
+    },
+    "Open lastGLANCE once to sync.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffne lastGLANCE einmal zum Synchronisieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre lastGLANCE una vez para sincronizar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrez lastGLANCE une fois pour synchroniser."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri lastGLANCE una volta per sincronizzare."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o lastGLANCE uma vez para sincronizar."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abra o lastGLANCE uma vez para sincronizar."
+          }
+        }
+      }
+    },
+    "Open lastGLANCE ready to add a new chore.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Öffnet lastGLANCE direkt beim Hinzufügen einer neuen Aufgabe."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre lastGLANCE listo para añadir una nueva tarea."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvre lastGLANCE prêt à ajouter une nouvelle tâche."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apre lastGLANCE pronto per aggiungere una nuova attività."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre o lastGLANCE pronto para adicionar uma nova tarefa."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abre o lastGLANCE pronto para adicionar uma nova tarefa."
+          }
+        }
+      }
+    },
+    "Overdue at a glance": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überfälliges auf einen Blick"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrasadas de un vistazo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En retard en un coup d'œil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In ritardo a colpo d'occhio"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrasadas num relance"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atrasadas num relance"
+          }
+        }
+      }
+    },
+    "Pick the chore this widget tracks.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wähle die Aufgabe, die dieses Widget zeigt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elige la tarea que sigue este widget."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisissez la tâche suivie par ce widget."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegli l'attività seguita da questo widget."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha a tarefa que este widget acompanha."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolha a tarefa que este widget acompanha."
+          }
+        }
+      }
+    },
+    "SOON": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BALD"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRONTO"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BIENTÔT"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PRESTO"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EM BREVE"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "EM BREVE"
+          }
+        }
+      }
+    },
+    "Snapshot unreadable.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot nicht lesbar."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instantánea ilegible."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instantané illisible."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Snapshot illeggibile."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instantâneo ilegível."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instantâneo ilegível."
+          }
+        }
+      }
+    },
+    "Soon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bald"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pronto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bientôt"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Presto"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em breve"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em breve"
+          }
+        }
+      }
+    },
+    "Your completion history at a glance.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dein Erledigungsverlauf auf einen Blick."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu historial de tareas completadas de un vistazo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Votre historique de réalisations en un coup d'œil."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La tua cronologia di completamenti a colpo d'occhio."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O seu histórico de conclusões num relance."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O seu histórico de conclusões num relance."
+          }
+        }
+      }
+    },
+    "active day": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aktiver Tag"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "día activo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jour actif"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "giorno attivo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dia ativo"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dia ativo"
+          }
+        }
+      }
+    },
+    "active days": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aktive Tage"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "días activos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jours actifs"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "giorni attivi"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dias ativos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dias ativos"
+          }
+        }
+      }
+    },
+    "completion": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erledigung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "completada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "réalisation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "completamento"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conclusão"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conclusão"
+          }
+        }
+      }
+    },
+    "completions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erledigungen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "completadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "réalisations"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "completamenti"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conclusões"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "conclusões"
+          }
+        }
+      }
+    },
+    "day streak": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tage in Folge"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "días seguidos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jours d'affilée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "giorni di fila"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dias seguidos"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "dias seguidos"
+          }
+        }
+      }
+    },
+    "due": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "fällig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "vencidas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "en retard"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "in ritardo"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "atrasadas"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "atrasadas"
+          }
+        }
+      }
+    },
+    "lastGLANCE · %lld overdue, %lld soon": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lastGLANCE · %lld überfällig, %lld bald fällig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lastGLANCE · %lld vencidas, %lld por vencer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lastGLANCE · %lld en retard, %lld bientôt"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lastGLANCE · %lld in ritardo, %lld in scadenza"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lastGLANCE · %lld atrasadas, %lld a vencer"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "lastGLANCE · %lld atrasadas, %lld a vencer"
+          }
+        }
+      }
+    },
+    "never": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nie"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nunca"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "jamais"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mai"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nunca"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "nunca"
+          }
+        }
+      }
+    },
+    "today": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "heute"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hoy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "aujourd'hui"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "oggi"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hoje"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hoje"
+          }
+        }
+      }
+    },
+    "yesterday": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gestern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ayer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "hier"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ieri"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ontem"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ontem"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/ios/App/GlanceWidgets/Snapshot.swift
+++ b/ios/App/GlanceWidgets/Snapshot.swift
@@ -127,8 +127,8 @@ enum SnapshotLoad {
         switch self {
         case .loaded: return nil
         case .appGroupUnavailable: return "App Group unavailable.\nCheck the GlanceWidgets entitlement."
-        case .noSnapshotYet: return "Open lastGLANCE once to sync."
-        case .undecodable: return "Snapshot unreadable."
+        case .noSnapshotYet: return String(localized: "Open lastGLANCE once to sync.")
+        case .undecodable: return String(localized: "Snapshot unreadable.")
         }
     }
 

--- a/src/iosStrings.test.ts
+++ b/src/iosStrings.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { EUROPEAN_ONLY, BRAZILIAN_ONLY } from './ptMarkers'
+
+/**
+ * CI cannot run Xcode, so the widget string catalog and its project wiring
+ * are validated here instead: a language dropped from a key ships English on
+ * that device, a format specifier lost in translation truncates or crashes
+ * at render, a duplicate pbxproj object id corrupts the project the next
+ * time Xcode loads it, and a wrong-standard Portuguese word is exactly what
+ * the variant guardrail exists to stop.
+ */
+const IOS = join(__dirname, '../ios/App')
+const CATALOG = join(IOS, 'GlanceWidgets/Localizable.xcstrings')
+const PBXPROJ = join(IOS, 'App.xcodeproj/project.pbxproj')
+
+const LANGS = ['de', 'es', 'fr', 'it', 'pt-PT', 'pt-BR']
+
+interface StringUnit { stringUnit: { state: string; value: string } }
+interface CatalogEntry { localizations?: Record<string, StringUnit> }
+interface Catalog { sourceLanguage: string; strings: Record<string, CatalogEntry>; version: string }
+
+const catalog: Catalog = JSON.parse(readFileSync(CATALOG, 'utf8'))
+const entries = Object.entries(catalog.strings)
+const specifiers = (v: string) => (v.match(/%(lld|@|d)/g) ?? []).sort().join(',')
+
+describe('GlanceWidgets string catalog', () => {
+  it('parses and declares en as the source language', () => {
+    expect(catalog.sourceLanguage).toBe('en')
+    expect(entries.length).toBeGreaterThan(20)
+  })
+
+  it.each(LANGS)('every key carries a translated %s value', (lng) => {
+    const missing = entries
+      .filter(([, e]) => e.localizations && !e.localizations[lng]?.stringUnit?.value)
+      .map(([k]) => k)
+    expect(missing, `these keys would render English on ${lng} devices`).toEqual([])
+  })
+
+  it('keeps every format specifier in every translation', () => {
+    const bad: string[] = []
+    for (const [key, e] of entries) {
+      for (const [lng, unit] of Object.entries(e.localizations ?? {})) {
+        if (specifiers(unit.stringUnit.value) !== specifiers(key)) bad.push(`${lng}: ${key}`)
+      }
+    }
+    expect(bad, 'specifier mismatches truncate or crash at render').toEqual([])
+  })
+
+  it('holds pt-PT to the European standard', () => {
+    const violations: string[] = []
+    for (const [key, e] of entries) {
+      const v = e.localizations?.['pt-PT']?.stringUnit?.value ?? ''
+      for (const [marker, pattern] of Object.entries(BRAZILIAN_ONLY)) {
+        if (pattern.test(v)) violations.push(`${key}: "${v}" — ${marker}`)
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('holds pt-BR to the Brazilian standard', () => {
+    const violations: string[] = []
+    for (const [key, e] of entries) {
+      const v = e.localizations?.['pt-BR']?.stringUnit?.value ?? ''
+      for (const [marker, pattern] of Object.entries(EUROPEAN_ONLY)) {
+        if (pattern.test(v)) violations.push(`${key}: "${v}" — ${marker}`)
+      }
+    }
+    expect(violations).toEqual([])
+  })
+})
+
+describe('pbxproj wiring', () => {
+  const pbx = readFileSync(PBXPROJ, 'utf8')
+
+  it('defines every object id exactly once', () => {
+    const defined = [...pbx.matchAll(/^\t\t([0-9A-F]{24}) [^=]*= \{/gm)].map((m) => m[1])
+    const dupes = defined.filter((id, i) => defined.indexOf(id) !== i)
+    expect(dupes, 'duplicate ids corrupt the project when Xcode next loads it').toEqual([])
+  })
+
+  it('registers the catalog as file, build file, and resource', () => {
+    expect(pbx).toContain('/* Localizable.xcstrings */ = {isa = PBXFileReference')
+    expect(pbx).toContain('/* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile')
+    expect(pbx.match(/Localizable\.xcstrings in Resources \*\//g)?.length).toBe(2)
+  })
+
+  it('declares every catalog language in knownRegions', () => {
+    const region = pbx.slice(pbx.indexOf('knownRegions'), pbx.indexOf(');', pbx.indexOf('knownRegions')))
+    for (const lng of LANGS) expect(region, `knownRegions missing ${lng}`).toContain(lng)
+  })
+})

--- a/src/localeVariants.test.ts
+++ b/src/localeVariants.test.ts
@@ -1,81 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest'
 import { languages, loaders } from './locales'
-
-/**
- * Portuguese ships in two written standards, and the difference is lexical
- * enough to check mechanically. A word from the wrong standard is not a
- * subtlety a reader forgives — a Brazilian meeting "ficheiro" or "ecrã" reads
- * a foreign dialect, not a typo.
- *
- * Both lists below were calibrated against real files rather than assembled
- * from a grammar: every European marker was checked against lifeGLANCE's
- * Brazilian pt locale and every Brazilian marker against this app's European
- * one, and anything that fired was investigated and either fixed or dropped.
- * Words that are correct in BOTH standards are deliberately absent even where
- * they are stylistically preferred in one:
- *
- *   padrão      "pattern" in both; only "default" is a BR/EU split
- *   separador   a visual separator in both, not only a UI tab
- *   ligação     a phone call in Brazil, a connection in Portugal
- *   transferir  a transfer in Brazil, a download in Portugal
- *   excluir     "to exclude" in both, alongside BR "to delete"
- *
- * Keeping them out costs a little coverage and buys a guardrail that does not
- * cry wolf. Add a marker only after checking it against both files.
- */
-const EUROPEAN_ONLY: Record<string, RegExp> = {
-  ficheiro: /\bficheiros?\b/i,
-  utilizador: /\butilizador(es)?\b/i,
-  // JavaScript's \b is ASCII-only, so a trailing accented letter is not a word
-  // character and \b after it never matches: /\becrã\b/ silently matches
-  // nothing. Any marker ending in an accent uses a lookahead instead, and the
-  // self-test below fails on a pattern that cannot match its own name.
-  ecrã: /\becrãs?(?![a-zà-ÿ])/i,
-  aplicação: /\baplicaç(ão|ões)\b/i,
-  definições: /\bdefinições\b/i,
-  'palavra-passe': /\bpalavras?-passe\b/i,
-  'frase-passe': /\bfrases?-passe\b/i,
-  telemóvel: /\btelemó(vel|veis)\b/i,
-  registo: /\bregistos?\b/i,
-  contacto: /\bcontactos?\b/i,
-  predefinição: /\bpredefini(?:ç(?:ão|ões)|d[oa]s?)(?![a-zà-ÿ])/i,
-  secção: /\bsecç(?:ão|ões)(?![a-zà-ÿ])/i,
-  contentor: /\bcontentor(es)?\b/i,
-  partilhar: /\bpartilh\w+\b/i,
-  aceder: /\bacede\w*\b/i,
-  guardar: /\bguardar\b/i,
-  carregue: /\bcarregue\b/i,
-  premir: /\bpremir\b/i,
-  autoalojado: /\bautoalojad[oa]s?\b/i,
-  desfasado: /\bdesfasad[oa]s?\b/i,
-  noutro: /\bnoutr[oa]s?\b/i,
-  // "está a sincronizar" — Portugal's progressive. Brazil uses the gerund.
-  'está a + infinitivo': /\best(á|ão) a \w+[aei]r\b/i,
-  // "precisa de ser atualizado" — European before an infinitive only; before a
-  // noun ("precisa de ajuda") it is correct in both, hence the ending.
-  'precisa de + infinitivo': /\b(precisa|precisam|tem|têm) de \w+[aei]r\b/i,
-}
-
-const BRAZILIAN_ONLY: Record<string, RegExp> = {
-  arquivo: /\barquivos?\b/i,
-  usuário: /\busuários?\b/i,
-  aplicativo: /\baplicativos?\b/i,
-  tela: /\btelas?\b/i,
-  configurações: /\bconfigurações\b/i,
-  senha: /\bsenhas?\b/i,
-  celular: /\bcelular(es)?\b/i,
-  registro: /\bregistros?\b/i,
-  contato: /\bcontatos?\b/i,
-  aba: /\babas?\b/i,
-  conexão: /\bconex(ão|ões)\b/i,
-  mouse: /\bmouse\b/i,
-  compartilhar: /\bcompartilh\w+\b/i,
-  baixar: /\bbaixar\b/i,
-  contêiner: /\bcontêiner(es)?\b/i,
-  // "está sincronizando" — Brazil's progressive.
-  'gerúndio progressivo': /\best(á|ão) \w+ndo\b/i,
-  'precisa + infinitivo': /\b(precisa|precisam) (ser|estar|\w+[aei]r)\b/i,
-}
+import { EUROPEAN_ONLY, BRAZILIAN_ONLY, MARKER_CONSTRUCTIONS } from './ptMarkers'
 
 // Which standard each shipped Portuguese locale must hold to. A bare "pt" is
 // European because that is what this app's single locale has always been —
@@ -117,13 +42,7 @@ describe('Portuguese variant purity', () => {
     (name, pattern) => {
       // Multi-word grammatical markers are named for the construction, not a
       // literal string, so they are exercised by the sample phrases instead.
-      const constructions: Record<string, string> = {
-        'está a + infinitivo': 'está a sincronizar',
-        'precisa de + infinitivo': 'precisa de ser atualizado',
-        'gerúndio progressivo': 'está sincronizando',
-        'precisa + infinitivo': 'precisa ser atualizado',
-      }
-      expect(pattern.test(constructions[name] ?? name)).toBe(true)
+      expect(pattern.test(MARKER_CONSTRUCTIONS[name] ?? name)).toBe(true)
     },
   )
 

--- a/src/ptMarkers.ts
+++ b/src/ptMarkers.ts
@@ -1,0 +1,85 @@
+/**
+ * Portuguese ships in two written standards, and the difference is lexical
+ * enough to check mechanically. A word from the wrong standard is not a
+ * subtlety a reader forgives — a Brazilian meeting "ficheiro" or "ecrã" reads
+ * a foreign dialect, not a typo.
+ *
+ * Both lists below were calibrated against real files rather than assembled
+ * from a grammar: every European marker was checked against lifeGLANCE's
+ * Brazilian pt locale and every Brazilian marker against this app's European
+ * one, and anything that fired was investigated and either fixed or dropped.
+ * Words that are correct in BOTH standards are deliberately absent even where
+ * they are stylistically preferred in one:
+ *
+ *   padrão      "pattern" in both; only "default" is a BR/EU split
+ *   separador   a visual separator in both, not only a UI tab
+ *   ligação     a phone call in Brazil, a connection in Portugal
+ *   transferir  a transfer in Brazil, a download in Portugal
+ *   excluir     "to exclude" in both, alongside BR "to delete"
+ *
+ * Keeping them out costs a little coverage and buys a guardrail that does not
+ * cry wolf. Add a marker only after checking it against both files.
+ */
+export const EUROPEAN_ONLY: Record<string, RegExp> = {
+  ficheiro: /\bficheiros?\b/i,
+  utilizador: /\butilizador(es)?\b/i,
+  // JavaScript's \b is ASCII-only, so a trailing accented letter is not a word
+  // character and \b after it never matches: /\becrã\b/ silently matches
+  // nothing. Any marker ending in an accent uses a lookahead instead, and the
+  // self-test below fails on a pattern that cannot match its own name.
+  ecrã: /\becrãs?(?![a-zà-ÿ])/i,
+  aplicação: /\baplicaç(ão|ões)\b/i,
+  definições: /\bdefinições\b/i,
+  'palavra-passe': /\bpalavras?-passe\b/i,
+  'frase-passe': /\bfrases?-passe\b/i,
+  telemóvel: /\btelemó(vel|veis)\b/i,
+  registo: /\bregistos?\b/i,
+  contacto: /\bcontactos?\b/i,
+  predefinição: /\bpredefini(?:ç(?:ão|ões)|d[oa]s?)(?![a-zà-ÿ])/i,
+  secção: /\bsecç(?:ão|ões)(?![a-zà-ÿ])/i,
+  contentor: /\bcontentor(es)?\b/i,
+  partilhar: /\bpartilh\w+\b/i,
+  aceder: /\bacede\w*\b/i,
+  guardar: /\bguardar\b/i,
+  carregue: /\bcarregue\b/i,
+  premir: /\bpremir\b/i,
+  autoalojado: /\bautoalojad[oa]s?\b/i,
+  desfasado: /\bdesfasad[oa]s?\b/i,
+  noutro: /\bnoutr[oa]s?\b/i,
+  // "está a sincronizar" — Portugal's progressive. Brazil uses the gerund.
+  'está a + infinitivo': /\best(á|ão) a \w+[aei]r\b/i,
+  // "precisa de ser atualizado" — European before an infinitive only; before a
+  // noun ("precisa de ajuda") it is correct in both, hence the ending.
+  'precisa de + infinitivo': /\b(precisa|precisam|tem|têm) de \w+[aei]r\b/i,
+}
+
+export const BRAZILIAN_ONLY: Record<string, RegExp> = {
+  arquivo: /\barquivos?\b/i,
+  usuário: /\busuários?\b/i,
+  aplicativo: /\baplicativos?\b/i,
+  tela: /\btelas?\b/i,
+  configurações: /\bconfigurações\b/i,
+  senha: /\bsenhas?\b/i,
+  celular: /\bcelular(es)?\b/i,
+  registro: /\bregistros?\b/i,
+  contato: /\bcontatos?\b/i,
+  aba: /\babas?\b/i,
+  conexão: /\bconex(ão|ões)\b/i,
+  mouse: /\bmouse\b/i,
+  compartilhar: /\bcompartilh\w+\b/i,
+  baixar: /\bbaixar\b/i,
+  contêiner: /\bcontêiner(es)?\b/i,
+  // "está sincronizando" — Brazil's progressive.
+  'gerúndio progressivo': /\best(á|ão) \w+ndo\b/i,
+  'precisa + infinitivo': /\b(precisa|precisam) (ser|estar|\w+[aei]r)\b/i,
+}
+
+
+// Sample phrases for the multi-word grammatical markers, used by the
+// self-tests that assert every pattern can match what it is named for.
+export const MARKER_CONSTRUCTIONS: Record<string, string> = {
+  'está a + infinitivo': 'está a sincronizar',
+  'precisa de + infinitivo': 'precisa de ser atualizado',
+  'gerúndio progressivo': 'está sincronizando',
+  'precisa + infinitivo': 'precisa ser atualizado',
+}


### PR DESCRIPTION
Second native-strings PR (lastGLANCE iOS). **Stacked on #299** so this diff shows only the iOS work — retarget to `main` when #299 merges.

## What ships

- **`GlanceWidgets/Localizable.xcstrings`** — a String Catalog with all 36 user-facing keys in de/es/fr/it/pt-PT/pt-BR: widget gallery names and descriptions, the Soon list, Done buttons, "All caught up", Lock Screen accessories ("N overdue · N soon", "due"), the Control Center control, intent titles ("Mark chore done", "Choose chore"), heatmap legend and stat labels, elapsed labels, and the two reachable snapshot status messages.
- **pbxproj wiring by hand** (no Xcode here): file reference + build file + the extension's Resources phase + `knownRegions` extended with the six languages. Object IDs verified unique — my first pick collided with `LucidePath.swift`'s ID, which is exactly why the new test checks for duplicates.
- **Minimal Swift changes** — SwiftUI `Text` literals, `configurationDisplayName`/`.description`, `LocalizedStringResource` titles, and `@Parameter` titles all localize from the catalog automatically. Only the four plain-`String` sites needed `String(localized:)`: `ChoreSnapshot.elapsedLabel`, the two snapshot status messages, and the heatmap stat labels. The App Group misconfiguration message deliberately stays English (it flags a build error, not a user state).
- **Portuguese splits only where the standards diverge**: *ecrã*/*tela* in the Lock Screen description, and the clitic "para **a escolher**" (pt-PT) vs "para **escolhê-la**" (pt-BR) in the chore-widget description. Everything else is common Portuguese. Vocabulary matches the Android resources (#299) and the web app exactly — the widget, the tile, and the list agree in every language.

## CI guardrails (new `src/iosStrings.test.ts`, 13 tests)

Since CI can't run Xcode: every key must carry all six languages (else silent English per-device); format specifiers (`%lld`, `%@`) must survive translation (else truncation/crash at render); **pt-PT/pt-BR values are held to their standards** by the shared marker lists — extracted to `src/ptMarkers.ts`, now used by both this test and `localeVariants.test.ts`; and the pbxproj must define every object ID exactly once with the catalog registered and all languages in `knownRegions`.

## Verification

`npm run lint` clean, tests green (38 files, 499 tests), `npm run build` passes. **Not compiled here — no Xcode on this machine.** The Swift diff is four `String(localized:)` wraps; the pbxproj edits follow the file's existing hand-authored style and are structurally validated by the tests. Before release: build locally, and click through the widget gallery on a device/simulator set to one of the six languages (`SoonListWidget` etc. under Settings → Language on the sim is the quickest check).

**Translation quality:** no native-speaker review; wording is drawn from the already-localized web strings wherever an equivalent exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_