### PR TITLE
ci: give the GHCR publish job a 30-minute timeout

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -13,6 +13,14 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # The arm64 half of the build runs under QEMU, and npm ci under emulation
+    # can deadlock with no output: the v2.6.0 release run sat there for five
+    # and a half hours before it was cancelled by hand. A healthy run finishes
+    # in about six minutes, so half an hour is generous headroom and turns a
+    # hang into a visible failure. Recover with "Re-run all jobs" on the
+    # failed run, which keeps the release event (and so the version tags);
+    # a manual run from main only publishes the :main and :sha-* tags.
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
One line of config plus a comment explaining it.

## Why

The v2.6.0 release run of "Publish to GHCR" ([run 33997727886](https://github.com/krelltunez/lastGLANCE/actions/runs/33997727886)) sat in the arm64 builder's `npm ci` step for five and a half hours before it was cancelled by hand. That step runs under QEMU emulation, and npm under QEMU can deadlock with no output. A healthy run of this job, including arm64, takes about six minutes (v2.5.2, and the manual re-run of 2.6.0 from main).

The job had no time limit, so the hang looked like a slow build rather than a failure.

## What

`timeout-minutes: 30` on the job. Five times the normal duration, so a legitimately slow run still passes, but a hang fails inside half an hour and shows up red.

The comment also records the recovery step, since it is easy to get wrong: "Re-run all jobs" on the failed run keeps the release event and so publishes the version tags and `latest`. A manual run from main publishes only the `:main` and `:sha-*` tags, which is why deployments pulling `latest` saw no update after the 2.6.0 re-run.

## Verification

- YAML parses.
- No behavior change for a run that completes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPc7UoXkwWaD4Cop2NJKXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPc7UoXkwWaD4Cop2NJKXU)_