### PR TITLE
i18n: fix zh-CN parity after #314/#315 and pin the Chinese fallback

### DIFF
--- a/public/locales/zh-CN/translation.json
+++ b/public/locales/zh-CN/translation.json
@@ -523,6 +523,7 @@
     "sourceLifetime": "永久版已解锁",
     "sourceSubscription": "年度订阅已生效",
     "sourceReviewer": "审核员访问权限已生效",
+    "sourceChannel": "此版本已完整解锁",
     "sourceNone": "未解锁",
     "gateHeadline": "解锁 lastGLANCE",
     "trialHeadline_one": "开始 {{count}} 天免费试用",

--- a/src/locales.test.ts
+++ b/src/locales.test.ts
@@ -34,6 +34,16 @@ describe('locale bundles', () => {
     expect(languages).toEqual(EXPECTED)
   })
 
+  // completionsLabel routes 0 to its own key instead of a `_zero` plural
+  // suffix, on the grounds that no shipped language has a CLDR zero
+  // category. Pin that here so a language that does (Arabic, Latvian, Welsh)
+  // fails loudly when it is added instead of quietly reading "0 completions".
+  it('ships no language with a CLDR zero plural category', () => {
+    for (const lng of languages) {
+      expect(new Intl.PluralRules(lng).resolvedOptions().pluralCategories, lng).not.toContain('zero')
+    }
+  })
+
   // Shared by the detector (convertDetectedLanguage) and the picker's value —
   // the two must agree, or the UI renders one language while the picker
   // displays another.
@@ -62,6 +72,22 @@ describe('locale bundles', () => {
       expect(resolveLanguage('pt-MZ')).toBe('pt-PT')
     })
 
+    // Deliberate: Simplified is the only Chinese we ship, and for a
+    // Traditional-script reader (Taiwan, Hong Kong, Macau) it is closer than
+    // English. When a zh-TW locale lands, zh-TW resolves to itself and this
+    // test fails on purpose — that is the moment to add `zh: 'zh-CN'` (or
+    // whichever variant should own the bare tag) to REGIONAL_DEFAULTS and to
+    // decide where zh-HK / zh-MO go, since the generic fallback would
+    // otherwise hand them the alphabetically-first variant (zh-CN).
+    it('sends every Chinese tag to Simplified until a Traditional locale ships', () => {
+      expect(resolveLanguage('zh')).toBe('zh-CN')
+      expect(resolveLanguage('zh-Hans-CN')).toBe('zh-CN')
+      expect(resolveLanguage('zh-SG')).toBe('zh-CN')
+      expect(resolveLanguage('zh-TW')).toBe('zh-CN')
+      expect(resolveLanguage('zh-HK')).toBe('zh-CN')
+      expect(resolveLanguage('zh-Hant-TW')).toBe('zh-CN')
+    })
+
     it('reduces a regional tag to a base language that is shipped', () => {
       expect(resolveLanguage('en-US')).toBe('en')
       expect(resolveLanguage('de-AT')).toBe('de')
@@ -88,7 +114,7 @@ describe('locale bundles', () => {
     })
 
     it('always returns something the picker can render', () => {
-      for (const reported of ['en', 'pt', 'pt-AO', 'de-AT', 'zz', '', undefined]) {
+      for (const reported of ['en', 'pt', 'pt-AO', 'de-AT', 'zh-TW', 'zz', '', undefined]) {
         expect(languages).toContain(resolveLanguage(reported))
       }
     })

--- a/src/utils/completionsLabel.ts
+++ b/src/utils/completionsLabel.ts
@@ -3,9 +3,10 @@ import type { TFunction } from 'i18next'
 /**
  * "3 completions" / "1 completion" / "No completions" for a heatmap cell.
  *
- * Zero takes its own key rather than a `_zero` plural suffix: none of the six
- * supported languages has a CLDR zero plural category, so a count of 0 would
- * fall through to the `_other` form and read as "0 completions".
+ * Zero takes its own key rather than a `_zero` plural suffix: no shipped
+ * language has a CLDR zero plural category (locales.test.ts pins this), so a
+ * count of 0 would fall through to the `_other` form and read as
+ * "0 completions".
  *
  * Shared by both heatmaps — the header one and the per-chore one in LogModal —
  * so their cells describe themselves identically.

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -48,8 +48,10 @@ declare global {
 }
 
 // Full tags before base languages: pt-BR must land on dayjs's "pt-br", not be
-// stripped to the generic (European) "pt". i18next reports pt-PT and pt-BR
-// since the Portuguese split; every other language is still a bare tag.
+// stripped to the generic (European) "pt". i18next reports regional tags for
+// Portuguese (pt-PT, pt-BR) and Chinese (zh-CN); every other language is
+// still a bare tag. A new regional locale needs its lower-cased dayjs name
+// listed here, or it falls back to the base language's (or English's) format.
 const SUPPORTED = ['de', 'es', 'fr', 'it', 'pt', 'pt-br', 'zh-cn'] as const
 
 let activeLocale = 'en'


### PR DESCRIPTION
Follow-up to #315 (Simplified Chinese). Two commits.

## Fixes main

`main` is currently red on `locales.test.ts > zh-CN covers every key in en`. #314 added `paywall.sourceChannel` to every locale that existed on its branch, and #315 added zh-CN without it. Merging both left zh-CN one key behind en. This adds the translation (此版本已完整解锁, "This build is fully unlocked").

## Pins the Chinese fallback

Adding zh-CN made `resolveLanguage`'s generic "any variant beats English" branch route every Chinese tag, including Traditional-script ones (zh-TW, zh-HK, zh-Hant-*), to Simplified. That is intended until a Traditional locale ships, so it is now stated in a test rather than left implicit. The test is written to fail on purpose the day zh-TW lands, and its comment says what to do then: add a Chinese entry to `REGIONAL_DEFAULTS` and decide where zh-HK / zh-MO go, since the generic fallback would otherwise hand them the alphabetically-first variant.

## Pins the plural invariant

`completionsLabel` routes 0 to its own key on the grounds that no shipped language has a CLDR zero plural category. A new test asserts that against the live language list, so a future Arabic / Latvian / Welsh locale fails loudly instead of quietly reading "0 completions".

## Comment refreshes

- `datetime.ts`: the dayjs `SUPPORTED` note no longer claims Portuguese is the only regional tag.
- `completionsLabel.ts`: the rationale no longer hard-codes a language count.

## Verification

- Full suite: 42 files, 583 tests passing (main is 1 failing without the first commit).
- `tsc --noEmit` and eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPc7UoXkwWaD4Cop2NJKXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPc7UoXkwWaD4Cop2NJKXU)_