### PR TITLE
Localize the iOS share extension

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		EA00000000000000000000C8 /* AccessoryWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E8 /* AccessoryWidgets.swift */; };
 		EA00000000000000000000C9 /* SecureStorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E9 /* SecureStorePlugin.swift */; };
 		EB00000000000000000000C1 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000E1 /* ShareViewController.swift */; };
+		EB00000000000000000000FB /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000FA /* Localizable.xcstrings */; };
 		EB00000000000000000000C2 /* SharedDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F2 /* SharedDataStore.swift */; };
 		EB00000000000000000000B7 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000F9 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		EA00000000000000000000B7 /* GlanceWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000F9 /* GlanceWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -111,6 +112,7 @@
 		EB00000000000000000000E1 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		EB00000000000000000000F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EB00000000000000000000F8 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
+		EB00000000000000000000FA /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		EB00000000000000000000F9 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA00000000000000000000F9 /* GlanceWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GlanceWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -229,6 +231,7 @@
 				EB00000000000000000000E1 /* ShareViewController.swift */,
 				EB00000000000000000000F7 /* Info.plist */,
 				EB00000000000000000000F8 /* ShareExtension.entitlements */,
+				EB00000000000000000000FA /* Localizable.xcstrings */,
 			);
 			path = ShareExtension;
 			sourceTree = "<group>";
@@ -372,6 +375,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EB00000000000000000000FB /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/ShareExtension/Localizable.xcstrings
+++ b/ios/App/ShareExtension/Localizable.xcstrings
@@ -1,0 +1,206 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "%@\n\nIt'll be waiting as a new chore next time you open the app.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nSie wartet als neue Aufgabe, wenn du die App das nächste Mal öffnest."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nTe estará esperando como nueva tarea la próxima vez que abras la app."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nElle vous attendra comme nouvelle tâche à la prochaine ouverture de l'app."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nTi aspetterà come nuova attività alla prossima apertura dell'app."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nFicará à espera como nova tarefa da próxima vez que abrir a app."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@\n\nEla estará esperando como nova tarefa na próxima vez que você abrir o app."
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fertig"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Listo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fine"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concluído"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concluído"
+          }
+        }
+      }
+    },
+    "Nothing to save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichts zu speichern"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nada que guardar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rien à enregistrer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niente da salvare"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nada para guardar"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nada para salvar"
+          }
+        }
+      }
+    },
+    "Saved to lastGLANCE": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In lastGLANCE gespeichert"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado en lastGLANCE"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistré dans lastGLANCE"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvato in lastGLANCE"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guardado no lastGLANCE"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salvo no lastGLANCE"
+          }
+        }
+      }
+    },
+    "This item didn't contain any text or link lastGLANCE could use.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dieses Element enthielt keinen Text und keinen Link, den lastGLANCE verwenden kann."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este elemento no contenía texto ni enlaces que lastGLANCE pueda usar."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cet élément ne contenait ni texte ni lien utilisable par lastGLANCE."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo elemento non conteneva testo o link utilizzabili da lastGLANCE."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este item não continha texto nem ligações que o lastGLANCE possa usar."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este item não continha texto nem links que o lastGLANCE possa usar."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/ios/App/ShareExtension/ShareViewController.swift
+++ b/ios/App/ShareExtension/ShareViewController.swift
@@ -121,7 +121,7 @@ final class ShareViewController: UIViewController {
         detail.numberOfLines = 4
         detail.textAlignment = .center
 
-        doneButton.setTitle("Done", for: .normal)
+        doneButton.setTitle(String(localized: "Done"), for: .normal)
         doneButton.setTitleColor(brandGreen, for: .normal)
         doneButton.titleLabel?.font = .systemFont(ofSize: 17, weight: .semibold)
         doneButton.addTarget(self, action: #selector(finish), for: .touchUpInside)
@@ -147,11 +147,11 @@ final class ShareViewController: UIViewController {
 
     private func show(saved: String?) {
         if let name = saved {
-            headline.text = "Saved to lastGLANCE"
-            detail.text = "\(name)\n\nIt'll be waiting as a new chore next time you open the app."
+            headline.text = String(localized: "Saved to lastGLANCE")
+            detail.text = String(localized: "\(name)\n\nIt'll be waiting as a new chore next time you open the app.")
         } else {
-            headline.text = "Nothing to save"
-            detail.text = "This item didn't contain any text or link lastGLANCE could use."
+            headline.text = String(localized: "Nothing to save")
+            detail.text = String(localized: "This item didn't contain any text or link lastGLANCE could use.")
         }
         UIView.animate(withDuration: 0.2) { self.card.alpha = 1 }
     }

--- a/src/iosStrings.test.ts
+++ b/src/iosStrings.test.ts
@@ -12,7 +12,7 @@ import { EUROPEAN_ONLY, BRAZILIAN_ONLY } from './ptMarkers'
  * the variant guardrail exists to stop.
  */
 const IOS = join(__dirname, '../ios/App')
-const CATALOG = join(IOS, 'GlanceWidgets/Localizable.xcstrings')
+const CATALOGS = ['GlanceWidgets/Localizable.xcstrings', 'ShareExtension/Localizable.xcstrings']
 const PBXPROJ = join(IOS, 'App.xcodeproj/project.pbxproj')
 
 const LANGS = ['de', 'es', 'fr', 'it', 'pt-PT', 'pt-BR']
@@ -21,14 +21,14 @@ interface StringUnit { stringUnit: { state: string; value: string } }
 interface CatalogEntry { localizations?: Record<string, StringUnit> }
 interface Catalog { sourceLanguage: string; strings: Record<string, CatalogEntry>; version: string }
 
-const catalog: Catalog = JSON.parse(readFileSync(CATALOG, 'utf8'))
-const entries = Object.entries(catalog.strings)
 const specifiers = (v: string) => (v.match(/%(lld|@|d)/g) ?? []).sort().join(',')
 
-describe('GlanceWidgets string catalog', () => {
+describe.each(CATALOGS)('%s', (rel) => {
+  const catalog: Catalog = JSON.parse(readFileSync(join(IOS, rel), 'utf8'))
+  const entries = Object.entries(catalog.strings)
   it('parses and declares en as the source language', () => {
     expect(catalog.sourceLanguage).toBe('en')
-    expect(entries.length).toBeGreaterThan(20)
+    expect(entries.length).toBeGreaterThan(2)
   })
 
   it.each(LANGS)('every key carries a translated %s value', (lng) => {
@@ -80,10 +80,10 @@ describe('pbxproj wiring', () => {
     expect(dupes, 'duplicate ids corrupt the project when Xcode next loads it').toEqual([])
   })
 
-  it('registers the catalog as file, build file, and resource', () => {
-    expect(pbx).toContain('/* Localizable.xcstrings */ = {isa = PBXFileReference')
-    expect(pbx).toContain('/* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile')
-    expect(pbx.match(/Localizable\.xcstrings in Resources \*\//g)?.length).toBe(2)
+  it('registers both catalogs as files, build files, and resources', () => {
+    expect(pbx.match(/\/\* Localizable\.xcstrings \*\/ = \{isa = PBXFileReference/g)?.length).toBe(2)
+    expect(pbx.match(/\/\* Localizable\.xcstrings in Resources \*\/ = \{isa = PBXBuildFile/g)?.length).toBe(2)
+    expect(pbx.match(/Localizable\.xcstrings in Resources \*\//g)?.length).toBe(4)
   })
 
   it('declares every catalog language in knownRegions', () => {


### PR DESCRIPTION
The last English-only surface in the app, found in the closing sweep: the share-sheet card hardcoded five strings — the **Done** button, "Saved to lastGLANCE", the "It'll be waiting as a new chore next time you open the app." detail line, and the two nothing-to-save states.

## What ships

- **`ShareExtension/Localizable.xcstrings`** with all five keys in de/es/fr/it/pt-PT/pt-BR, wired into the pbxproj (file reference `…FA`, build file `…FB`, the extension's empty Resources phase; `knownRegions` already carries the six languages since #300).
- The UIKit strings are plain `String`s, so each site gets `String(localized:)` — including the interpolated detail line, whose catalog key carries the `%@` placeholder for the chore name.
- **Portuguese genuinely splits here**: pt-PT *Guardado no lastGLANCE* / *Nada para guardar* vs pt-BR *Salvo no lastGLANCE* / *Nada para salvar*, and *ligações* vs *links*. "Done" reuses each locale's `app.done` (Fertig / Listo / Terminer / Fine / Concluído).

## Verification

- `src/iosStrings.test.ts` now runs over **both** catalogs (GlanceWidgets + ShareExtension): all six languages per key, format-specifier survival, pt-PT/pt-BR held to their standards by the shared marker lists — which is exactly what polices the guardar/salvar split above — plus the pbxproj checks (unique object IDs, both catalogs registered as file + build file + resource).
- `npm run lint` clean, tests green (38 files, 509 tests), `npm run build` passes.
- **Not compiled here** — no Xcode on this machine. Same release note as #300: build locally, then share a link into the extension on a simulator set to another language.

**Translation quality:** no native-speaker review; glossary matches the localized web strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_