### PR TITLE
Bump version to 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump for the 2.5.1 release. No code changes.

## Why a patch bump

All four changes since v2.5.0 are bug fixes. Nothing adds capability, nothing breaks, and no data format changed.

| PR | Change | Surface |
|---|---|---|
| #305 | Control Center control did nothing when tapped (intent was extension-only) | iOS Swift + pbxproj |
| #307 | iPhone WebKit zoomed in on focused inputs with no way back out | JS |
| #308 | Date-derived UI frozen until reload (midnight rollover) | JS |
| #309 | Android replayed a task's rooting intent, reopening Add Chore | Android Java/Kotlin |

## What changed here

`package.json` plus the two root entries in `package-lock.json`, matching the shape of the 2.5.0 bump (952ba5f) exactly. Confirmed the third `2.5.0` occurrence in the lockfile is the unrelated `ts-api-utils` dependency and left it alone.

No other file hardcodes the version:

- **Android** derives both values from `package.json` (`build.gradle:11`). `versionCode` goes 2050000 to **2050100**, correctly above the shipped 2.5.0.
- **iOS** `MARKETING_VERSION` is rewritten by `sync-ios-version.mjs` during `npm run build:ios`.

## Verification

Lint, the full 545-test suite, and the production build all pass on this branch.

## Notes for the release

Two things worth flagging before tagging, neither of which this PR can address:

**`project.pbxproj` still reads `MARKETING_VERSION = 2.4.1`.** It was never committed at 2.5.0. The sync script rewrites it at build time so it self-corrects, but the checked-in value is two releases stale. Separately, `CURRENT_PROJECT_VERSION` still needs `IOS_BUILD=n` set explicitly per upload since it cannot be derived.

**Three of the four fixes in this release have never been compiled.** CI runs only the JS lint/test/build, with no Gradle or Xcode job, and the sessions that authored #305 and #309 had neither toolchain available. The JS half (#307, #308) is genuinely verified; the native half is not. A device pass on each is worth doing before this ships, particularly the Android widget relaunch path, since the Play release notes promise that fix to every user.

---
_Generated by [Claude Code](https://claude.ai/code/session_013zvxB3FqfNy8SpzEPH54Jw)_