### PR TITLE
Release 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lastglance",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lastglance",
-      "version": "2.5.2",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/android": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lastglance",
   "private": true,
   "license": "MIT",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump only (package.json and package-lock.json). Android versionCode derives to 2060000.

Minor rather than patch: a new language is a feature, matching how 2.5.0 (the localization port) was classified, and the sideload build now identifies itself differently to users.

## Since v2.5.2

- #315 Simplified Chinese (zh-CN) across the app, widgets, share extension and Android shortcuts. Contributed by @cyzg90.
- #314 The GitHub APK is identifiable and verifiable: versionName suffix (2.6.0-github), renamed artifact (lastglance-github.apk), "This build is fully unlocked" on the Subscription screen, signing fingerprint and verification steps in the README.
- #316 zh-CN key parity fix after #314 and #315 merged, plus tests pinning the Chinese fallback and the plural-category invariant.

## Release notes (GitHub)

**New**

- Simplified Chinese. lastGLANCE is now available in 中文（简体）, including the home screen widgets, the share sheet and the Android app shortcuts. Thanks to cyzg90 for the translation.
- The GitHub build now identifies itself. Android's app info shows the version as 2.6.0-github, and Settings > Subscription reads "This build is fully unlocked". If you see a paywall or a plain version number, you are not running the GitHub build.
- APK verification. The README now lists the signing certificate fingerprint and how to check it, so a download from a mirror site can be verified against the real release.

**Changed**

- The release APK is now named lastglance-github.apk. Update any bookmark or script that fetched the old filename.

## After merge

1. Tag v2.6.0 on the merge commit.
2. `./build-android.sh --release` on a machine with the keystore. Upload the .aab once and promote between tracks.
3. Attach lastglance-github.apk and SHA256SUMS.txt to the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPc7UoXkwWaD4Cop2NJKXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPc7UoXkwWaD4Cop2NJKXU)_