### PR TITLE
Make the sideload build identifiable, and verifiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,52 @@ A native Android app is available on Google Play and as a direct APK download. T
 [**Get it on Obtainium →**](https://github.com/ImranR98/Obtainium)
 <br> *Just point Obtainium to `krelltunez/lastGLANCE`!*
 
+### Which build am I running?
+
+The two Android builds differ in one way only: the **Play** build is a paid app
+(subscription or one-off lifetime unlock), the **GitHub APK is fully unlocked** —
+no paywall, no billing, every feature on. They otherwise share a package name,
+app name, icon and version, so once installed they look identical. Two ways to
+tell them apart:
+
+- **Settings → Subscription.** The GitHub APK says *"This build is fully
+  unlocked"* and offers nothing to buy. The Play build shows a purchase status
+  with *Manage subscription* / *Restore purchase* instead.
+- **The version.** The sideload APK's version ends in `-github`, e.g.
+  `2.5.2-github` (releases up to 2.5.2 do not carry this marker yet).
+
+**If you are seeing a paywall, you are running the Play build.** Third-party
+mirrors (APKPure, APKMirror, Aptoide and similar) republish the *Play* build
+under the same name and version — only the [releases page](../../releases) and
+Obtainium serve the ungated one. Switching from the Play build to the sideload
+APK needs an uninstall (the signing keys differ, so Android cannot update one
+into the other), and **uninstalling erases local data — export first**, or set
+up [sync](#sync--storage) before you switch.
+
+### Verifying the APK
+
+Every release publishes `SHA256SUMS.txt` next to the APK:
+
+```bash
+sha256sum -c SHA256SUMS.txt      # run in the folder you downloaded into
+```
+
+The APK is signed with this certificate — any APK claiming to be lastGLANCE
+with a different fingerprint was not built by us:
+
+```
+SHA-256: 50:D7:13:7E:92:B4:7A:6C:AB:C6:EF:57:22:AA:D2:07:AB:B9:00:CC:A0:1B:AB:23:85:A9:79:31:EF:76:04:69
+```
+
+```bash
+apksigner verify --print-certs lastglance-github.apk
+```
+
+(The Play copy is re-signed by Google Play App Signing, so it legitimately shows
+a *different* fingerprint — that is itself a way to tell the two apart. A
+single-engine antivirus flag on the sideload APK is the same story: the two
+signatures differ by design.)
+
 The Android app ships the full web app in a WebView with native enhancements that aren't possible in a browser:
 
 | Feature | Details |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,9 +9,18 @@ apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 // otherwise outrank the derived codes; it still increases monotonically with the
 // version, with 100 spare codes per patch for pre-release overrides.
 def pkg = new groovy.json.JsonSlurper().parse(rootProject.file("../package.json"))
-def appVersionName = pkg.version as String
-def versionParts = appVersionName.tokenize('.')
+def baseVersionName = pkg.version as String
+def versionParts = baseVersionName.tokenize('.')
 def derivedVersionCode = versionParts[0].toInteger() * 1000000 + versionParts[1].toInteger() * 10000 + versionParts[2].toInteger() * 100
+
+// Optional versionName tag, appended as "-<suffix>" (the versionCode is
+// untouched, so updates still work normally). build-android.sh passes
+// -PversionNameSuffix=github for the sideload APK: the Play and GitHub
+// artifacts otherwise share an applicationId, name, icon and versionCode, so
+// "2.5.2-github" in Android's app info is how a user — or a bug report — can
+// tell which of the two is installed.
+def versionNameTag = project.findProperty("versionNameSuffix") ?: System.getenv("LASTGLANCE_VERSION_SUFFIX")
+def appVersionName = versionNameTag ? "${baseVersionName}-${versionNameTag}" : baseVersionName
 
 // One-off versionCode override for uploading pre-release builds (e.g. to the
 // Play internal test track) without disturbing the derived release numbering.

--- a/build-android.sh
+++ b/build-android.sh
@@ -8,7 +8,9 @@ set -e
 # Usage:
 #   ./build-android.sh                     debug APK + install on a connected device
 #   ./build-android.sh --release           signed release APK + .aab for the Play Store
-#                                          -> outputs/lastglance.apk, outputs/lastglance.aab
+#                                          -> outputs/lastglance-github.apk (ungated
+#                                             sideload), outputs/lastglance.aab (Play),
+#                                             outputs/SHA256SUMS.txt
 #   ./build-android.sh --release --build N  release build with a test versionCode
 #                                          (N = 1..99) for internal/closed-test uploads
 #   ./build-android.sh --clean             full gradle clean + wipe dist/ first
@@ -114,19 +116,40 @@ if $RELEASE; then
     echo "         be UNSIGNED and not installable. See keystore.properties.example."
   fi
 
-  # Channel-split release builds (docs/paywall-billing-plan.md): the sideload
-  # APK is UNGATED (github channel) and the Play AAB is GATED (play channel),
-  # so each artifact needs its own web build — VITE_BUILD_CHANNEL is baked in
-  # at Vite build time. APP_VERSION_CODE, when set, overrides the derived
+  # Channel-split release builds: the sideload APK is UNGATED (github channel)
+  # and the Play AAB is GATED (play channel), so each artifact needs its own web
+  # build — VITE_BUILD_CHANNEL is baked in at Vite build time, and
+  # src/billing/billing.ts builds a billing adapter only for 'play' on Android
+  # (@glance-apps/billing treats a null adapter as ungated, so any other value
+  # ships an unlocked app). APP_VERSION_CODE, when set, overrides the derived
   # versionCode for both artifacts (see build.gradle).
+  #
+  # The two artifacts share an applicationId, app name, icon and versionCode —
+  # only the web assets and the signing key differ — so the sideload build is
+  # marked in the two places a user can actually look: the file name
+  # (lastglance-github.apk, matching dayGLANCE's and lifeGLANCE's) and the
+  # versionName (2.5.2-github). Without that, "the GitHub APK is showing me the
+  # paywall" cannot be told apart from "I am running the Play build" — and
+  # mirror sites republish the gated Play build under the same name.
+
+  # Artifacts this script wrote under its pre-rename name. Left in place they
+  # are indistinguishable from a fresh build in outputs/ and are exactly the
+  # wrong file to attach to a release, so clear them (they were overwritten on
+  # every run anyway).
+  if [ -f "$OUT_DIR/lastglance.apk" ]; then
+    echo "==> Removing stale lastglance.apk from a pre-rename build..."
+    rm -f "$OUT_DIR/lastglance.apk"
+  fi
+
+  APK_OUT="lastglance-github.apk"
 
   echo "==> Building web assets (channel: github — ungated sideload APK)..."
   cd "$SCRIPT_DIR"
   VITE_BUILD_CHANNEL=github npm run build:android
   cd "$ANDROID_DIR"
-  ./gradlew assembleRelease ${APP_VERSION_CODE:+-PappVersionCode="$APP_VERSION_CODE"}
-  cp "app/build/outputs/apk/release/lastglance.apk" "$OUT_DIR/lastglance.apk"
-  echo "    APK (release, github channel) → outputs/lastglance.apk"
+  ./gradlew assembleRelease -PversionNameSuffix=github ${APP_VERSION_CODE:+-PappVersionCode="$APP_VERSION_CODE"}
+  cp "app/build/outputs/apk/release/lastglance.apk" "$OUT_DIR/$APK_OUT"
+  echo "    APK (release, github channel, versionName -github) → outputs/$APK_OUT"
 
   # The reviewer bypass (@glance-apps/billing rule 9: store review needs a way
   # past a hard gate) is compiled in from src/config/reviewerAccess.js — a
@@ -150,9 +173,14 @@ if $RELEASE; then
   if [ -z "$APKSIGNER" ] && [ -n "$SDK_DIR" ]; then
     APKSIGNER="$(ls "$SDK_DIR"/build-tools/*/apksigner 2>/dev/null | sort -V | tail -1)"
   fi
-  if [ -n "$APKSIGNER" ]; then
+  if [ ! -f "$ANDROID_DIR/keystore.properties" ]; then
+    echo "    (no keystore.properties; APK is unsigned, skipping signature check)"
+  elif [ -n "$APKSIGNER" ]; then
+    # No `|| true`: set -e is on, so a bad signature stops the release here
+    # rather than at the point someone tries to install the APK. The published
+    # fingerprint is in README.md ("Verifying the APK").
     echo "==> Verifying signature..."
-    "$APKSIGNER" verify --print-certs "$OUT_DIR/lastglance.apk"
+    "$APKSIGNER" verify --print-certs "$OUT_DIR/$APK_OUT"
   else
     echo "    (apksigner not found on PATH or in \$ANDROID_HOME; skipping signature check)"
   fi
@@ -166,9 +194,9 @@ if $RELEASE; then
   (
     cd "$OUT_DIR"
     if command -v sha256sum >/dev/null 2>&1; then
-      sha256sum lastglance.apk lastglance.aab > SHA256SUMS.txt
+      sha256sum "$APK_OUT" lastglance.aab > SHA256SUMS.txt
     else
-      shasum -a 256 lastglance.apk lastglance.aab > SHA256SUMS.txt
+      shasum -a 256 "$APK_OUT" lastglance.aab > SHA256SUMS.txt
     fi
     sed 's/^/    /' SHA256SUMS.txt
   )

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "Lebenslange Freischaltung aktiv",
     "sourceSubscription": "Jahresabo aktiv",
     "sourceReviewer": "Prüfzugang aktiv",
+    "sourceChannel": "Diese Version ist vollständig freigeschaltet",
     "sourceNone": "Nicht freigeschaltet",
     "gateHeadline": "lastGLANCE freischalten",
     "trialHeadline_one": "Teste {{count}} Tag kostenlos",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "Lifetime unlock active",
     "sourceSubscription": "Annual subscription active",
     "sourceReviewer": "Review access active",
+    "sourceChannel": "This build is fully unlocked",
     "sourceNone": "Not unlocked",
     "gateHeadline": "Unlock lastGLANCE",
     "trialHeadline_one": "Start your {{count}}-day free trial",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "Desbloqueo de por vida activo",
     "sourceSubscription": "Suscripción anual activa",
     "sourceReviewer": "Acceso de revisión activo",
+    "sourceChannel": "Esta versión está completamente desbloqueada",
     "sourceNone": "No desbloqueado",
     "gateHeadline": "Desbloquea lastGLANCE",
     "trialHeadline_one": "Empieza tu prueba gratis de {{count}} día",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "Déblocage à vie actif",
     "sourceSubscription": "Abonnement annuel actif",
     "sourceReviewer": "Accès de test actif",
+    "sourceChannel": "Cette version est entièrement débloquée",
     "sourceNone": "Non débloqué",
     "gateHeadline": "Débloquez lastGLANCE",
     "trialHeadline_one": "Commencez votre essai gratuit de {{count}} jour",

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "Sblocco a vita attivo",
     "sourceSubscription": "Abbonamento annuale attivo",
     "sourceReviewer": "Accesso di revisione attivo",
+    "sourceChannel": "Questa versione è completamente sbloccata",
     "sourceNone": "Non sbloccato",
     "gateHeadline": "Sblocca lastGLANCE",
     "trialHeadline_one": "Inizia la tua prova gratuita di {{count}} giorno",

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "Desbloqueio vitalício ativo",
     "sourceSubscription": "Assinatura anual ativa",
     "sourceReviewer": "Acesso de revisão ativo",
+    "sourceChannel": "Esta versão está totalmente desbloqueada",
     "sourceNone": "Não desbloqueado",
     "gateHeadline": "Desbloqueie o lastGLANCE",
     "trialHeadline_one": "Comece o seu teste grátis de {{count}} dia",

--- a/public/locales/pt-PT/translation.json
+++ b/public/locales/pt-PT/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "Desbloqueio vitalício ativo",
     "sourceSubscription": "Subscrição anual ativa",
     "sourceReviewer": "Acesso de revisão ativo",
+    "sourceChannel": "Esta versão está totalmente desbloqueada",
     "sourceNone": "Não desbloqueado",
     "gateHeadline": "Desbloqueie o lastGLANCE",
     "trialHeadline_one": "Comece o seu teste grátis de {{count}} dia",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -489,8 +489,12 @@ function AppInner() {
     { label: isDark ? t('app.lightMode') : t('app.darkMode'), icon: isDark ? <Sun size={15} /> : <Moon size={15} />, onClick: () => { toggleTheme(); setShowSettingsSheet(false) } },
     { label: t('app.backupRestore'), icon: <Archive size={15} />, onClick: () => { setShowBackup(true); setShowSettingsSheet(false) } },
     { label: t('app.helpFeedback'), icon: <HelpCircle size={15} />, onClick: () => { setShowHelp(true); setShowSettingsSheet(false) } },
-    // Entitlement surface, Play builds only (gated is false on github/web).
-    ...(billing.gated ? [{ label: t('app.subscription'), icon: <BadgeCheck size={15} />, onClick: () => { setShowBillingStatus(true); setShowSettingsSheet(false) } }] : []),
+    // Entitlement surface, every channel. On a gated Play install it shows the
+    // purchase/restore actions; on an ungated one (github sideload, web) it
+    // says "This build is fully unlocked" — the only way a sideload user can
+    // tell their build from the Play one, since the two artifacts share an
+    // applicationId, name, icon and version.
+    { label: t('app.subscription'), icon: <BadgeCheck size={15} />, onClick: () => { setShowBillingStatus(true); setShowSettingsSheet(false) } },
   ]
 
   return (
@@ -801,8 +805,8 @@ function AppInner() {
           bypass code (never for paying customers). Its exit action is the
           reviewer's way back to the wall to test the IAPs; without it the
           review gets rejected for unlocatable purchases (learned on
-          dayGLANCE, see docs/reviewer-access-flow.md). Never visible with
-          the gate below: isReviewerUnlocked implies isUnlocked. */}
+          dayGLANCE). Never visible with the gate below: isReviewerUnlocked
+          implies isUnlocked. */}
       {billing.isReviewerUnlocked && (
         <ReviewerBanner onExit={exitReviewerMode} />
       )}

--- a/src/billing/billing.ts
+++ b/src/billing/billing.ts
@@ -56,11 +56,11 @@ export function useSubscription(): UseBillingResult {
 // Leave reviewer mode (the ReviewerBanner's "Exit & view plans" action): the
 // engine exposes no revoke, so clear the persisted unlock directly and reload —
 // the engine re-reads the now-absent key at start and, with no entitlement, the
-// hard gate (and its IAPs) returns. That way back is what App Review requires
-// (see docs/reviewer-access-flow.md). The key is read from DEFAULT_STORAGE_KEYS
-// because useSubscription passes no storageKeys override; deriving it from the
-// same constant the engine falls back to means the cleared key can never drift
-// from the one the engine wrote — the #1 porting bug the doc warns about.
+// hard gate (and its IAPs) returns. That way back is what App Review requires.
+// The key is read from DEFAULT_STORAGE_KEYS because useSubscription passes no
+// storageKeys override; deriving it from the same constant the engine falls
+// back to means the cleared key can never drift from the one the engine wrote —
+// the #1 bug when porting this between apps.
 export function exitReviewerMode(): void {
   try {
     localStorage.removeItem(DEFAULT_STORAGE_KEYS.reviewerUnlock)

--- a/src/components/PaywallModal/PaywallModal.tsx
+++ b/src/components/PaywallModal/PaywallModal.tsx
@@ -11,7 +11,11 @@ interface Props {
   // 'gate': the hard paywall on a locked Play install — fullscreen, not
   // dismissible (store review passes it via the reviewer code, rule 9).
   // 'status': the settings surface on an unlocked install — dismissible,
-  // shows the entitlement and manage/restore actions.
+  // shows the entitlement and, where there is a store, manage/restore actions.
+  // Reachable on EVERY channel: on an ungated build (web/PWA, GitHub sideload
+  // APK) the entitlement reads 'channel' and the line says the build is fully
+  // unlocked. That is the only in-app way to tell the sideload build from the
+  // gated Play one — they share an applicationId, name, icon and version.
   mode: 'gate' | 'status'
   onClose?: () => void
 }
@@ -106,28 +110,35 @@ export function PaywallModal({ billing, mode, onClose }: Props) {
                 {billing.entitlementSource === 'lifetime' ? t('paywall.sourceLifetime')
                   : billing.entitlementSource === 'subscription' ? t('paywall.sourceSubscription')
                   : billing.entitlementSource === 'reviewer' ? t('paywall.sourceReviewer')
+                  : billing.entitlementSource === 'channel' ? t('paywall.sourceChannel')
                   : t('paywall.sourceNone')}
               </p>
             </div>
             {billing.productId && (
               <p className="text-xs text-slate-400 dark:text-slate-500 ml-6 mb-4">{billing.productId}</p>
             )}
-            <div className="space-y-2 mt-4">
-              {billing.entitlementSource === 'subscription' && (
+            {/* Store actions only where there is a store to talk to. On an
+                ungated channel entitlementSource is 'channel', the engine has
+                no adapter, and Restore could only ever report "nothing to
+                restore" — so the status line stands alone. */}
+            {billing.entitlementSource !== 'channel' && (
+              <div className="space-y-2 mt-4">
+                {billing.entitlementSource === 'subscription' && (
+                  <button
+                    onClick={() => window.open(MANAGE_SUBSCRIPTION_URL, '_blank')}
+                    className="w-full py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+                  >
+                    {t('paywall.manage')}
+                  </button>
+                )}
                 <button
-                  onClick={() => window.open(MANAGE_SUBSCRIPTION_URL, '_blank')}
+                  onClick={() => billing.restore()}
                   className="w-full py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
                 >
-                  {t('paywall.manage')}
+                  {t('paywall.restore')}
                 </button>
-              )}
-              <button
-                onClick={() => billing.restore()}
-                className="w-full py-2.5 rounded-xl text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
-              >
-                {t('paywall.restore')}
-              </button>
-            </div>
+              </div>
+            )}
           </>
         ) : (
           <>

--- a/src/components/ReviewerBanner/ReviewerBanner.tsx
+++ b/src/components/ReviewerBanner/ReviewerBanner.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 // Shown while the install is reviewer-unlocked (store-review bypass code —
 // never a paying customer, who is entitled via Play/StoreKit instead). Ported
-// from dayGLANCE (docs/reviewer-access-flow.md): the launch paywall is the only
+// from dayGLANCE: the launch paywall is the only
 // IAP surface, so once the bypass code hides it the reviewer needs a way BACK
 // to locate and test the purchases (Guideline 2.1(b) / Play app-access).
 // "Exit & view plans" revokes the unlock and returns to the wall.


### PR DESCRIPTION
## Why

Ports krelltunez/lifeGLANCE#335, where a GitHub-APK user reported hitting the paywall. They couldn't have — the gate needs a billing adapter, and `src/billing/billing.ts` builds one only for `VITE_BUILD_CHANNEL=play` on Android. The published `lastglance.apk` v2.5.2 likewise has `adapter = null` inlined in its bundle (checked), and its `SHA256SUMS.txt` matches the asset byte-for-byte.

The underlying problem is shared by both apps: the Play and GitHub artifacts differ only in their web assets and signing key — same `applicationId`, app name, icon and version — so a Play install, or a mirror site's repack of one, is indistinguishable from the sideload APK and such a report can't be triaged.

Two of lifeGLANCE's four items were already done here, so this is the smaller half:

- `capacitor.config.ts` already carries `com.lastglance.app` with the iOS note — no change needed.
- `apksigner` + `SHA256SUMS.txt` already existed in `build-android.sh` (that's where lifeGLANCE's version came from) — only pointed at the renamed artifact and hardened.

## What changed

**In-app indicator.** This app has no settings license line — the *Subscription* row opens `PaywallModal` in `status` mode, and the row itself was built only when `billing.gated`. So the row is now built on every channel, and status mode renders a new `paywall.sourceChannel` case: *"This build is fully unlocked."* Manage/Restore are hidden when the source is `'channel'` — with a null adapter, Restore could only ever report "nothing to restore".

**New string in all 7 locales,** taken from lifeGLANCE's existing `statusChannel` so the wording matches across apps, minus the trailing period to match this repo's sibling `source*` strings. One-line insertions after `sourceReviewer`; nothing else in the files moved.

**Artifact naming.** The release APK is now `outputs/lastglance-github.apk` (matching dayGLANCE and lifeGLANCE) and carries a `-github` versionName suffix, so Android's app info shows e.g. `2.5.2-github`. `build.gradle` had no suffix mechanism at all, so this adds one (`-PversionNameSuffix` / `LASTGLANCE_VERSION_SUFFIX`), reordering the version derivation so `versionParts` still tokenizes the clean `x.y.z`. The versionCode is untouched, so updates work normally, and the Play AAB keeps the clean name. Stale pre-rename `lastglance.apk` is cleared from `outputs/`.

**Verification hardening.** The signature check now covers the renamed artifact and skips cleanly when `keystore.properties` is absent — previously an unsigned build would abort the script under `set -e` *after* producing artifacts — while a genuine mismatch still stops the release. `SHA256SUMS.txt` follows the rename. README gains *"Which build am I running?"* and *"Verifying the APK"* with the signing fingerprint, the mirror-site warning, and a note that the AV false positive in #255 has the same cause: Play re-signs its copy, so the two builds legitimately carry different signatures.

**Comments.** References to `docs/reviewer-access-flow.md` (three places) and `docs/paywall-billing-plan.md` (one) — neither file exists in this repo, or in lifeGLANCE or dayGLANCE — are rewritten to stand alone.

## Verification

- `tsc -b` clean, which also confirms `'channel'` is in the `entitlementSource` union
- `eslint . --max-warnings 0` clean
- `vitest run` — 569/569 pass
- Both channel builds still fold correctly: `VITE_BUILD_CHANNEL=github` inlines `const … = null`; `play` keeps the platform-conditional adapter

## Note

The release-asset rename may prompt existing Obtainium users to re-pick the APK once. There's only one APK asset, so it should auto-resolve, but it's worth a line in the release notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvXbBooyeqxB8PQxUt7ay6)_