### PR TITLE
Fix the Control Center control doing nothing when tapped

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		EA00000000000000000000C6 /* SingleChoreWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E6 /* SingleChoreWidget.swift */; };
 		EA00000000000000000000C7 /* AddChoreWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E7 /* AddChoreWidget.swift */; };
 		EA00000000000000000000C8 /* AccessoryWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E8 /* AccessoryWidgets.swift */; };
+		EA00000000000000000000CA /* AddChoreControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000EA /* AddChoreControl.swift */; };
+		EA00000000000000000000CB /* AddChoreControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000EA /* AddChoreControl.swift */; };
 		EA00000000000000000000C9 /* SecureStorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA00000000000000000000E9 /* SecureStorePlugin.swift */; };
 		EB00000000000000000000C1 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000E1 /* ShareViewController.swift */; };
 		EB00000000000000000000FB /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = EB00000000000000000000FA /* Localizable.xcstrings */; };
@@ -91,6 +93,7 @@
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 		EA00000000000000000000F1 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		EA00000000000000000000F2 /* SharedDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataStore.swift; sourceTree = "<group>"; };
+		EA00000000000000000000EA /* AddChoreControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddChoreControl.swift; sourceTree = "<group>"; };
 		EA00000000000000000000F3 /* WidgetBridgePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetBridgePlugin.swift; sourceTree = "<group>"; };
 		EA00000000000000000000F4 /* GlanceWidgetsBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlanceWidgetsBundle.swift; sourceTree = "<group>"; };
 		EA00000000000000000000F5 /* HeatmapWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapWidget.swift; sourceTree = "<group>"; };
@@ -189,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				EA00000000000000000000F2 /* SharedDataStore.swift */,
+				EA00000000000000000000EA /* AddChoreControl.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -387,6 +391,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				EA00000000000000000000CA /* AddChoreControl.swift in Sources */,
 				7A4E51062E3A9A0100C4F2D1 /* BridgeViewController.swift in Sources */,
 				7A4E51022E3A9A0100C4F2D1 /* VaultSseClient.swift in Sources */,
 				7A4E51042E3A9A0100C4F2D1 /* VaultSsePlugin.swift in Sources */,
@@ -412,6 +417,7 @@
 				EA00000000000000000000C6 /* SingleChoreWidget.swift in Sources */,
 				EA00000000000000000000C7 /* AddChoreWidget.swift in Sources */,
 				EA00000000000000000000C8 /* AccessoryWidgets.swift in Sources */,
+				EA00000000000000000000CB /* AddChoreControl.swift in Sources */,
 				EA00000000000000000000B8 /* LucidePath.swift in Sources */,
 				EA00000000000000000000B9 /* LucideIcons.generated.swift in Sources */,
 			);

--- a/ios/App/App/Shared/AddChoreControl.swift
+++ b/ios/App/App/Shared/AddChoreControl.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import WidgetKit
+import AppIntents
+
+// Control Center control (iOS 18+) and the intent behind it.
+//
+// THIS FILE MUST BE A MEMBER OF BOTH THE App AND GlanceWidgetsExtension
+// TARGETS. A control button can only trigger an AppIntent, and iOS resolves
+// that intent against the *app's* AppIntents metadata when deciding whether it
+// may open the app. While this lived in GlanceWidgets/AccessoryWidgets.swift,
+// which is compiled into the extension alone, tapping the control did nothing
+// at all. That is why it sits in App/Shared/ next to SharedDataStore.swift,
+// the repo's existing both-targets home, rather than beside the widgets it
+// belongs to conceptually.
+//
+// The dual membership is what makes the OpenURLIntent chain below reachable;
+// it is not an alternative to it. Both are required.
+
+// Opens the app straight into the new-chore form — the Quick Settings
+// add-chore tile, relocated to where iOS puts such things.
+//
+// The intent's ONLY job is to hand back an OpenURLIntent for the same
+// lastglance:// URL every other entry point uses; the app then receives it
+// through the AppDelegate URL path, which is device-verified. Two designs
+// that look right do not work from a control, learned the hard way:
+//  - `openAppWhenRun` alone is ignored when the intent runs in the widget
+//    extension process — which is exactly where a control button's intent
+//    runs. The tap performed, wrote its token, and nothing opened.
+//  - Writing the pending token from the intent also had a warm-open race:
+//    the app's foreground drain could run before the token landed.
+// Chaining OpenURLIntent solves both: the system opens the URL itself, and
+// the token is minted by AppDelegate on receipt, exactly as for a widget tap.
+@available(iOS 18.0, *)
+struct OpenAddChoreIntent: AppIntent {
+    static let title: LocalizedStringResource = "Add chore"
+    static let isDiscoverable = false
+    static let openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult & OpensIntent {
+        .result(opensIntent: OpenURLIntent(URL(string: "lastglance://action/add")!))
+    }
+}
+
+@available(iOS 18.0, *)
+struct AddChoreControl: ControlWidget {
+    let kind = "AddChoreControl"
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: kind) {
+            ControlWidgetButton(action: OpenAddChoreIntent()) {
+                Label("Add chore", systemImage: "plus.circle")
+            }
+        }
+        .displayName("Add chore")
+        .description("Open lastGLANCE ready to add a new chore.")
+    }
+}

--- a/ios/App/GlanceWidgets/AccessoryWidgets.swift
+++ b/ios/App/GlanceWidgets/AccessoryWidgets.swift
@@ -92,45 +92,7 @@ struct AccessoryStatusWidget: Widget {
     }
 }
 
-// MARK: - Control Center control (iOS 18+)
-
-// Opens the app straight into the new-chore form — the Quick Settings
-// add-chore tile, relocated to where iOS puts such things.
-//
-// The intent's ONLY job is to hand back an OpenURLIntent for the same
-// lastglance:// URL every other entry point uses; the app then receives it
-// through the AppDelegate URL path, which is device-verified. Two designs
-// that look right do not work from a control, learned the hard way:
-//  - `openAppWhenRun` alone is ignored when the intent runs in the widget
-//    extension process — which is exactly where a control button's intent
-//    runs. The tap performed, wrote its token, and nothing opened.
-//  - Writing the pending token from the intent also had a warm-open race:
-//    the app's foreground drain could run before the token landed.
-// Chaining OpenURLIntent solves both: the system opens the URL itself, and
-// the token is minted by AppDelegate on receipt, exactly as for a widget tap.
-@available(iOS 18.0, *)
-struct OpenAddChoreIntent: AppIntent {
-    static let title: LocalizedStringResource = "Add chore"
-    static let isDiscoverable = false
-    static let openAppWhenRun = true
-
-    @MainActor
-    func perform() async throws -> some IntentResult & OpensIntent {
-        .result(opensIntent: OpenURLIntent(URL(string: "lastglance://action/add")!))
-    }
-}
-
-@available(iOS 18.0, *)
-struct AddChoreControl: ControlWidget {
-    let kind = "AddChoreControl"
-
-    var body: some ControlWidgetConfiguration {
-        StaticControlConfiguration(kind: kind) {
-            ControlWidgetButton(action: OpenAddChoreIntent()) {
-                Label("Add chore", systemImage: "plus.circle")
-            }
-        }
-        .displayName("Add chore")
-        .description("Open lastGLANCE ready to add a new chore.")
-    }
-}
+// The Control Center control that used to live here now sits in
+// App/Shared/AddChoreControl.swift: it has to compile into the app target
+// as well as this one, and the accessory widget above cannot (it depends on
+// SnapshotProvider/SnapshotEntry, which are extension-only).

--- a/src/iosControls.test.ts
+++ b/src/iosControls.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * CI cannot run Xcode, so the project wiring the Control Center control
+ * depends on is validated here.
+ *
+ * A control button can only trigger an AppIntent, and iOS resolves that intent
+ * against the *app's* AppIntents metadata when deciding whether it may open the
+ * app. An intent compiled into the widget extension alone is invisible there,
+ * and the tap does nothing at all: no launch, no error, nothing to debug from.
+ * That is how AddChoreControl shipped, living in GlanceWidgets/AccessoryWidgets.swift.
+ *
+ * Chaining OpenURLIntent (which the intent does, and should keep doing) is not
+ * a substitute for the membership. Both are required, which is the trap: the
+ * code reads as though the OpenURLIntent alone is enough.
+ *
+ * Nothing else catches this. It is not a compile error, and the accessory
+ * widget in the same original file genuinely cannot join the app target, since
+ * it depends on the extension-only SnapshotProvider.
+ */
+const IOS = join(__dirname, '../ios/App')
+const PBXPROJ = join(IOS, 'App.xcodeproj/project.pbxproj')
+
+const APP_TARGET = 'App'
+const WIDGET_TARGET = 'GlanceWidgetsExtension'
+const CONTROL_FILE = 'AddChoreControl.swift'
+
+/** Map each native target to the file names in its Sources build phase. */
+function sourcesByTarget(pbx: string): Record<string, string[]> {
+  const phases: Record<string, string[]> = {}
+  const phaseRe = /([0-9A-F]{24}) \/\* Sources \*\/ = \{\s*isa = PBXSourcesBuildPhase;([\s\S]*?)\n\t\t\};/g
+  for (const m of pbx.matchAll(phaseRe)) {
+    phases[m[1]] = [...m[2].matchAll(/\/\* (.+?) in Sources \*\//g)].map((f) => f[1])
+  }
+
+  const out: Record<string, string[]> = {}
+  const targetRe = /([0-9A-F]{24}) \/\* ([A-Za-z]+) \*\/ = \{\s*isa = PBXNativeTarget;([\s\S]*?)\n\t\t\};/g
+  for (const m of pbx.matchAll(targetRe)) {
+    const files: string[] = []
+    for (const ph of m[3].matchAll(/([0-9A-F]{24}) \/\* Sources \*\//g)) {
+      files.push(...(phases[ph[1]] ?? []))
+    }
+    out[m[2]] = files
+  }
+  return out
+}
+
+describe('iOS Control Center control', () => {
+  const pbx = readFileSync(PBXPROJ, 'utf8')
+  const targets = sourcesByTarget(pbx)
+
+  it('parses both targets out of the project file', () => {
+    expect(Object.keys(targets)).toEqual(expect.arrayContaining([APP_TARGET, WIDGET_TARGET]))
+    expect(targets[APP_TARGET].length).toBeGreaterThan(0)
+    expect(targets[WIDGET_TARGET].length).toBeGreaterThan(0)
+  })
+
+  it.each([APP_TARGET, WIDGET_TARGET])('compiles %s into the control file', (target) => {
+    expect(
+      targets[target],
+      `${CONTROL_FILE} must be a member of BOTH ${APP_TARGET} and ${WIDGET_TARGET}. ` +
+        'An intent the app target cannot see will not open the app, and the control ' +
+        'silently does nothing when tapped.',
+    ).toContain(CONTROL_FILE)
+  })
+
+  it('defines the control and its intent in that shared file', () => {
+    const src = readFileSync(join(IOS, 'App/Shared', CONTROL_FILE), 'utf8')
+    expect(src).toMatch(/struct OpenAddChoreIntent: AppIntent/)
+    expect(src).toMatch(/struct AddChoreControl: ControlWidget/)
+    // The OpenURLIntent chain is the other half of what makes the tap work.
+    expect(src).toMatch(/OpenURLIntent/)
+  })
+
+  it('does not let the control drift back into the extension-only file', () => {
+    const accessory = readFileSync(join(IOS, 'GlanceWidgets/AccessoryWidgets.swift'), 'utf8')
+    expect(accessory).not.toMatch(/struct AddChoreControl: ControlWidget/)
+    expect(accessory).not.toMatch(/struct OpenAddChoreIntent: AppIntent/)
+  })
+
+  it('still registers the control in the widget bundle', () => {
+    const bundle = readFileSync(join(IOS, 'GlanceWidgets/GlanceWidgetsBundle.swift'), 'utf8')
+    expect(bundle).toMatch(/AddChoreControl\(\)/)
+  })
+})


### PR DESCRIPTION
## Cause

`OpenAddChoreIntent` and `AddChoreControl` lived in `GlanceWidgets/AccessoryWidgets.swift`, which the project compiles into the **GlanceWidgetsExtension target only**.

A control button can only trigger an `AppIntent`, and iOS resolves that intent against the *app's* AppIntents metadata when deciding whether it may open the app. An extension-only intent is invisible at exactly that moment, so the tap does nothing: no launch, nothing logged, nothing to debug from.

| Target | Before | After |
| --- | --- | --- |
| App | not a member | member |
| GlanceWidgetsExtension | member | member |

## Fix

Both control types move to `App/Shared/AddChoreControl.swift`, registered in both targets. `App/Shared` is where `SharedDataStore.swift` already sits for the same reason, so this follows the existing convention rather than inventing one.

Only those two types move. The accessory Lock Screen widget stays put because it *cannot* join the app target: it depends on `SnapshotProvider` and `SnapshotEntry`, which are extension-only. That asymmetry is why the whole file could not simply be shared.

## The OpenURLIntent chain is untouched

It was already correct and stays exactly as written. It was never an alternative to the membership, which is what makes this trap quiet: the intent reads as though returning `OpenURLIntent` is sufficient on its own. The file's existing note that `openAppWhenRun` is "ignored when the intent runs in the widget extension process" is describing a symptom of this same missing membership.

## Guard

CI cannot run Xcode, so `src/iosControls.test.ts` checks the wiring: membership in both targets, both types defined in the shared file, the `OpenURLIntent` chain intact, the extension-only file not regaining them, and the bundle still registering the control.

Verified it **fails against the previous layout** (4 of 6 red, with the membership assertions naming the problem) rather than only passing now.

`npm run lint` clean; `npm test` 525 tests across 40 files, all passing. The existing `iosStrings.test.ts` pbxproj object-id check also passes, confirming the new ids do not collide.

## Not built here

No Xcode in this environment. The project wiring is guarded, but opening the project and tapping the control is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYy9cGsKHGqfQbvUVTHA4X)_