### PR TITLE
Bump version to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The localization release: the language picker and desktop overflow menu, the pt-PT/pt-BR split, localized notifications, and localized Android widgets, tiles, and shortcuts (#292, #294 to #300, #303). A minor bump, since it ships new user-facing functionality; the iOS work rides along unreleased.

`versionName` comes from package.json, so this is the only change needed; the Android `versionCode` derives to **2050000** (2\*1000000 + 5\*10000), leaving the usual +100 headroom for pre-release `APP_VERSION_CODE` overrides. Bumped with `npm version`, so package-lock.json stays in step.

Release notes for GitHub and Play are ready to paste once this merges and the release is built (`./build-android.sh --release`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkA5o2YwoCHHjGLAVuZcVX)_