### PR TITLE
Adopt @glance-apps/sync 2.0.0 and declare pullCursorCommit: 'per-page'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@capacitor/status-bar": "^8.0.2",
         "@glance-apps/billing": "0.2.2",
         "@glance-apps/intents": "1.4.0",
-        "@glance-apps/sync": "1.10.0",
+        "@glance-apps/sync": "2.0.0",
         "dayjs": "^1.11.13",
         "dexie": "^4.4.2",
         "i18next": "^26.3.1",
@@ -2787,9 +2787,9 @@
       }
     },
     "node_modules/@glance-apps/sync": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-1.10.0.tgz",
-      "integrity": "sha512-/OCQZPm/dsv6OmOMdXj8gjmbKR9F/eXaJdr/8BR7Rs04ScxaSdw1ozSu5cejfLyziMHaelcBecaeKVK8wvmF8A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@glance-apps/sync/-/sync-2.0.0.tgz",
+      "integrity": "sha512-i6IpNo6DrMd20/aAkjWIEcPEofB3Z1G2sxn+nO1YWRSp9uKJuUCW5d805bgFIVhptmNN9h/ZcKyswdJ4PWXWNg==",
       "license": "MIT"
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@capacitor/status-bar": "^8.0.2",
     "@glance-apps/billing": "0.2.2",
     "@glance-apps/intents": "1.4.0",
-    "@glance-apps/sync": "1.10.0",
+    "@glance-apps/sync": "2.0.0",
     "dayjs": "^1.11.13",
     "dexie": "^4.4.2",
     "i18next": "^26.3.1",

--- a/src/sync/dbEngine.ts
+++ b/src/sync/dbEngine.ts
@@ -31,6 +31,30 @@ import {
 const APP_ID = 'lastglance'
 const CRYPTO_DB_NAME = 'lastglance-crypto'
 
+// Pull-cursor durability contract (@glance-apps/sync 2.0.0).
+//
+// 2.0.0 turned the cursor commit point into a declared mode and flipped the
+// DEFAULT to 'end-of-pull', which advances the pull cursor once, after a fully
+// successful pagination loop. lastGLANCE declares 'per-page' to KEEP the
+// behaviour it has had since 1.10.0: the cursor advances after each completed
+// page, so a large backlog on a flaky connection resumes from the last good
+// page instead of re-downloading everything it already applied on every
+// failure. Taking the new default would silently reintroduce exactly the
+// convergence bug 1.10.0 fixed, and it would present as a network problem.
+//
+// 'per-page' is safe HERE because applyRemoteEntity / applyRemoteDelete write
+// straight into Dexie (see the module header) and are durable the moment they
+// return: there is no per-cycle mirror a later failure could discard, so the
+// persisted cursor is always behind committed local state. The default flipped
+// because that is NOT true of every consumer of the package (a
+// commit-only-on-success composer loses rows under per-page), not because
+// per-page is wrong for the callers it fits.
+//
+// Exported so the multi-device test exercises the real declared mode rather
+// than a second copy of the literal. An unrecognised mode is refused at
+// construction, so a typo throws instead of silently reverting to the default.
+export const PULL_CURSOR_COMMIT = 'per-page' as const
+
 // User-facing text for the typed vault (DB transport) error codes is no longer
 // mapped here. The engine emits a typed SyncErrorCode alongside its message on
 // onError; the client localizes it at render time via syncErrorText (see
@@ -537,6 +561,7 @@ export function createDbEngine(callbacks: DbEngineCallbacks = {}): DbSyncEngine 
     applyRemoteDelete,
     isInsertOnly,
     getEntityLastModified,
+    pullCursorCommit: PULL_CURSOR_COMMIT,
     onStatusChange: callbacks.onStatusChange,
     onError: callbacks.onError,
     onRowsSkipped: callbacks.onRowsSkipped,

--- a/src/sync/dbEngineMultiDevice.test.ts
+++ b/src/sync/dbEngineMultiDevice.test.ts
@@ -16,8 +16,8 @@ import 'fake-indexeddb/auto'
 import { webcrypto } from 'node:crypto'
 import { describe, it, expect, beforeAll } from 'vitest'
 import { createDbSyncEngine, setupDbRootKey } from '@glance-apps/sync'
-import type { VaultClient } from '@glance-apps/sync'
-import { isInsertOnly, getEntityLastModified } from './dbEngine'
+import type { VaultClient, PullCursorCommit } from '@glance-apps/sync'
+import { isInsertOnly, getEntityLastModified, PULL_CURSOR_COMMIT } from './dbEngine'
 
 // WebCrypto global for the encrypt/decrypt path (Node exposes it; guard anyway).
 if (!(globalThis as { crypto?: Crypto }).crypto) {
@@ -45,12 +45,18 @@ installLocalStorage()
 // a peer's earlier, unread rows sit at LOWER seqs.
 interface VaultRow { seq: number; entityId: string; envelope: string | null; deleted: boolean }
 
-function makeInMemoryVault() {
+// `pageSize` caps how many rows one list() returns, so a pull paginates the way
+// a real backlog does; `hooks.beforeList` observes each page request (and may
+// throw, to fail a pull mid-pagination). Both default to the single-page,
+// never-failing behaviour the 1.4.0 tests below have always used.
+function makeInMemoryVault(opts: { pageSize?: number } = {}) {
   const rows = new Map<string, VaultRow>() // entityId -> latest row
   let seqCounter = 0
   let salt: Uint8Array | null = null
+  const hooks: { beforeList: ((since: number) => void) | null } = { beforeList: null }
 
   return {
+    hooks,
     pushed() { return [...rows.values()].sort((a, b) => a.seq - b.seq) },
 
     async getSalt() { return salt },
@@ -73,8 +79,10 @@ function makeInMemoryVault() {
     },
 
     async list(_app: string, { since }: { accountId: string; since: number }) {
+      hooks.beforeList?.(since)
       const out = [...rows.values()].filter(r => r.seq > since).sort((a, b) => a.seq - b.seq)
-      return { rows: out, hasMore: false }
+      const page = out.slice(0, opts.pageSize ?? out.length)
+      return { rows: page, hasMore: page.length < out.length }
     },
 
     async device() { return { updated: true } },
@@ -85,9 +93,18 @@ function makeInMemoryVault() {
 // getLocalEntity / applyRemoteEntity / applyRemoteDelete are per-device (each
 // device has its own data), while isInsertOnly / getEntityLastModified are
 // lastGLANCE's actual production classifiers.
-function makeDevice(id: string, vault: ReturnType<typeof makeInMemoryVault>) {
+//
+// The cursor mode defaults to lastGLANCE's PRODUCTION declaration, imported
+// rather than re-typed, so these tests exercise the mode the app actually ships
+// (and an unrecognised value — which the engine refuses at construction — would
+// fail every test in this file, not just the cursor ones).
+function makeDevice(
+  id: string,
+  vault: ReturnType<typeof makeInMemoryVault>,
+  opts: { pullCursorCommit?: PullCursorCommit } = {},
+) {
   const local = new Map<string, Record<string, unknown>>()
-  const engine = createDbSyncEngine({
+  const build = () => createDbSyncEngine({
     storageKeyPrefix: `dev-${id}`,
     appId: 'lastglance',
     vaultApp: 'lastglance',
@@ -101,13 +118,23 @@ function makeDevice(id: string, vault: ReturnType<typeof makeInMemoryVault>) {
     applyRemoteDelete: async (entityId: string) => { local.delete(entityId) },
     isInsertOnly,
     getEntityLastModified,
+    pullCursorCommit: opts.pullCursorCommit ?? PULL_CURSOR_COMMIT,
   })
+  let engine = build()
   // Create a local entity and mark it dirty (mirrors the app's write path).
   const create = (entity: Record<string, unknown>) => {
     local.set(entity.id as string, entity)
     engine.markDirty(entity.id as string)
   }
-  return { id, engine, local, create, has: (eid: string) => local.has(eid) }
+  return {
+    id, local, create,
+    get engine() { return engine },
+    has: (eid: string) => local.has(eid),
+    // Rebuild the engine over the SAME storage prefix and the SAME local store.
+    // Models a later cycle / app restart: the persisted cursor survives, the
+    // in-memory backoff window a failed primitive opened does not.
+    rebuild() { engine = build(); return engine },
+  }
 }
 
 const cat = (id: string, updatedAt: string) => ({
@@ -179,5 +206,123 @@ describe('GLANCEvault multi-device cursor ordering (1.4.0 fix)', () => {
     // Sanity: both completion events survived end to end on both devices.
     expect(A.has('evt-A')).toBe(true)
     expect(B.has('evt-B')).toBe(true)
+  })
+})
+
+// ── Pull-cursor durability contract (@glance-apps/sync 2.0.0) ────────────────
+//
+// 2.0.0 made the cursor commit point a declared mode and flipped the DEFAULT to
+// 'end-of-pull'. lastGLANCE declares 'per-page' (src/sync/dbEngine.ts) to keep
+// 1.10.0's mid-pagination resume, which is safe here because applyRemoteEntity
+// writes durably into Dexie before it returns. These tests drive the real
+// engine over a PAGINATING vault, and each one contrasts the shipped mode
+// against the new default — so they fail if the declaration is ever dropped,
+// rather than passing under either mode and proving nothing.
+describe('pull cursor commit mode (2.0.0 pullCursorCommit)', () => {
+  // Publish `n` completion events from a peer so the device under test faces a
+  // multi-page backlog. They are insert-only, so a re-listed page is applied
+  // again harmlessly — the cost of the wrong mode is bandwidth, not rows.
+  async function seedBacklog(prefix: string, vault: ReturnType<typeof makeInMemoryVault>, n: number) {
+    const peer = makeDevice(`${prefix}-peer`, vault)
+    for (let i = 1; i <= n; i++) {
+      peer.create(event(`${prefix}-e${i}`, 'chore-x', `2026-01-01T00:00:0${i}.000Z`))
+    }
+    await peer.engine.dbSyncCycle()
+  }
+
+  it('advances the cursor after each page, which the new default does not', async () => {
+    const vault = makeInMemoryVault({ pageSize: 2 })
+    await seedBacklog('pp', vault, 6)
+
+    // Sample the PERSISTED cursor at the moment each page is requested. Under
+    // 'per-page' it is 0 only for the first page and strictly rises after each
+    // completed page; under 'end-of-pull' it stays 0 for the whole loop and
+    // moves once, at the end.
+    const sample = (dev: ReturnType<typeof makeDevice>, out: number[]) => {
+      vault.hooks.beforeList = () => { out.push(dev.engine.getHighWaterMark()) }
+    }
+
+    const shipped = makeDevice('pp-shipped', vault) // PULL_CURSOR_COMMIT
+    const atPage: number[] = []
+    sample(shipped, atPage)
+    await shipped.engine.pullRemoteChanges()
+
+    const dflt = makeDevice('pp-default', vault, { pullCursorCommit: 'end-of-pull' })
+    const atPageDefault: number[] = []
+    sample(dflt, atPageDefault)
+    await dflt.engine.pullRemoteChanges()
+    vault.hooks.beforeList = null
+
+    // Six rows, two per page: three list() calls, so two commit points are
+    // observable mid-loop.
+    expect(atPage).toHaveLength(3)
+    expect(atPageDefault).toHaveLength(3)
+
+    // The load-bearing assertion. This is what the declaration buys, and it is
+    // exactly what fails if lastGLANCE takes the new default.
+    expect(atPage[0]).toBe(0)
+    expect(atPage[1]).toBeGreaterThan(0)
+    expect(atPage[2]).toBeGreaterThan(atPage[1])
+    expect(atPageDefault).toEqual([0, 0, 0])
+
+    // Both modes converge: the end state is identical, and unchanged from
+    // today. Only the resume point during a failed pull differs.
+    const pushed = vault.pushed()
+    const finalSeq = pushed[pushed.length - 1].seq
+    expect(shipped.engine.getHighWaterMark()).toBe(finalSeq)
+    expect(dflt.engine.getHighWaterMark()).toBe(finalSeq)
+    for (let i = 1; i <= 6; i++) {
+      expect(shipped.has(`pp-e${i}`)).toBe(true)
+      expect(dflt.has(`pp-e${i}`)).toBe(true)
+    }
+  })
+
+  it('resumes a failed pull from the last completed page, where the new default restarts', async () => {
+    // Two devices, same six-row backlog, same failure on the third page.
+    const run = async (prefix: string, mode: PullCursorCommit | undefined) => {
+      const vault = makeInMemoryVault({ pageSize: 2 })
+      await seedBacklog(prefix, vault, 6)
+      const seqs = vault.pushed().map(r => r.seq)
+
+      const dev = makeDevice(`${prefix}-dev`, vault, mode ? { pullCursorCommit: mode } : {})
+      const listedSince: number[] = []
+      vault.hooks.beforeList = (since) => {
+        listedSince.push(since)
+        if (listedSince.length > 2) throw new Error('connection reset')
+      }
+      await expect(dev.engine.pullRemoteChanges()).rejects.toThrow('connection reset')
+
+      // The resumed pull. It runs on a REBUILT engine because 1.12.0 moved the
+      // backoff window down into the primitive: the failure above opened the
+      // pull window, so an immediate retry on the same instance is refused with
+      // SYNC_SUPPRESSED before any request. The window is per-instance memory;
+      // the cursor is what persists, and the cursor is what is under test.
+      listedSince.length = 0
+      vault.hooks.beforeList = (since) => { listedSince.push(since) }
+      await dev.rebuild().pullRemoteChanges()
+      vault.hooks.beforeList = null
+
+      return { dev, seqs, resumedFrom: listedSince[0], finalSeq: seqs[seqs.length - 1] }
+    }
+
+    // Shipped mode: two pages committed, so the retry resumes at the end of
+    // page 2 and never re-downloads rows 1-4.
+    const shipped = await run('rz', undefined)
+    expect(shipped.dev.engine.getHighWaterMark()).toBeGreaterThan(0)
+    expect(shipped.resumedFrom).toBe(shipped.seqs[3])
+
+    // New default: the failed run committed nothing, so the retry re-lists the
+    // whole backlog from where the first attempt started. On a flaky connection
+    // and a large backlog this never converges — the 1.10.0 bug.
+    const dflt = await run('rd', 'end-of-pull')
+    expect(dflt.resumedFrom).toBe(0)
+
+    // Both still converge once a pull completes; the difference is the work.
+    expect(shipped.dev.engine.getHighWaterMark()).toBe(shipped.finalSeq)
+    expect(dflt.dev.engine.getHighWaterMark()).toBe(dflt.finalSeq)
+    for (let i = 1; i <= 6; i++) {
+      expect(shipped.dev.has(`rz-e${i}`)).toBe(true)
+      expect(dflt.dev.has(`rd-e${i}`)).toBe(true)
+    }
   })
 })


### PR DESCRIPTION
Bumps `@glance-apps/sync` 1.10.0 → 2.0.0 and declares the one config line 2.0.0 requires of this app.

## The declared mode, and why not the new default

`src/sync/dbEngine.ts` now passes `pullCursorCommit: 'per-page'` to `createDbSyncEngine`.

2.0.0 turns the pull-cursor commit point into an explicit, validated mode and flips the **default** to `'end-of-pull'`, which advances the cursor once after a fully successful pagination loop. lastGLANCE declares `'per-page'` to keep exactly the behaviour it has had since 1.10.0: the cursor advances after each completed page, so a large backlog on a flaky connection resumes from the last good page instead of re-downloading pages it had already applied.

Taking the new default would have silently reintroduced the convergence bug 1.10.0 fixed, and it would have presented as a network problem weeks after a package bump nobody would connect it to.

`'per-page'` is safe here for the same reason the default changed: `applyRemoteEntity` / `applyRemoteDelete` write straight into Dexie (never through `src/db/queries.ts`) and are durable the moment they return. There is no per-cycle mirror a later failure could discard, so the persisted cursor is always behind committed local state. The default flipped because that is not true of every consumer of the package — a commit-only-on-success composer loses rows under per-page — not because per-page is wrong for the callers it fits.

The mode is exported as `PULL_CURSOR_COMMIT` so the tests drive the real declared value rather than a second copy of the literal. An unrecognised mode is refused at construction (verified: `'perPage'`, `'per_page'` and `'PER-PAGE'` all throw naming the valid modes and the value passed), so a typo there fails loudly in every test in that file rather than silently reverting to the default.

## The cursor test is load-bearing, not decorative

Both new tests were run against `PULL_CURSOR_COMMIT = 'end-of-pull'` and **fail**:

```
× advances the cursor after each page, which the new default does not
  AssertionError: expected 0 to be greater than 0
× resumes a failed pull from the last completed page, where the new default restarts
  AssertionError: expected +0 to be 4
```

Each test contrasts the shipped mode against the new default over the same paginating vault, so the discriminator is permanent in the suite rather than a one-time manual check.

- **Per-page commit.** Six rows, two per page. The persisted cursor is sampled at the moment each page is requested: under the shipped mode it is `0` only for the first page and strictly rises after each completed page (`[0, 2, 4]`); under the default it stays `[0, 0, 0]` and moves once, at the end.
- **Mid-pagination resume.** The third page throws. The shipped mode has committed two pages, so the retry lists from seq 4 and never re-downloads rows 1-4; the default lists from 0 again. Both converge once a pull completes — the difference is the work, which is why it would read as a network problem.

The resumed pull runs on a rebuilt engine over the same storage prefix and the same local store. That is required, not incidental: 1.12.0 moved the backoff window down into the primitive, so an immediate retry of the failed `pullRemoteChanges` on the same instance is refused with `SYNC_SUPPRESSED` before any request. The window is per-instance memory; the cursor is what persists, and the cursor is what is under test.

## What 4a changes here: nothing, by design

Phase 4a moved backoff, quota suppression and the credential halt down into `pullRemoteChanges` and `pushDirtyRows`. lastGLANCE gains nothing from it and no code changed for it. That is the correct outcome, not a failed adoption: every production sync trigger already routes through `dbSyncCycle`, which has carried all three since it existed. 4a closes the gap for callers that compose their own cycle; lastGLANCE is not one.

Surveyed before writing anything, and nothing turned up:

1. **Every sync trigger still routes through `dbSyncCycle`.** The production call sites are `App.tsx:219` (`runDbSync`, the shared trigger behind the poll cadence and the SSE nudge), `App.tsx:779` (after the passphrase prompt derives the root key), `SyncSettingsModal.tsx:316` (Sync now), and `dirtyTracker.ts:39` (the debounced local-write trigger). `createDbEngine` also aliases the engine's `sync` to its own wrapped `dbSyncCycle`, so no caller can reach the raw cycle either. The only direct primitive calls remain the two in `dbEngineMultiDevice.test.ts`, deliberately exercising the primitives' contract. The `engine.sync()` calls in `App.tsx`, `BackupModal` and `SyncSettingsModal` are the file-tier engine, untouched by this package release.
2. **Nothing treats "no request went out" as a problem.** lastGLANCE has no retry ladder or circuit breaker of its own to compound with the engine's — the integration hazard 1.12.0 calls out. Its triggers are unconditional (poll cadence, focus, SSE nudge, debounced write) and it already reads standing backoff from `engine.getBackoffState()` via `src/sync/backoffStatus.ts` rather than inferring it from request flow. No production or test assertion depends on a request being issued.
3. **The two direct-primitive tests still pass**, unmodified: no window open, no halt, single-page pull. Confirmed by running them, not assumed.

## Regression surface

- Normal operation unaffected: a healthy client that never hits a window sees nothing new.
- Cursor behaviour is unchanged from today, which is the entire point of declaring `'per-page'`.
- The seed-gate flag and its one-shot persistence are untouched; those tests pass unchanged.
- Existing users see no change.

## Verification

- `npm test` — 42 files, 547 tests passing (545 before, +2 new).
- `npm run lint` — clean, `--max-warnings 0`.
- `npx tsc -b` — clean.
- `npm run build` — succeeds.

**Needs a real server, not covered here:** item 3 of the verification list, normal sync against a live GLANCEvault instance. Everything above runs against the in-memory vault double in `dbEngineMultiDevice.test.ts` and the `127.0.0.1:9` fail-fast config in `dbEngine.test.ts`. The stub reproduces pagination, per-page commits and a mid-pagination failure faithfully, but it does not exercise real HTTP, real auth, SSE nudges, or a real multi-device account. Worth one manual pass on a real vault before this ships in a release.

## Out of scope

The backoff-aware UI, the vault section i18n, the timeline-level vault indicator, lifeGLANCE and dayGLANCE bumps, billing, the vault, and the iOS submission work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2Njz3PwgtnR7vEHuonm8y)_