### PR TITLE
Stop iPhone WebKit zooming the app in on focused inputs

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import './i18n'
 import App from './App'
 import { hydrateSecureConfig, installSecureConfigShim } from './sync/secureConfigShim'
 import { initHardwareBackButton } from './native/backButton'
+import { lockViewportScaleOnIPhone } from './utils/viewportZoom'
 
 // crypto.randomUUID() is only available in secure contexts (HTTPS / localhost).
 // This polyfill covers HTTP access over a LAN IP (e.g. self-hosted Docker).
@@ -25,6 +26,11 @@ if (typeof crypto.randomUUID !== 'function') {
 if (Capacitor.isNativePlatform()) {
   document.documentElement.classList.add('native')
 }
+
+// Cap the viewport scale on iPhone before anything can take focus, so WebKit
+// cannot zoom the page in on a sub-16px field it can never zoom back out of
+// (see utils/viewportZoom.ts). No-op on every other platform.
+lockViewportScaleOnIPhone()
 
 // Apply theme before React renders to avoid flash
 const saved = localStorage.getItem('theme')

--- a/src/utils/viewportZoom.test.ts
+++ b/src/utils/viewportZoom.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { isFocusZoomPlatform, withScaleLock, lockViewportScaleOnIPhone } from './viewportZoom'
+
+const IPHONE_WKWEBVIEW = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
+const IPAD_SAFARI = 'Mozilla/5.0 (iPad; CPU OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Mobile/15E148 Safari/604.1'
+const IPAD_DESKTOP_SITE = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15'
+const ANDROID_CHROME = 'Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36'
+
+describe('isFocusZoomPlatform', () => {
+  it('matches the iPhone WebView and Safari', () => {
+    expect(isFocusZoomPlatform(IPHONE_WKWEBVIEW)).toBe(true)
+  })
+
+  it('leaves iPad alone — iPadOS does not zoom on focus', () => {
+    expect(isFocusZoomPlatform(IPAD_SAFARI)).toBe(false)
+    expect(isFocusZoomPlatform(IPAD_DESKTOP_SITE)).toBe(false)
+  })
+
+  it('leaves Android alone so pinch-to-zoom survives', () => {
+    expect(isFocusZoomPlatform(ANDROID_CHROME)).toBe(false)
+  })
+})
+
+describe('withScaleLock', () => {
+  it('caps the scale while keeping the shipped viewport directives', () => {
+    const shipped = 'width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content'
+    expect(withScaleLock(shipped)).toBe(`${shipped}, maximum-scale=1`)
+  })
+
+  it('leaves an explicit maximum-scale from the markup untouched', () => {
+    const content = 'width=device-width, maximum-scale=2'
+    expect(withScaleLock(content)).toBe(content)
+  })
+
+  it('does not mistake another directive for maximum-scale', () => {
+    expect(withScaleLock('width=device-width, initial-scale=1')).toBe('width=device-width, initial-scale=1, maximum-scale=1')
+  })
+
+  it('handles an empty or trailing-comma content attribute', () => {
+    expect(withScaleLock('')).toBe('maximum-scale=1')
+    expect(withScaleLock('width=device-width,')).toBe('width=device-width, maximum-scale=1')
+  })
+})
+
+// Minimal stand-in for the viewport meta element (the suite runs in the node
+// environment, so there is no DOM to query).
+function stubDocument(content: string | null) {
+  const meta = content === null ? null : {
+    attrs: { content } as Record<string, string>,
+    getAttribute(name: string) { return this.attrs[name] ?? null },
+    setAttribute(name: string, value: string) { this.attrs[name] = value },
+  }
+  vi.stubGlobal('document', { querySelector: () => meta })
+  return meta
+}
+
+describe('lockViewportScaleOnIPhone', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('caps the live viewport meta on iPhone', () => {
+    vi.stubGlobal('navigator', { userAgent: IPHONE_WKWEBVIEW })
+    const meta = stubDocument('width=device-width, initial-scale=1.0')
+    lockViewportScaleOnIPhone()
+    expect(meta!.getAttribute('content')).toBe('width=device-width, initial-scale=1.0, maximum-scale=1')
+  })
+
+  it('leaves the meta untouched elsewhere', () => {
+    vi.stubGlobal('navigator', { userAgent: ANDROID_CHROME })
+    const meta = stubDocument('width=device-width, initial-scale=1.0')
+    lockViewportScaleOnIPhone()
+    expect(meta!.getAttribute('content')).toBe('width=device-width, initial-scale=1.0')
+  })
+
+  it('does not throw on a page with no viewport meta', () => {
+    vi.stubGlobal('navigator', { userAgent: IPHONE_WKWEBVIEW })
+    stubDocument(null)
+    expect(() => lockViewportScaleOnIPhone()).not.toThrow()
+  })
+})

--- a/src/utils/viewportZoom.ts
+++ b/src/utils/viewportZoom.ts
@@ -1,0 +1,47 @@
+// iPhone WebKit zooms the whole page in when a form control whose computed
+// font-size is under 16px takes focus. Inside the native shell that zoom is a
+// one-way trip: Capacitor's iOS default is `zoomingEnabled = NO`, which hands
+// the WebView's scroll view a delegate that disables the pinch recognizer the
+// moment zooming begins, so nothing can scale the page back down and the UI
+// stays cropped until the app is force-quit and relaunched. A home-screen PWA
+// behaves the same way once the viewport is locked; only a Safari tab lets the
+// user pinch back out.
+//
+// Every text field in the app is text-sm (14px) or smaller, but Search and the
+// chore form are the two screens that focus an input the instant they open
+// (SearchModal's focus effect, ChoreFormModal's autoFocus), so they trip the
+// zoom without the user ever tapping into a field — which is why only those two
+// appear to be broken.
+//
+// Capping the viewport at scale 1 leaves WebKit no headroom to zoom on focus.
+// WKWebView honors the page's scale limits (`ignoresViewportScaleLimits`
+// defaults to false and Capacitor never overrides it), as does a standalone
+// PWA. Safari tabs ignore the cap, but the zoom is recoverable by pinch there.
+//
+// Deliberately iPhone/iPod only: iPadOS does not focus-zoom, and Android and
+// the desktop browser must keep pinch-to-zoom, which this would take away.
+
+// Matches the native shell's WKWebView UA and Mobile Safari alike; an iPad
+// (including one asking for the desktop site, which reports "Macintosh") does
+// not match, and neither does anything non-Apple.
+export function isFocusZoomPlatform(userAgent: string): boolean {
+  return /iPhone|iPod/.test(userAgent)
+}
+
+// Appends the scale cap, preserving whatever else the meta already declares
+// (width, viewport-fit, interactive-widget). An explicit maximum-scale in the
+// markup wins — this only fills in the one that isn't there.
+export function withScaleLock(content: string): string {
+  if (/(^|[;,\s])maximum-scale\s*=/.test(content)) return content
+  const existing = content.trim().replace(/,$/, '')
+  return existing === '' ? 'maximum-scale=1' : `${existing}, maximum-scale=1`
+}
+
+// Applies the cap to the live viewport meta. Safe to call anywhere: a no-op off
+// iPhone, and off any page that has no viewport meta.
+export function lockViewportScaleOnIPhone(): void {
+  if (!isFocusZoomPlatform(navigator.userAgent)) return
+  const meta = document.querySelector('meta[name="viewport"]')
+  if (!meta) return
+  meta.setAttribute('content', withScaleLock(meta.getAttribute('content') ?? ''))
+}


### PR DESCRIPTION
Opening **Search** or **Add Chore** on iPhone left the app zoomed in, with no way back short of force-quitting and relaunching. iPad was unaffected.

## Cause

iPhone WebKit zooms the whole page in when a form control whose computed font-size is under 16px takes focus. Every text field in the app is `text-sm` (14px) or smaller, and these two screens are the only ones that focus a field *the instant they open*:

- `SearchModal.tsx` — `inputRef.current?.focus()` in a mount effect
- `ChoreFormModal.tsx` — `autoFocus` on the name input

Everything else waits for a deliberate tap on a field, which is why only those two looked broken.

The zoom is a one-way trip inside the native shell: Capacitor's iOS default is `zoomingEnabled = NO` (`CAPInstanceDescriptor.m`), which hands the WebView's scroll view a delegate that disables the pinch recognizer the moment zooming begins (`WebViewDelegationHandler.swift`). WebKit's focus zoom is programmatic so it still fires, but pinch-to-zoom-out is dead, so nothing can scale the page back down. A standalone home-screen PWA behaves the same way; only a Safari tab lets the user pinch back out.

iPad never hit it because iPadOS does not focus-zoom.

## Fix

New `src/utils/viewportZoom.ts` caps the viewport at `maximum-scale=1`, called from `src/main.tsx` before React renders, so it is in place before anything can take focus. With no headroom above scale 1, WebKit has nowhere to zoom to. WKWebView honors the page's scale limits (`ignoresViewportScaleLimits` defaults to false and Capacitor never overrides it), as does a standalone PWA.

The cap is applied at runtime rather than baked into `index.html` so it stays scoped to iPhone/iPod. A static cap in the markup would also strip pinch-to-zoom from Android, the desktop browser, and iPad, none of which have this bug.

## Verification

`npm run lint`, `npm run build`, and `npm test` (526 tests across 40 files) all pass, including 10 new tests covering the UA matching, the meta rewrite, and the no-viewport-meta case.

One caveat: this needs a real device to confirm, since it rests on WebKit honoring the cap. If a rebuilt iPhone build still zooms, the guaranteed fallback is raising text-entry controls to 16px on iPhone — that always works, but it changes the typography of every input, so it was not the first move here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012W3LgouF4cJPCDGQcnKF8B)_