### PR TITLE
Release 2.5.2: version bump and the RATE_LIMITED translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -395,6 +395,7 @@
       "ACCOUNT_ID_REQUIRED": "Die Sync-Einrichtung wird abgeschlossen – versuche es gleich noch einmal.",
       "CREDENTIAL_INVALID": "Der Sync-Server akzeptiert den Sync-Zugriff dieses Geräts nicht mehr. Deine Änderungen sind auf diesem Gerät gespeichert. Bitte die Person, die deinen Sync-Server betreibt, den Zugriff für dieses Gerät wiederherzustellen.",
       "QUOTA_EXCEEDED": "Der Sync-Server hat das Limit für dieses Konto erreicht. Deine Änderungen sind auf diesem Gerät gespeichert und die Synchronisierung versucht es automatisch erneut. Bitte die Person, die deinen Sync-Server betreibt, das Limit zu erhöhen.",
+      "RATE_LIMITED": "Der Sync-Server erhält zu viele Anfragen. Die Synchronisierung pausiert kurz und wird automatisch fortgesetzt. Deine Änderungen sind auf diesem Gerät gespeichert.",
       "passphraseNeeded": "Gib deine Sync-Passphrase ein, um fortzufahren.",
       "vaultUnreachable": "GLANCEvault ist nicht erreichbar: {{detail}}",
       "requestFailed": "Sync-Anfrage fehlgeschlagen. Bitte versuche es erneut.",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -395,6 +395,7 @@
       "ACCOUNT_ID_REQUIRED": "Finishing sync setup — try again in a moment.",
       "CREDENTIAL_INVALID": "The sync server no longer accepts this device's sync access. Your changes are saved on this device. Ask whoever runs your sync server to restore access for this device.",
       "QUOTA_EXCEEDED": "The sync server has reached its limit for this account. Your changes are saved on this device and syncing will retry automatically. Ask whoever runs your sync server to raise the limit.",
+      "RATE_LIMITED": "The sync server is receiving too many requests. Syncing has paused briefly and will resume automatically. Your changes are saved on this device.",
       "passphraseNeeded": "Enter your sync passphrase to continue.",
       "vaultUnreachable": "Couldn't reach GLANCEvault: {{detail}}",
       "requestFailed": "Sync request failed. Please try again.",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -395,6 +395,7 @@
       "ACCOUNT_ID_REQUIRED": "Finalizando la configuración de sincronización: inténtalo de nuevo en un momento.",
       "CREDENTIAL_INVALID": "El servidor de sincronización ya no acepta el acceso de este dispositivo. Tus cambios están guardados en este dispositivo. Pide a quien administra tu servidor de sincronización que restaure el acceso para este dispositivo.",
       "QUOTA_EXCEEDED": "El servidor de sincronización ha alcanzado el límite de esta cuenta. Tus cambios están guardados en este dispositivo y la sincronización se reintentará automáticamente. Pide a quien administra tu servidor de sincronización que aumente el límite.",
+      "RATE_LIMITED": "El servidor de sincronización está recibiendo demasiadas solicitudes. La sincronización se ha pausado un momento y se reanudará automáticamente. Tus cambios están guardados en este dispositivo.",
       "passphraseNeeded": "Introduce tu contraseña de sincronización para continuar.",
       "vaultUnreachable": "No se pudo conectar con GLANCEvault: {{detail}}",
       "requestFailed": "La solicitud de sincronización falló. Inténtalo de nuevo.",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -395,6 +395,7 @@
       "ACCOUNT_ID_REQUIRED": "Finalisation de la configuration de la sync — réessayez dans un instant.",
       "CREDENTIAL_INVALID": "Le serveur de synchronisation n'accepte plus l'accès de cet appareil. Vos modifications sont enregistrées sur cet appareil. Demandez à la personne qui gère votre serveur de synchronisation de rétablir l'accès pour cet appareil.",
       "QUOTA_EXCEEDED": "Le serveur de synchronisation a atteint la limite de ce compte. Vos modifications sont enregistrées sur cet appareil et la synchronisation réessaiera automatiquement. Demandez à la personne qui gère votre serveur de synchronisation d'augmenter la limite.",
+      "RATE_LIMITED": "Le serveur de synchronisation reçoit trop de requêtes. La synchronisation est suspendue un instant et reprendra automatiquement. Vos modifications sont enregistrées sur cet appareil.",
       "passphraseNeeded": "Saisissez votre phrase secrète de sync pour continuer.",
       "vaultUnreachable": "Impossible de joindre GLANCEvault : {{detail}}",
       "requestFailed": "La requête de synchronisation a échoué. Veuillez réessayer.",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -395,6 +395,7 @@
       "ACCOUNT_ID_REQUIRED": "Completamento della configurazione della sincronizzazione — riprova tra poco.",
       "CREDENTIAL_INVALID": "Il server di sincronizzazione non accetta più l'accesso di questo dispositivo. Le tue modifiche sono salvate su questo dispositivo. Chiedi a chi gestisce il tuo server di sincronizzazione di ripristinare l'accesso per questo dispositivo.",
       "QUOTA_EXCEEDED": "Il server di sincronizzazione ha raggiunto il limite di questo account. Le tue modifiche sono salvate su questo dispositivo e la sincronizzazione riproverà automaticamente. Chiedi a chi gestisce il tuo server di sincronizzazione di aumentare il limite.",
+      "RATE_LIMITED": "Il server di sincronizzazione sta ricevendo troppe richieste. La sincronizzazione è in pausa per un momento e riprenderà automaticamente. Le tue modifiche sono salvate su questo dispositivo.",
       "passphraseNeeded": "Inserisci la tua passphrase di sincronizzazione per continuare.",
       "vaultUnreachable": "Impossibile raggiungere GLANCEvault: {{detail}}",
       "requestFailed": "Richiesta di sincronizzazione non riuscita. Riprova.",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -395,6 +395,7 @@
       "ACCOUNT_ID_REQUIRED": "Concluindo a configuração da sincronização — tente novamente daqui a pouco.",
       "CREDENTIAL_INVALID": "O servidor de sincronização já não aceita o acesso deste dispositivo. As suas alterações estão salvas neste dispositivo. Peça a quem gerencia o seu servidor de sincronização para restaurar o acesso deste dispositivo.",
       "QUOTA_EXCEEDED": "O servidor de sincronização atingiu o limite desta conta. As suas alterações estão salvas neste dispositivo e a sincronização será repetida automaticamente. Peça a quem gerencia o seu servidor de sincronização para aumentar o limite.",
+      "RATE_LIMITED": "O servidor de sincronização recebeu solicitações demais. A sincronização foi pausada por um momento e será retomada automaticamente. As suas alterações estão salvas neste dispositivo.",
       "passphraseNeeded": "Digite a sua frase de sincronização para continuar.",
       "vaultUnreachable": "Não foi possível contatar o GLANCEvault: {{detail}}",
       "requestFailed": "O pedido de sincronização falhou. Tente novamente.",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -395,6 +395,7 @@
       "ACCOUNT_ID_REQUIRED": "A concluir a configuração da sincronização — tente novamente daqui a pouco.",
       "CREDENTIAL_INVALID": "O servidor de sincronização já não aceita o acesso deste dispositivo. As suas alterações estão guardadas neste dispositivo. Peça a quem gere o seu servidor de sincronização para restaurar o acesso deste dispositivo.",
       "QUOTA_EXCEEDED": "O servidor de sincronização atingiu o limite desta conta. As suas alterações estão guardadas neste dispositivo e a sincronização será repetida automaticamente. Peça a quem gere o seu servidor de sincronização para aumentar o limite.",
+      "RATE_LIMITED": "O servidor de sincronização recebeu demasiados pedidos. A sincronização foi pausada por um momento e será retomada automaticamente. As suas alterações estão guardadas neste dispositivo.",
       "passphraseNeeded": "Introduza a sua frase-passe de sincronização para continuar.",
       "vaultUnreachable": "Não foi possível contactar o GLANCEvault: {{detail}}",
       "requestFailed": "O pedido de sincronização falhou. Tente novamente.",

--- a/scripts/gen-pt-br.mjs
+++ b/scripts/gen-pt-br.mjs
@@ -168,6 +168,9 @@ const RULES = [
   ['partilhados', 'compartilhados'],
   ['Gerir subscrição', 'Gerenciar assinatura'],
   ['quem gere', 'quem gerencia'],
+  // "pedidos" is fine in both, but Brazil says "solicitações" for the
+  // HTTP sense the rate-limit message is about.
+  ['recebeu demasiados pedidos', 'recebeu solicitações demais'],
 
   // ── progressives: Portugal's "a + infinitive", Brazil's gerund ──
   ['A aguardar chave', 'Aguardando chave'],

--- a/src/locales.test.ts
+++ b/src/locales.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { languages, loaders, resolveLanguage } from './locales'
 
 // de/es/fr/it/pt sat 8 keys behind en — the backup restore confirmation and
@@ -144,6 +146,71 @@ describe('locale bundles', () => {
       bundles['pt-BR'],
       'pt-BR does not match its transform — run `node scripts/gen-pt-br.mjs` (and never edit pt-BR by hand)',
     ).toEqual(regenerated)
+  })
+
+  // Locale-to-locale parity cannot see a code the ENGINE knows about and no
+  // locale has, which is how RATE_LIMITED arrived unmapped: @glance-apps/sync
+  // 1.11.0 added it, the bump to 2.0.0 brought it in, and syncErrorText's
+  // fallback to the engine's own message meant it degraded to English instead
+  // of failing. Nothing was broken, and nothing said anything either.
+  //
+  // So the codes are checked against the package's own union rather than
+  // against each other. A code that should NOT have a key needs an entry in
+  // UNMAPPED with a reason, which turns "we forgot" into "we decided".
+  describe('every SyncErrorCode the engine can surface has English text', () => {
+    // Codes deliberately without a key, and why.
+    const UNMAPPED: Record<string, string> = {
+      // dbSyncCycle never routes this to onError: a suppressed half is
+      // reported through surfaceStandingWindow (quota only) and the standing
+      // window is rendered from getBackoffState() by backoffStatus.ts, not by
+      // syncErrorText. A string here would be unreachable.
+      SYNC_SUPPRESSED: 'never reaches onError; rendered as a backoff window',
+    }
+
+    const codes = (() => {
+      const dts = readFileSync(
+        join(__dirname, '../node_modules/@glance-apps/sync/types/index.d.ts'),
+        'utf8',
+      )
+      // Comments are stripped BEFORE the union's terminating `;` is located.
+      // Several members carry doc comments containing a semicolon, so matching
+      // `=([\s\S]*?);` against the raw text truncates the union mid-way — it
+      // silently yielded 12 of 14 codes, with the two newest (the ones a bump
+      // actually adds) falling off the end.
+      const body = dts.slice(dts.indexOf('export type SyncErrorCode =')).replace(/\/\/[^\n]*/g, '')
+      const union = body.slice(0, body.indexOf(';'))
+      return [...union.matchAll(/'([A-Z_]+)'/g)].map((m) => m[1])
+    })()
+
+    it('parses the whole union out of the package types', () => {
+      // Pinned at BOTH ends: a parse that stops early still returns plausible
+      // codes, so a count threshold does not catch it. The last member is the
+      // one that matters — a truncated union makes every case below vacuous
+      // for exactly the newly-added codes this guard exists to catch.
+      expect(codes[0]).toBe('APP_ID_MISMATCH')
+      expect(codes).toContain('NETWORK_ERROR')
+      expect(codes[codes.length - 1]).toBe('SYNC_SUPPRESSED')
+    })
+
+    it.each(codes)('%s', (code) => {
+      const errors = (bundles.en as { sync: { errors: Record<string, string> } }).sync.errors
+      if (code in UNMAPPED) {
+        expect(
+          errors[code],
+          `${code} is listed in UNMAPPED (${UNMAPPED[code]}) but has a string. ` +
+            'Drop it from UNMAPPED if it can now reach onError.',
+        ).toBeUndefined()
+        return
+      }
+      expect(
+        errors[code],
+        `sync.errors.${code} is missing from en. The engine can pass this code to ` +
+          'onError, and syncErrorText falls back to the raw English message, so the ' +
+          'gap shows up as untranslated text rather than as an error. Add the key to ' +
+          'every locale (pt-BR via scripts/gen-pt-br.mjs), or add it to UNMAPPED here ' +
+          'with the reason it cannot be surfaced.',
+      ).toBeTypeOf('string')
+    })
   })
 
   // Parity can be satisfied by pasting the English text in. Spot-check one


### PR DESCRIPTION
Maintenance release. `versionName` 2.5.1 to 2.5.2; Android `versionCode` derives to 2050200.

## What ships in this release

Everything on main since v2.5.1 is two merges, and only one of them reaches a shipped build:

- **`@glance-apps/sync` 1.10.0 to 2.0.0** (PR #311). This is the release.
- **The iOS Control Center fix** (PR #312) is on main but ships nothing here: iOS has not been released, so there is no build for it to change. It also still needs device verification.

Plus the translation gap that bump left behind, fixed below.

## User-visible effect: essentially none, deliberately

- The cursor behaviour is **unchanged**, which is the whole point of declaring `pullCursorCommit: 'per-page'`. Taking 2.0.0's new default would have been the visible change, and a bad one.
- 1.12.0's move of backoff, quota suppression and the credential halt down into the primitives is inert here, because every sync trigger already routes through `dbSyncCycle`.
- Existing users need to reconfigure nothing, and a healthy client that never hits a backoff window sees nothing new.

The one genuine behaviour gain is 1.11.0's **device-wide rate-limit brake**: a real 429 from a vault server now pauses every vault request in the bundle and fails fast before touching the network, escalating per burst and decaying on success.

## The RATE_LIMITED translation

That brake introduced a code with no `sync.errors` entry, so a rate-limited vault rendered the engine's English message to every non-English user. Nothing was broken, which is exactly the problem: `syncErrorText` falls back to the raw message, so the gap degraded to English instead of failing.

The string is added to all seven locales. pt-BR is derived, so the European file gains the text and one transform rule renders "demasiados pedidos" as "solicitações demais", the HTTP sense the message is about.

## The guard that should have caught it

The existing parity check compares locales **against each other**, so it is blind to a code that every locale is missing. Codes are now checked against the package's own `SyncErrorCode` union, with an `UNMAPPED` list for those that deliberately have no string. `SYNC_SUPPRESSED` is the only entry: `dbSyncCycle` never routes it to `onError`, and a standing backoff window is rendered from `getBackoffState()` by `backoffStatus.ts`, so a string would be unreachable.

Parsing that union needs care, and the first attempt got it wrong. Several members carry doc comments containing a semicolon, so matching to the first `;` truncated the union at 12 of 14 codes and dropped the two newest, which are precisely the ones a bump adds. Comments are stripped first, and the parse is now pinned at **both** ends: a count threshold still looks plausible when the tail is missing, which is how the truncation initially passed its own sanity check.

Verified by deleting the key from all seven locales: the new guard fails with the actionable message, where the parity check alone stays green.

## Verification

- `npm test` - 42 files, 569 tests passing (552 before).
- `npm run lint` - clean at `--max-warnings 0`.
- `npx tsc -b` - clean.
- `npm run build` - succeeds.

GitHub and Play release notes are drafted separately, following the v2.4.1 maintenance-release shape.