### PR TITLE
iOS: Control Center Add opens the app but not the new-chore form

### DIFF
--- a/ios/App/App/Shared/AddChoreControl.swift
+++ b/ios/App/App/Shared/AddChoreControl.swift
@@ -12,24 +12,38 @@ import AppIntents
 // at all. That is why it sits in App/Shared/ next to SharedDataStore.swift,
 // the repo's existing both-targets home, rather than beside the widgets it
 // belongs to conceptually.
-//
-// The dual membership is what makes the OpenURLIntent chain below reachable;
-// it is not an alternative to it. Both are required.
 
 // Opens the app straight into the new-chore form — the Quick Settings
 // add-chore tile, relocated to where iOS puts such things.
 //
-// The intent's ONLY job is to hand back an OpenURLIntent for the same
-// lastglance:// URL every other entry point uses; the app then receives it
-// through the AppDelegate URL path, which is device-verified. Two designs
-// that look right do not work from a control, learned the hard way:
-//  - `openAppWhenRun` alone is ignored when the intent runs in the widget
-//    extension process — which is exactly where a control button's intent
-//    runs. The tap performed, wrote its token, and nothing opened.
-//  - Writing the pending token from the intent also had a warm-open race:
-//    the app's foreground drain could run before the token landed.
-// Chaining OpenURLIntent solves both: the system opens the URL itself, and
-// the token is minted by AppDelegate on receipt, exactly as for a widget tap.
+// TWO INDEPENDENT HALVES, AND THE DESTINATION MUST NOT RIDE ON EITHER ONE.
+//
+// Opening the app and saying WHERE to go are separate problems here, and the
+// system decides which of the two open mechanisms below it honours:
+//
+//  - `openAppWhenRun` foregrounds the app but carries no destination. It is
+//    ignored while the app target cannot see this intent, which is why the
+//    control did nothing before the file gained its App-target membership —
+//    and it is what opens the app now that it can.
+//  - The chained `OpenURLIntent` carries the destination in the URL, and the
+//    app receives it through the AppDelegate URL path every widget body-tap
+//    already uses. But the system will not necessarily perform it once
+//    `openAppWhenRun` has already satisfied "open the app".
+//
+// So `perform()` writes the pending token itself, BEFORE handing back the
+// open. That is the half that cannot be dropped: whichever mechanism actually
+// foregrounds the app, the destination is already in the App Group for
+// usePendingDeepLink to drain on mount or on the foreground visibilitychange.
+//
+// Deleting this write is precisely how the control regressed from "does
+// nothing" to "opens the app on the wrong screen": it was removed in favour of
+// the OpenURLIntent chain alone, at a point when the control could not open
+// the app at all, so the chain was never actually observed to deliver the URL.
+//
+// The OpenURLIntent is kept, not redundant. If the system does perform it,
+// AppDelegate maps the same URL to the same "action:add" token and writes it
+// to the same single slot — same value, consumed once by
+// readAndClearPendingDeepLink, so at most one new-chore form either way.
 @available(iOS 18.0, *)
 struct OpenAddChoreIntent: AppIntent {
     static let title: LocalizedStringResource = "Add chore"
@@ -38,7 +52,11 @@ struct OpenAddChoreIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult & OpensIntent {
-        .result(opensIntent: OpenURLIntent(URL(string: "lastglance://action/add")!))
+        // Runs to completion in the widget extension process before the system
+        // opens the app, so the token is in the shared container ahead of any
+        // drain the foregrounding app can run.
+        SharedDataStore.writePendingDeepLink("action:add")
+        return .result(opensIntent: OpenURLIntent(URL(string: "lastglance://action/add")!))
     }
 }
 

--- a/src/iosControls.test.ts
+++ b/src/iosControls.test.ts
@@ -1,6 +1,22 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+
+// The router is exercised for real below, so the native bridge it calls is
+// stubbed. vi.hoisted because vi.mock is lifted above ordinary declarations.
+const { plugin } = vi.hoisted(() => ({
+  plugin: {
+    consumeDeepLink: vi.fn(async () => ({ deepLink: null as string | null })),
+    consumeSharedChore: vi.fn(async () => ({ text: null as string | null })),
+  },
+}))
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { getPlatform: () => 'ios' },
+  registerPlugin: () => plugin,
+}))
+
+import { routeWidgetDeepLink } from '@/native/pendingDeepLink'
 
 /**
  * CI cannot run Xcode, so the project wiring the Control Center control
@@ -19,6 +35,14 @@ import { join } from 'node:path'
  * Nothing else catches this. It is not a compile error, and the accessory
  * widget in the same original file genuinely cannot join the app target, since
  * it depends on the extension-only SnapshotProvider.
+ *
+ * OPENING THE APP AND SAYING WHERE TO GO ARE SEPARATE PROBLEMS, and the second
+ * regressed on its own once the first was fixed: with the membership in place
+ * `openAppWhenRun` foregrounds the app, which can satisfy "open" without the
+ * system ever performing the chained OpenURLIntent — so the app arrived on the
+ * chore list with no destination. The intent therefore writes the pending token
+ * itself, and the tests below follow that token all the way to the web event,
+ * because every layer of that chain is a plain literal no compiler checks.
  */
 const IOS = join(__dirname, '../ios/App')
 const PBXPROJ = join(IOS, 'App.xcodeproj/project.pbxproj')
@@ -83,5 +107,80 @@ describe('iOS Control Center control', () => {
   it('still registers the control in the widget bundle', () => {
     const bundle = readFileSync(join(IOS, 'GlanceWidgets/GlanceWidgetsBundle.swift'), 'utf8')
     expect(bundle).toMatch(/AddChoreControl\(\)/)
+  })
+})
+
+// ── The destination, from the intent to the web event ────────────────────────
+//
+// The control opening the app is only half the job. Nothing about "and it opens
+// the new-chore form" is checked by a compiler, a type, or the Swift build: the
+// token is a bare string that has to survive an App Group write, an AppDelegate
+// URL mapping, a Capacitor bridge call and a web-router branch, each of which
+// spells it out as its own literal. These tests read the token out of the Swift
+// intent and follow that exact value through every remaining layer, so any one
+// of them drifting fails here rather than on someone's phone.
+describe('iOS Control Center destination', () => {
+  const src = readFileSync(join(IOS, 'App/Shared', CONTROL_FILE), 'utf8')
+
+  /** The token the intent writes, and the URL it chains — from source. */
+  const token = src.match(/writePendingDeepLink\("([^"]+)"\)/)?.[1]
+  const url = src.match(/OpenURLIntent\(URL\(string: "([^"]+)"\)!\)/)?.[1]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    plugin.consumeDeepLink.mockResolvedValue({ deepLink: null })
+    plugin.consumeSharedChore.mockResolvedValue({ text: null })
+  })
+
+  it('writes the pending token itself, rather than relying on the chained URL', () => {
+    expect(
+      token,
+      'OpenAddChoreIntent.perform() must write the deep-link token. `openAppWhenRun` ' +
+        'foregrounds the app carrying no destination, and once it has satisfied "open the ' +
+        'app" the system need not perform the chained OpenURLIntent — so the URL is not a ' +
+        'reliable carrier. Without this write the control opens the app on the chore list.',
+    ).toBe('action:add')
+  })
+
+  it('keeps the chained URL, and AppDelegate maps it back to the same token', () => {
+    // Not redundant with the write: when the system DOES perform it, this is
+    // the path the URL takes, and it must land on the same single slot.
+    expect(url).toBe('lastglance://action/add')
+
+    // Mirror AppDelegate.deepLinkToken's parse: host, then lastPathComponent.
+    const { host, pathname } = new URL(url!)
+    const last = pathname.split('/').filter(Boolean).pop()
+
+    const delegate = readFileSync(join(IOS, 'App/AppDelegate.swift'), 'utf8')
+    expect(delegate).toMatch(new RegExp(`case "${host}":`))
+    expect(delegate).toMatch(new RegExp(`case "${last}": return "${token}"`))
+  })
+
+  it('is accepted by the quick-action validity check too', () => {
+    // The same token arrives from home-screen quick actions, which validate
+    // against an explicit allow-list. A token the control writes but that list
+    // rejects would work from one entry point and not the other.
+    const delegate = readFileSync(join(IOS, 'App/AppDelegate.swift'), 'utf8')
+    expect(delegate).toContain(`token == "${token}"`)
+  })
+
+  it('routes that exact token to the new-chore form', async () => {
+    // The web half, run for real: the router is driven with the token read out
+    // of the Swift source, not with a literal re-typed here.
+    const dispatched: string[] = []
+    vi.stubGlobal('window', { dispatchEvent: (e: Event) => { dispatched.push(e.type); return true } })
+    plugin.consumeDeepLink.mockResolvedValue({ deepLink: token! })
+
+    await routeWidgetDeepLink()
+
+    expect(dispatched).toContain('lg:new-chore')
+    vi.unstubAllGlobals()
+  })
+
+  it('has a listener for that event mounted in the Ribbon', () => {
+    // The last link in the chain, and the only one not executable here: the
+    // Ribbon owns the new-chore form and registers the listener on mount.
+    const ribbon = readFileSync(join(__dirname, 'components/Ribbon/Ribbon.tsx'), 'utf8')
+    expect(ribbon).toContain("addEventListener('lg:new-chore'")
   })
 })


### PR DESCRIPTION
The Control Center "Add" control now launches the app and lands on the chore list. Opening the app and saying where to go are separate problems, and only the first was fixed.

## What is happening

The wiring the last fix added is all correct, and that is itself the diagnosis. Verified statically:

- `AddChoreControl.swift` is in both targets' Sources build phases, and so is `SharedDataStore.swift`, so `perform()` can write from the extension.
- `group.com.lastglance` is declared identically in `App.entitlements` and `GlanceWidgets.entitlements`.
- `lastglance` is declared in `CFBundleURLTypes`, and there is no `UIApplicationSceneManifest`, so the classic `application(_:open:)` delivery path applies.
- `deepLinkToken(from:)` maps `lastglance://action/add` to `action:add` correctly, and the web router handles that token.

Nothing is missing. What broke is which of the two open mechanisms actually carries the destination:

- Putting the intent in the app target is what lets the app's AppIntents metadata see `OpenAddChoreIntent`, which is what makes `openAppWhenRun = true` effective. That is what opens the app today.
- `openAppWhenRun` carries no destination. Once it has satisfied "open the app", the system need not perform the chained `OpenURLIntent`, so no `lastglance://` URL reaches `AppDelegate`, no pending token is written, and `usePendingDeepLink` has nothing to route.

The token write was deleted in 29ab983 in favour of the `OpenURLIntent` chain alone, at a point when the control could not open the app at all. That chain was therefore never actually observed to deliver the URL, and the "warm-open race" cited as the reason for deleting the write was inferred rather than seen, because nothing was opening to race with. The regression only became visible once 6aa0f77 fixed the target membership and the app started opening.

The three-commit symptom sequence fits exactly: "does nothing" (e6a6147, metadata missing), "does nothing" (29ab983, metadata still missing, write now gone), "opens on the wrong screen" (6aa0f77, metadata fixed, nothing left to carry the destination).

## The fix

`perform()` writes the pending token itself, before handing back the open, so the destination does not ride on whichever mechanism the system honours.

The `OpenURLIntent` stays rather than betting everything on one path. When it is performed, `AppDelegate` maps the same URL to the same `action:add` token into the same single slot, and `readAndClearPendingDeepLink` consumes it once, so at most one new-chore form either way.

## Tests

Five new cases in `src/iosControls.test.ts`. The token is read out of the Swift source and followed through every remaining layer, because each one spells it out as its own literal that no compiler, type, or Swift build checks:

- the intent writes the token at all (the line whose deletion caused this);
- the chained URL still maps back to the same token in `AppDelegate.deepLinkToken`;
- the quick-action allow-list accepts the same token, so the control and a home-screen long-press cannot diverge;
- the web router, run for real against a stubbed bridge and driven with the token read from Swift, dispatches `lg:new-chore`;
- the Ribbon registers a listener for that event.

Deleting the `writePendingDeepLink` line fails four of them, with the first naming the cause in its assertion message.

- `npm test` - 42 files, 552 tests passing (547 before, +5 new).
- `npm run lint` - clean at `--max-warnings 0`.
- `npx tsc -b` - clean.

## Needs verification on a device

CI cannot run Xcode and the failure mode is only observable on a phone, so the reasoning above is inference from the symptom sequence plus the fact that every piece of static wiring checks out. The fix is deliberately robust to that inference being wrong about which mechanism opens the app: if `OpenURLIntent` was firing all along and the break is downstream in the drain, the token write is harmless and the real cause is elsewhere. Worth one tap on a phone before this ships in a release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2Njz3PwgtnR7vEHuonm8y)_