### PR TITLE
Refresh date-derived UI at midnight and on tab focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { useDbIntentsPoller, drainDbIntents } from '@/hooks/useDbIntentsPoller'
 import { useVaultEventStream } from '@/hooks/useVaultEventStream'
 import { useAndroidIntentBridge } from '@/hooks/useAndroidIntentBridge'
 import { useOutboxFlush } from '@/hooks/useOutboxFlush'
+import { useDayRollover } from '@/hooks/useDayRollover'
 import { IntentsProvider, useIntents } from '@/intents/IntentsContext'
 import { getAllCompletionCounts } from '@/db/queries'
 import { formatDate } from '@/utils/datetime'
@@ -384,6 +385,20 @@ function AppInner() {
     setHeatmapWeeks(buildHeaderHeatmap(counts))
     setWaveKey(k => k + 1)
   }, [])
+
+  // Same reload, without bumping waveKey. The wave is a flourish for a *user*
+  // action landing (a chore logged, a backup imported); the rollover refresh is
+  // ambient bookkeeping, and replaying a 1.5s animation every time the tab
+  // regains focus would read as the app churning for no reason.
+  const refreshHeatmapQuietly = useCallback(async () => {
+    const counts = await getAllCompletionCounts()
+    setHeatmapWeeks(buildHeaderHeatmap(counts))
+  }, [])
+
+  // The heatmap bakes the current date into every cell (which column is today,
+  // which days are still in the future), so it goes stale the same way the
+  // chore rows do.
+  useDayRollover(refreshHeatmapQuietly)
 
   useIntentsPoller(loadHeatmap)
   // GLANCEvault DB intents transport — gated by isDbIntentsEnabled(); a no-op

--- a/src/components/Ribbon/Ribbon.tsx
+++ b/src/components/Ribbon/Ribbon.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback } from 'react'
 import { Plus, GripVertical, Search, UserCircle, Clock, ChevronDown, ChevronUp } from 'lucide-react'
 import { useChores } from '@/hooks/useChores'
+import { useDayRollover } from '@/hooks/useDayRollover'
 import { ensureInboxCategory, reorderCategories } from '@/db/queries'
 import { CategorySection } from '@/components/CategorySection/CategorySection'
 import { LogModal } from '@/components/LogModal/LogModal'
@@ -66,6 +67,9 @@ const ADD_CAT_ID = -1
 export function Ribbon({ editMode, onLogged }: Props) {
   const { t } = useTranslation()
   const { data, loading, refresh } = useChores()
+  // elapsed_days is computed inside the query, not in render, so a stale day
+  // can only be corrected by re-reading — a re-render alone would not do it.
+  useDayRollover(refresh)
   const { multiUserEnabled, meId, filter, setFilter, attentionOnly, setAttentionOnly } = useUsersContext()
   const [localData, setLocalData] = useState<CategoryWithChores[]>([])
   const [activeCategoryIndex, setActiveCategoryIndex] = useState(0)

--- a/src/hooks/useDayRollover.test.ts
+++ b/src/hooks/useDayRollover.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest'
+import { msUntilNextLocalMidnight, localDayKey } from './useDayRollover'
+
+// Local time, so these are stable regardless of the runner's zone: the boundary
+// under test is the *local* midnight, not UTC's.
+function at(local: string): number {
+  return new Date(local).getTime()
+}
+
+afterEach(() => { vi.useRealTimers() })
+
+describe('msUntilNextLocalMidnight', () => {
+  it('counts to the next local midnight, not 24h out', () => {
+    const now = at('2026-03-10T09:30:00')
+    expect(msUntilNextLocalMidnight(now)).toBe(at('2026-03-11T00:00:00') - now)
+  })
+
+  it('returns a full day one tick after midnight', () => {
+    const now = at('2026-03-10T00:00:00')
+    expect(msUntilNextLocalMidnight(now)).toBe(at('2026-03-11T00:00:00') - now)
+  })
+
+  it('never returns zero or negative, so a re-arming caller cannot spin', () => {
+    // One millisecond before the boundary is the tightest case there is.
+    const now = at('2026-03-10T23:59:59.999')
+    const ms = msUntilNextLocalMidnight(now)
+    expect(ms).toBeGreaterThan(0)
+    expect(ms).toBeLessThanOrEqual(1)
+  })
+
+  it('lands exactly on midnight from any point in the day', () => {
+    for (const hour of [0, 1, 6, 12, 18, 23]) {
+      const now = at(`2026-06-15T${String(hour).padStart(2, '0')}:17:03.250`)
+      const landing = new Date(now + msUntilNextLocalMidnight(now))
+      expect(landing.getHours()).toBe(0)
+      expect(landing.getMinutes()).toBe(0)
+      expect(landing.getSeconds()).toBe(0)
+      expect(landing.getMilliseconds()).toBe(0)
+    }
+  })
+
+  it('defaults to the current clock', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(at('2026-03-10T09:30:00'))
+    expect(msUntilNextLocalMidnight()).toBe(msUntilNextLocalMidnight(Date.now()))
+  })
+})
+
+// Pinned to a DST-observing zone, because the whole point of deriving the delay
+// from the clock is that a local day is not always 24h. In a fixed-offset zone
+// (UTC on CI) a naive +24h constant would pass every assertion here.
+describe('msUntilNextLocalMidnight across DST', () => {
+  const original = process.env.TZ
+  beforeAll(() => { process.env.TZ = 'America/Denver' })
+  afterAll(() => { process.env.TZ = original })
+
+  const HOUR = 60 * 60 * 1000
+
+  it('spans only 23h on a spring-forward day', () => {
+    // US spring forward 2026 is Mar 8 at 02:00. A timer chained at a fixed
+    // +24h from the previous midnight would fire at 01:00 on Mar 9 and every
+    // day after, an hour late forever.
+    const midnight = at('2026-03-08T00:00:00')
+    expect(msUntilNextLocalMidnight(midnight)).toBe(23 * HOUR)
+  })
+
+  it('spans 25h on a fall-back day', () => {
+    // US fall back 2026 is Nov 1 at 02:00; the same chained timer fires an
+    // hour early, before the date has actually changed.
+    const midnight = at('2026-11-01T00:00:00')
+    expect(msUntilNextLocalMidnight(midnight)).toBe(25 * HOUR)
+  })
+
+  it('still lands exactly on midnight through both shifts', () => {
+    for (const day of ['2026-03-07', '2026-03-08', '2026-10-31', '2026-11-01']) {
+      const now = at(`${day}T13:45:00`)
+      const landing = new Date(now + msUntilNextLocalMidnight(now))
+      expect(landing.getHours()).toBe(0)
+      expect(landing.getMinutes()).toBe(0)
+    }
+  })
+})
+
+describe('localDayKey', () => {
+  it('is a local calendar day, and changes across local midnight', () => {
+    expect(localDayKey(at('2026-03-10T23:59:59'))).toBe('2026-03-10')
+    expect(localDayKey(at('2026-03-11T00:00:00'))).toBe('2026-03-11')
+  })
+
+  it('moves backwards when the clock is corrected backwards', () => {
+    // Issue #306 in reverse: a machine running ~12h fast, corrected by NTP.
+    // The rollover guard compares keys rather than asking "is it past
+    // midnight yet", so a backwards correction is still a change.
+    const wrong = localDayKey(at('2026-03-11T04:00:00'))
+    const corrected = localDayKey(at('2026-03-10T16:00:00'))
+    expect(corrected).not.toBe(wrong)
+  })
+})

--- a/src/hooks/useDayRollover.ts
+++ b/src/hooks/useDayRollover.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from 'react'
+import dayjs from 'dayjs'
+
+/**
+ * Keeps date-derived UI honest about what time it actually is.
+ *
+ * Every date in the app is computed live from the system clock — `elapsed_days`
+ * inside the query (db/queries.ts), the heatmap's "today" column, "yesterday"
+ * vs "N days ago". None of it is cached. But nothing recomputes it either:
+ * chore data loads on mount and on edits, so a tab left open shows whatever the
+ * clock said when the data last loaded. Leave lastGLANCE open overnight and it
+ * still calls yesterday "today".
+ *
+ * Two wake signals, deliberately no polling interval:
+ *
+ *   • Local midnight, when every calendar-derived label changes at once.
+ *   • Tab becoming visible, which also heals the sub-day drift ("2 hours ago"
+ *     when you come back at 6pm) and is the ONLY signal that works on native,
+ *     where the OS suspends timers outright while the app is backgrounded.
+ */
+
+/**
+ * Milliseconds until the next local midnight.
+ *
+ * Derived from the clock on every call rather than a 24h constant: local days
+ * are 23 or 25 hours long across a DST shift, and a timer chained at a fixed
+ * +24h would drift a full hour off the boundary it exists to catch.
+ *
+ * Always >= 1, so a caller re-arming on every fire can never spin.
+ */
+export function msUntilNextLocalMidnight(now: number = Date.now()): number {
+  const next = dayjs(now).add(1, 'day').startOf('day').valueOf()
+  return Math.max(1, next - now)
+}
+
+/** The current local calendar day, as the key we compare rollovers against. */
+export function localDayKey(now: number = Date.now()): string {
+  return dayjs(now).format('YYYY-MM-DD')
+}
+
+/**
+ * Calls `onRefresh` when the calendar day rolls over, and whenever the tab
+ * becomes visible.
+ *
+ * `onRefresh` is read through a ref, so a caller passing an inline closure does
+ * not tear down and re-arm the timer on every render.
+ */
+export function useDayRollover(onRefresh: () => void): void {
+  const onRefreshRef = useRef(onRefresh)
+  useEffect(() => { onRefreshRef.current = onRefresh }, [onRefresh])
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    // Seeded at mount so the first midnight fire has something to compare to.
+    let lastDay = localDayKey()
+
+    function arm() {
+      if (timer) clearTimeout(timer)
+      // Re-read the clock on every arm. A timer that chained a fixed interval
+      // from its own last fire would inherit each of these errors permanently:
+      // background throttling delays a hidden tab's fire, machine sleep skips
+      // it, DST moves the boundary, and a system clock correction (issue #306)
+      // invalidates the delay outright.
+      timer = setTimeout(onMidnight, msUntilNextLocalMidnight())
+    }
+
+    function onMidnight() {
+      const today = localDayKey()
+      // Guarded rather than assumed: a throttled or clock-shifted fire can land
+      // on the same day it was armed in, and refreshing then would be pointless
+      // churn. The comparison also catches a clock moved *backwards* past a
+      // boundary, which a "did we pass midnight yet" check would miss.
+      if (today !== lastDay) {
+        lastDay = today
+        onRefreshRef.current()
+      }
+      arm()
+    }
+
+    function onVisibilityChange() {
+      if (document.visibilityState !== 'visible') return
+      // Unguarded by design: returning to the tab refreshes regardless of
+      // whether the date changed, which is what fixes same-day drift. This is
+      // bounded by the user's attention rather than by a clock, so it cannot
+      // produce a refresh nobody asked for. The existing sync-on-visible in
+      // App.tsx already does strictly more work on this same event.
+      lastDay = localDayKey()
+      onRefreshRef.current()
+      // The clock may have moved arbitrarily while we were hidden, so the
+      // pending timer's delay is no longer trustworthy.
+      arm()
+    }
+
+    arm()
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      if (timer) clearTimeout(timer)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+}


### PR DESCRIPTION
## Problem

Every date in the app is computed live from the system clock, and none of it is cached. But nothing recomputes it either: chore data loads on mount and on edits only (`useChores.ts:57`), and `elapsed_days` is calculated inside the query (`db/queries.ts:199`) rather than in render.

So a tab left open shows whatever the clock said when the data last loaded:

- Leave lastGLANCE open overnight and it still calls yesterday "today".
- Leave it open for an afternoon and "2 hours ago" never advances.
- The heatmap's today column and `isFuture` flags stay pinned to the load date.

This is a plain midnight-rollover bug, visible without any clock weirdness at all.

## Approach

New `useDayRollover` hook, refreshing on two signals and deliberately **no polling interval**:

- **Local midnight**, when every calendar-derived label turns over at once.
- **Tab becoming visible**, which also heals same-day drift in `elapsed_days`. This is the only signal that works on native, where the OS suspends timers outright while the app is backgrounded.

Refresh-on-visible is intentionally unguarded by a date check. It is bounded by the user's attention rather than by a clock, so it cannot produce a refresh nobody asked for, and the existing sync-on-visible in `App.tsx:357` already does strictly more work on that same event.

### The midnight timer re-derives its delay on every arm

It does not chain a fixed +24h. A chained timer permanently inherits every error it hits:

- Background throttling delaying a hidden tab's fire
- Machine sleep skipping it
- DST moving the boundary by an hour
- A system clock correction invalidating the delay outright

The fire is guarded by a day-key comparison rather than assuming it landed on midnight, which also catches a clock moved *backwards* past a boundary.

## Wiring

Two call sites, because the state lives apart: `Ribbon` owns the chore rows, `App` owns the heatmap.

Not routed through `ribbonKey` (`App.tsx:668`). That force-remounts the Ribbon, which holds `selectedChore`, `newChoreName` and `activeCategoryIndex`, so a midnight remount would discard a half-typed new chore or close an open detail view mid-session. `ribbonKey` stays reserved for backup-restore, which is legitimately destructive.

The heatmap refresh skips the `waveKey` bump, so the 1.5s wave animation stays a flourish for user actions instead of replaying on every tab focus.

## Testing

`npm run lint`, `npm run build`, and the full suite (529 tests, 40 files) all pass.

New tests pin a DST-observing zone to cover the 23h and 25h local days that a fixed 24h constant gets wrong. I verified they have teeth by mutating the implementation to the naive `startOf('day') + 24h` chain: all three DST tests fail against it, and pass against the real one.

## Relationship to #306

That report is a Chromium bug, not ours: the renderer was serving cached system time below the app, which a page reload would have cleared. Reviewed separately.

This PR is the genuine in-app staleness that report surfaced while investigating. It is deliberately a separate change, since it would not have fixed what the reporter saw.

---
_Generated by [Claude Code](https://claude.ai/code/session_013zvxB3FqfNy8SpzEPH54Jw)_